### PR TITLE
fix: ignore first line break of table in wysiwyg (close #470)

### DIFF
--- a/src/js/wwTableManager.js
+++ b/src/js/wwTableManager.js
@@ -158,7 +158,6 @@ class WwTableManager {
 
         if (isRangeInTable && !this._isSingleModifierKey(keymap)) {
           this._recordUndoStateIfNeed(range);
-          this._removeBRIfNeed(range);
           this._removeContentsAndChangeSelectionIfNeed(range, keymap, ev);
         } else if (!isRangeInTable && this._lastCellNode) {
           this._recordUndoStateAndResetCellNode(range);
@@ -362,7 +361,6 @@ class WwTableManager {
           this._tableHandlerOnDelete(range, ev);
         }
 
-        this._insertBRIfNeed(range);
         this._removeContentsAndChangeSelectionIfNeed(range, keymap, ev);
         isNeedNext = false;
       } else if ((!isBackspace && this._isBeforeTable(range))
@@ -1251,43 +1249,6 @@ class WwTableManager {
     this.tableID += 1;
 
     return tableClassName;
-  }
-
-  /**
-   * Remove br when text inputted
-   * @param {Range} range Range object
-   * @private
-   */
-  _removeBRIfNeed(range) {
-    const isText = domUtils.isTextNode(range.startContainer);
-    const startContainer = isText ? range.startContainer.parentNode : range.startContainer;
-    const nodeName = domUtils.getNodeName(startContainer);
-
-    if (/td|th/i.test(nodeName) && range.collapsed && startContainer.textContent.length === 1) {
-      $(startContainer).find('br').remove();
-    }
-  }
-
-  /**
-   * Insert br when text deleted
-   * @param {Range} range Range object
-   * @private
-   */
-  _insertBRIfNeed(range) {
-    const isText = domUtils.isTextNode(range.startContainer);
-    const currentCell = isText ? range.startContainer.parentNode : range.startContainer;
-    const nodeName = domUtils.getNodeName(currentCell);
-    const $currentCell = $(currentCell);
-
-    if (/td|th/i.test(nodeName)
-            && range.collapsed
-            && !currentCell.textContent.length
-            && !$currentCell.children().length
-            && !isIE10And11
-    ) {
-      currentCell.normalize();
-      $currentCell.append('<br>');
-    }
   }
 
   /**

--- a/test/unit/wwTableManager.spec.js
+++ b/test/unit/wwTableManager.spec.js
@@ -1081,44 +1081,6 @@ describe('WwTableManager', () => {
     });
   });
 
-  describe('_removeBRIfNeed', () => {
-    beforeEach(() => {
-      wwe.getEditor().setHTML('<table><thead><tr><th>1</th></tr></thead>' +
-                '<tbody><tr><td>1<br></td></tr></tbody></table>');
-    });
-
-    it('should remove BR when one character inputted', () => {
-      const range = wwe.getEditor().getSelection().cloneRange();
-      range.setStart(wwe.get$Body().find('td')[0].childNodes[0], 0);
-      range.collapse(true);
-
-      mgr._removeBRIfNeed(range);
-
-      expect(wwe.get$Body().find('td').eq(0).find('br').length).toEqual(0);
-      expect(wwe.get$Body().find('td').eq(0).find('br').length).toEqual(0);
-    });
-  });
-
-  describe('_insertBRIfNeed', () => {
-    beforeEach(() => {
-      wwe.getEditor().setHTML('<table><thead><tr><th>1234</th></tr></thead>' +
-                '<tbody><tr><td></td></tr></tbody></table>');
-      wwe.get$Body().find('br').remove();
-    });
-    const expectation =
-            util.browser.msie && (util.browser.version === 10 || util.browser.version === 11) ? 0 : 1;
-
-    it('should insert BR when text content length is 0', () => {
-      const range = wwe.getEditor().getSelection().cloneRange();
-      range.setStart(wwe.get$Body().find('td')[0], 0);
-      range.collapse(true);
-
-      mgr._insertBRIfNeed(range);
-
-      expect(wwe.get$Body().find('td').eq(0).find('br').length).toEqual(expectation);
-    });
-  });
-
   describe('_isDeletingNonText', () => {
     beforeEach(() => {
       const html = '<table>' +


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description
fix #470 
위지윅 테이블에서 한글자 입력 시 br을 삭제하고, 다시 한글자 삭제 시(td가 비어있을 때) br을 넣는 동작을 제거하였습니다. 해당 코드로 인해서 td의 글자 한개가 입력된 상태에서 엔터로 개행 시 br을 의도적으로 지워서 개행이 없어지는 문제가 발생합니다. 따라서 해당 코드를 제거하였습다.
해당 코드 없이도 IE와 Firefox를 제외한 모든 브라우저에서 브라우저 자체적으로 한글자 입력 시 br을 제거하고, td가 비어있을 때 br을 넣고 있습니다. 그리고 IE와 Firefox에서 테스트 시에 br로 인한 다른 문제는 발생하지 않았습니다.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
