### PR TITLE
fix: key(up/down, enter, backspace, delete) operation in list of table

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -51,7 +51,7 @@
     "markdown-it": "^8.4.0",
     "to-mark": "^1.1.5",
     "tui-color-picker": "^2.2.1",
-    "squire-rte": "sohee-lee7/Squire#e35304de663568a458a75f0d3c206fbddb8c0699",
+    "squire-rte": "sohee-lee7/Squire#3bc0ea011c22aa0253e6e15aad6aebbebd6d0fda",
     "plantuml-encoder": "^1.2.5",
     "tui-chart": "^2.13.0"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13297,8 +13297,8 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "squire-rte": {
-      "version": "github:sohee-lee7/Squire#e35304de663568a458a75f0d3c206fbddb8c0699",
-      "from": "github:sohee-lee7/Squire#e35304de663568a458a75f0d3c206fbddb8c0699"
+      "version": "github:sohee-lee7/Squire#3bc0ea011c22aa0253e6e15aad6aebbebd6d0fda",
+      "from": "github:sohee-lee7/Squire#3bc0ea011c22aa0253e6e15aad6aebbebd6d0fda"
     },
     "sshpk": {
       "version": "1.14.2",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "markdown-it": "^8.4.0",
     "plantuml-encoder": "^1.2.5",
     "resize-observer-polyfill": "^1.5.0",
-    "squire-rte": "github:sohee-lee7/Squire#e35304de663568a458a75f0d3c206fbddb8c0699",
+    "squire-rte": "github:sohee-lee7/Squire#3bc0ea011c22aa0253e6e15aad6aebbebd6d0fda",
     "to-mark": "^1.1.5",
     "tui-chart": "^3.0.1",
     "tui-code-snippet": "^1.5.0",

--- a/src/js/domUtils.js
+++ b/src/js/domUtils.js
@@ -617,6 +617,49 @@ const isListNode = function(node) {
   return result;
 };
 
+/**
+ * Check whether node is first list item
+ * @param {node} node - node
+ * @returns {boolean} whether node is first list item
+ * @ignore
+ */
+const isFirstListItem = function(node) {
+  const {nodeName, parentNode} = node;
+
+  return nodeName === 'LI' && node === parentNode.firstChild;
+};
+
+/**
+ * Check whether node is first level list item
+ * @param {node} node - node
+ * @returns {boolean} whether node is first level list item
+ * @ignore
+ */
+const isFirstLevelListItem = function(node) {
+  const {nodeName, parentNode: listNode} = node;
+  const {parentNode: listParentNode} = listNode;
+
+  return nodeName === 'LI' && !isListNode(listParentNode);
+};
+
+/**
+ * Merge node to target node and detach node
+ * @param {node} node - node
+ * @param {node} targetNode - target node
+ * @ignore
+ */
+const mergeNode = function(node, targetNode) {
+  if (node.hasChildNodes()) {
+    util.forEachArray(node.childNodes, () => {
+      targetNode.appendChild(node.firstChild);
+    });
+  }
+
+  if (node.parentNode) {
+    node.parentNode.removeChild(node);
+  }
+};
+
 export default {
   getNodeName,
   isTextNode,
@@ -627,6 +670,7 @@ export default {
   getPrevOffsetNodeUntil,
   getNodeOffsetOfParent,
   getChildNodeByOffset,
+  getNodeWithDirectionUntil,
   containsNode,
   getTopPrevNodeUnder,
   getTopNextNodeUnder,
@@ -645,5 +689,8 @@ export default {
   removeNodesByDirection,
   getLeafNode,
   isInsideTaskBox,
-  isListNode
+  isListNode,
+  isFirstListItem,
+  isFirstLevelListItem,
+  mergeNode
 };

--- a/src/js/wwTableManager.js
+++ b/src/js/wwTableManager.js
@@ -219,7 +219,7 @@ class WwTableManager {
    * @returns {boolean} whether node is li and empty
    * @private
    */
-  _isEmptyLI(node) {
+  _isEmptyListItem(node) {
     const {childNodes, nodeName} = node;
 
     return nodeName === 'LI' && childNodes.length === 1 && childNodes[0].nodeName === 'BR';
@@ -235,7 +235,7 @@ class WwTableManager {
     const {collapsed, startContainer, startOffset} = range;
 
     return collapsed && startOffset === 0
-        && this._isEmptyLI(startContainer)
+        && this._isEmptyListItem(startContainer)
         && domUtils.isFirstLevelListItem(startContainer);
   }
 
@@ -446,12 +446,10 @@ class WwTableManager {
    * @returns {node} liNode or null
    * @private
    */
-  _findLI(startContainer) {
-    return domUtils.getParentUntilBy(startContainer, (node) => {
-      return node && domUtils.isListNode(node);
-    }, (node) => {
-      return node && (node.nodeName === 'TD' || node.nodeName === 'TH');
-    });
+  _findListItem(startContainer) {
+    return domUtils.getParentUntilBy(startContainer,
+      (node) => node && domUtils.isListNode(node),
+      (node) => node && (node.nodeName === 'TD' || node.nodeName === 'TH'));
   }
 
   /**
@@ -464,7 +462,7 @@ class WwTableManager {
    */
   _tableHandlerOnBackspace(range, event) {
     const {startContainer, startOffset} = range;
-    const liNode = this._findLI(startContainer);
+    const liNode = this._findListItem(startContainer);
 
     if (liNode && startOffset === 0
       && domUtils.isFirstListItem(liNode)
@@ -474,8 +472,8 @@ class WwTableManager {
       this._moveListItemToPreviousOfList(liNode, range);
       event.preventDefault();
     } else {
-      const prevNode = domUtils.getPrevOffsetNodeUntil(startContainer, startOffset, 'TR'),
-        prevNodeName = domUtils.getNodeName(prevNode);
+      const prevNode = domUtils.getPrevOffsetNodeUntil(startContainer, startOffset, 'TR');
+      const prevNodeName = domUtils.getNodeName(prevNode);
 
       if (prevNodeName === 'BR' && prevNode.parentNode.childNodes.length !== 1) {
         event.preventDefault();
@@ -581,7 +579,7 @@ class WwTableManager {
    * @private
    */
   _tableHandlerOnDelete(range, event) {
-    const liNode = this._findLI(range.startContainer);
+    const liNode = this._findListItem(range.startContainer);
 
     if (liNode && this._isEndOfList(liNode, range)) {
       this.wwe.getEditor().saveUndoState(range);

--- a/src/js/wwTableManager.js
+++ b/src/js/wwTableManager.js
@@ -187,6 +187,14 @@ class WwTableManager {
             this.wwe.defer(() => {
               this._removeBRinStyleText();
             });
+          } else if (this._isEmptyFirstLevelLI(range)) {
+            this.wwe.defer(() => {
+              // Squire make div when LI level is decreased in first level so should replace div to br
+              const afterRange = this.wwe.getRange();
+              const div = afterRange.startContainer;
+
+              div.parentNode.replaceChild(document.createElement('br'), div);
+            });
           }
           this._appendBrIfTdOrThNotHaveAsLastChild(range);
           isNeedNext = false;
@@ -203,6 +211,32 @@ class WwTableManager {
     };
 
     util.forEach(this.keyEventHandlers, (handler, key) => this.wwe.addKeyEventHandler(key, handler));
+  }
+
+  /**
+   * Check whether node is li and empty
+   * @param {node} node node
+   * @returns {boolean} whether node is li and empty
+   * @private
+   */
+  _isEmptyLI(node) {
+    const {childNodes, nodeName} = node;
+
+    return nodeName === 'LI' && childNodes.length === 1 && childNodes[0].nodeName === 'BR';
+  }
+
+  /**
+   * Check whether range is in empty LI that is first level
+   * @param {range} range range
+   * @returns {boolean} whether range is in empty LI that is first level
+   * @private
+   */
+  _isEmptyFirstLevelLI(range) {
+    const {collapsed, startContainer, startOffset} = range;
+
+    return collapsed && startOffset === 0
+        && this._isEmptyLI(startContainer)
+        && domUtils.isFirstLevelListItem(startContainer);
   }
 
   /**

--- a/src/js/wwTableManager.js
+++ b/src/js/wwTableManager.js
@@ -396,36 +396,10 @@ class WwTableManager {
     const prevNode = domUtils.getPrevOffsetNodeUntil(range.startContainer, range.startOffset, 'TR'),
       prevNodeName = domUtils.getNodeName(prevNode);
 
-    if (!prevNode || prevNodeName === 'TD' || prevNodeName === 'TH') {
-      event.preventDefault();
-    } else if (prevNodeName === 'BR' && prevNode.parentNode.childNodes.length !== 1) {
+    if (prevNodeName === 'BR' && prevNode.parentNode.childNodes.length !== 1) {
       event.preventDefault();
       $(prevNode).remove();
     }
-  }
-
-  /**
-   * Return whether delete non text or not
-   * @param {Range} range Range object
-   * @returns {boolean}
-   */
-  _isDeletingNonText(range) {
-    const currentElement = range.startContainer;
-    const nextNode = currentElement.nextSibling;
-    const nextNodeName = domUtils.getNodeName(nextNode);
-    const currentNodeName = domUtils.getNodeName(currentElement);
-    const insideNode = this._getCurrentNodeInCell(range);
-    const insideNodeName = domUtils.getNodeName(insideNode);
-
-    const isEmptyLineBetweenText = insideNode && insideNodeName === 'BR' && insideNode.nextSibling;
-    const isCellDeleting = !isEmptyLineBetweenText && currentNodeName === nextNodeName && currentNodeName !== 'TEXT';
-    const isEndOfText = (!nextNode || (nextNodeName === 'BR' && nextNode.parentNode.lastChild === nextNode))
-            && (domUtils.isTextNode(currentElement) && range.startOffset === currentElement.nodeValue.length);
-    const isLastCellOfRow = !isEmptyLineBetweenText && !isEndOfText
-            && $(currentElement).parents('tr').children().last()[0] === currentElement
-            && (currentNodeName === 'TD' || currentNodeName === 'TH');
-
-    return isCellDeleting || isEndOfText || isLastCellOfRow;
   }
 
   /**
@@ -468,9 +442,6 @@ class WwTableManager {
 
       currentNode.parentNode.removeChild(currentNode.nextSibling);
       event.preventDefault();
-    } else if (this._isDeletingNonText(range)) {
-      event.preventDefault();
-      range.startContainer.normalize();
     }
   }
 

--- a/src/js/wwTableManager.js
+++ b/src/js/wwTableManager.js
@@ -1192,7 +1192,7 @@ class WwTableManager {
     let isNeedNext;
 
     if (range.collapsed) {
-      if (this.wwe.isInTable(range) && currentCell) {
+      if (this.wwe.isInTable(range) && currentCell && !sq.hasFormat('LI')) {
         if ((direction === 'previous' || interval === 'row')
                     && !util.isUndefined(ev)
         ) {

--- a/test/unit/wwTableManager.spec.js
+++ b/test/unit/wwTableManager.spec.js
@@ -1081,57 +1081,6 @@ describe('WwTableManager', () => {
     });
   });
 
-  describe('_isDeletingNonText', () => {
-    beforeEach(() => {
-      const html = '<table>' +
-                '<thead>' +
-                '<tr><th>1<br></th><th>2<br></th></tr>' +
-                '</thead>' +
-                '<tbody>' +
-                '<tr><td><br></td><td>1<br><br>2<br></td></tr>' +
-                '<tr><td>123<br></td><td><br></td></tr>' +
-                '</tbody>' +
-                '</table>';
-      wwe.get$Body().html(html);
-    });
-
-    it('should check empty cell as true', () => {
-      const range = wwe.getEditor().getSelection();
-      range.setStart(wwe.get$Body().find('td')[0], 0);
-      range.collapse(true);
-      wwe.getEditor().setSelection(range);
-
-      expect(mgr._isDeletingNonText(range)).toEqual(true);
-    });
-
-    it('should check the empty line between text line as false', () => {
-      const range = wwe.getEditor().getSelection();
-      range.setStart(wwe.get$Body().find('td')[1], 2);
-      range.collapse(true);
-      wwe.getEditor().setSelection(range);
-
-      expect(mgr._isDeletingNonText(range)).toEqual(false);
-    });
-
-    it('should check the end of text as true', () => {
-      const range = wwe.getEditor().getSelection();
-      range.setStart(wwe.get$Body().find('td')[2].childNodes[0], 3);
-      range.collapse(true);
-      wwe.getEditor().setSelection(range);
-
-      expect(mgr._isDeletingNonText(range)).toEqual(true);
-    });
-
-    it('should check the last cell of row as true', () => {
-      const range = wwe.getEditor().getSelection();
-      range.setStart(wwe.get$Body().find('td')[2].childNodes[0], 3);
-      range.collapse(true);
-      wwe.getEditor().setSelection(range);
-
-      expect(mgr._isDeletingNonText(range)).toEqual(true);
-    });
-  });
-
   describe('_isDeletingBR', () => {
     beforeEach(() => {
       const html = '<table>' +


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description

- up/down : 리스트 아이템 사이를 up/down키로 이동 못하는 문제 수정
- enter : 리스트를 enter키로 없앨 때 div 생기는 것 수정
- backspace : 맨 첫번째 리스트 아이템에서 커서가 맨 앞에 있을 때, backspace 동작 구현 (해당 라인 리스트 제거)
- delete : 리스트의 맨마지막 아이템에서 커서가 맨 뒤에 있을 때, delete 키 동작 구현 (뒷 줄과 merge)
- backspace/delete 키로 테이블 깨는 문제는 squire의 mergeBlock과 mergeContainer때문인데, 일반적으로 TD와 TR 등의 table 요소들은 merge하지 말아야함. 따라서 Squire를 https://github.com/sohee-lee7/Squire/pull/1 이와 같이 수정 예정.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
