### PR TITLE
fix: range is wrong when using list in table (fix #497)

### DIFF
--- a/src/js/wwTableManager.js
+++ b/src/js/wwTableManager.js
@@ -190,10 +190,15 @@ class WwTableManager {
           } else if (this._isEmptyFirstLevelLI(range)) {
             this.wwe.defer(() => {
               // Squire make div when LI level is decreased in first level so should replace div to br
-              const afterRange = this.wwe.getRange();
+              const afterRange = this.wwe.getRange().cloneRange();
               const div = afterRange.startContainer;
+              const br = document.createElement('br');
 
-              div.parentNode.replaceChild(document.createElement('br'), div);
+              div.parentNode.replaceChild(br, div);
+
+              afterRange.setStartBefore(br);
+              afterRange.collapse(true);
+              this.wwe.getEditor().setSelection(afterRange);
             });
           }
           this._appendBrIfTdOrThNotHaveAsLastChild(range);

--- a/src/js/wwTableManager.js
+++ b/src/js/wwTableManager.js
@@ -425,13 +425,13 @@ class WwTableManager {
    * @private
    */
   _moveListItemToPreviousOfList(liNode, range) {
-    const {parentNode: listNode} = liNode;
+    const {parentNode: listNode, firstChild} = liNode;
     const fragment = document.createDocumentFragment();
 
     domUtils.mergeNode(liNode, fragment);
     listNode.parentNode.insertBefore(fragment, listNode);
 
-    range.setStart(listNode.previousSibling, 0);
+    range.setStart(firstChild, 0);
     range.collapse(true);
     this.wwe.getEditor().setSelection(range);
 


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description

fix #497 

* Backspace 키로 리스트 아이템이 지워질 때, 지워지는 리스트 아이템 내용물의 가장 맨 뒤의 element로 range가 설정되는 문제 수정 (#497의 Issue 1)
* Enter 키로 리스트 아이템이 지워질 때, range가 설정된 div테그가 사라져서 range가 이상해지는 문제 수정 (#497의 Issue 2, 3)


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
