### PR TITLE
fix: space is not convert html entity when pasting (fix: #432)

### DIFF
--- a/src/js/wwClipboardManager.js
+++ b/src/js/wwClipboardManager.js
@@ -234,6 +234,12 @@ class WwClipboardManager {
    * @private
    */
   _preparePaste($clipboardContainer) {
+    const html = $clipboardContainer.html();
+
+    $clipboardContainer.html(html.replace(/>([^<]*\s[^<]*)</g, (match, text) => {
+      return `>${text.replace(/\s/g, '&nbsp;')}<`;
+    }));
+
     // When pasting text, the empty line processing differ our viewer and MS Office.
     // In our viewer case, <p>aaa</p><p>bbb<p> have empty line becuase P tags have margin.
     // In MS Office case, <p>aaa</p><p>bbb<p> do not have empty line becuase P tags means just one line.


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description

When pasting text in Wysiwyg, space is not converted `&nbsp;`(html entity). And then to-mark trim those spaces.

So when pasting, should convert spaces to `&nbsp;`.

Fix #432 


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
