### PR TITLE
fix: data tomark pass side effect

### DIFF
--- a/src/js/convertor.js
+++ b/src/js/convertor.js
@@ -105,7 +105,8 @@ class Convertor {
    * @returns {string} html text
    */
   _markdownToHtml(markdown, env) {
-    markdown = markdown.replace(/<([^>]+)([/]?)>/g, '<$1 data-tomark-pass $2>');
+    // should insert data-tomark-pass in the opening tag
+    markdown = markdown.replace(/<(?!\/)([^>]+)([/]?)>/g, '<$1 data-tomark-pass $2>');
     // eslint-disable-next-line
         const onerrorStripeRegex = /(<img[^>]*)(onerror\s*=\s*[\"']?[^\"']*[\"']?)(.*)/i;
     while (onerrorStripeRegex.exec(markdown)) {

--- a/src/js/convertor.js
+++ b/src/js/convertor.js
@@ -129,7 +129,7 @@ class Convertor {
 
     $wrapperDiv.find('code, pre').each((i, codeOrPre) => {
       const $code = $(codeOrPre);
-      $code.html($code.html().replace(/&lt;([\S ]+\s*) data-tomark-pass &gt;/g, '&lt;$1&gt;'));
+      $code.html($code.html().replace(/ data-tomark-pass &gt;/g, '&gt;'));
     });
 
     renderedHTML = $wrapperDiv.html();

--- a/test/unit/convertor.spec.js
+++ b/test/unit/convertor.spec.js
@@ -70,6 +70,23 @@ describe('Convertor', () => {
       expect(convertor.toHTML(tag).replace(/\n/g, '')).toEqual(expectedHTML);
     });
 
+    it('should insert data-tomark-pass in html tag with markdown syntax', () => {
+      const tag = [
+        '| | |',
+        '| --- | --- |',
+        '| aa | <ul><li>test</li></ul> |'
+      ].join('\n');
+
+      const expectedHTML = [
+        '<table><thead><tr><th></th><th></th></tr></thead>',
+        '<tbody><tr><td>aa</td>',
+        '<td><ul data-tomark-pass=""><li data-tomark-pass="">test</li></ul></td>',
+        '</tr></tbody></table>'
+      ].join('');
+
+      expect(convertor.toHTML(tag).replace(/\n/g, '')).toEqual(expectedHTML);
+    });
+
     it('should insert data-tomark-pass in html tag even if attrubute has slash', () => {
       const imgTag = '<img src="https://user-images.githubusercontent.com/1215767/34336735-e7c9c4b0-e99c-11e7-853b-2449b51f0bab.png">';
 

--- a/test/unit/convertor.spec.js
+++ b/test/unit/convertor.spec.js
@@ -94,6 +94,22 @@ describe('Convertor', () => {
 
       expect(convertor.toHTML(imgTag).replace(/\n/g, '')).toEqual(expectedHTML);
     });
+
+    it('should not insert data-tomark-pass in codeblock that has tag', () => {
+      const codeBlockMd = `\`\`\`\n<p>hello</p>\n\`\`\``;
+
+      const expectedHTML = `<pre><code>&lt;p&gt;hello&lt;/p&gt;</code></pre>`;
+
+      expect(convertor.toHTML(codeBlockMd).replace(/\n/g, '')).toEqual(expectedHTML);
+    });
+
+    it('should not insert data-tomark-pass in codeblock that has tag with attribute', () => {
+      const codeBlockMd = `\`\`\`\n<p class="test">hello</p>\n\`\`\``;
+
+      const expectedHTML = `<pre><code>&lt;p class="test"&gt;hello&lt;/p&gt;</code></pre>`;
+
+      expect(convertor.toHTML(codeBlockMd).replace(/\n/g, '')).toEqual(expectedHTML);
+    });
   });
 
   describe('html to markdown', () => {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description

* #502 수정의 side-effect
  * closing tag 에도 `data-tomark-pass`를 넣는 문제가 발생하여 처리
    * closing tag를 정규식으로 거름 (`<(?!\/)`)
* #511 수정의 side-effect
  * 코드블럭에 `<p>`만 입력하면 `data-tomark-pass`가 들어가는 문제 발생하여 처리
    * 전체 테그를 인식하지 않고 마지막의 ` data-tomark-pass >`가 입력된 부분만 찾아서 `data-tomark-pass` 제거 (`>`는 html entity인 상황)

테스트코드도 보강하였습니다.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
