### PR TITLE
fix: left/right key works wrong around hr (fix: 543)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -51,7 +51,7 @@
     "markdown-it": "^8.4.0",
     "to-mark": "^1.1.7",
     "tui-color-picker": "^2.2.1",
-    "squire-rte": "sohee-lee7/Squire#812513279820be381f0182683e01ad7867e140c0",
+    "squire-rte": "sohee-lee7/Squire#e7e620ca30a280db62c9e2fee166470d241af234",
     "plantuml-encoder": "^1.2.5",
     "tui-chart": "^2.13.0"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13651,8 +13651,8 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "squire-rte": {
-      "version": "github:sohee-lee7/Squire#812513279820be381f0182683e01ad7867e140c0",
-      "from": "github:sohee-lee7/Squire#812513279820be381f0182683e01ad7867e140c0"
+      "version": "github:sohee-lee7/Squire#e7e620ca30a280db62c9e2fee166470d241af234",
+      "from": "github:sohee-lee7/Squire#e7e620ca30a280db62c9e2fee166470d241af234"
     },
     "sshpk": {
       "version": "1.14.2",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "markdown-it": "^8.4.0",
     "plantuml-encoder": "^1.2.5",
     "resize-observer-polyfill": "^1.5.0",
-    "squire-rte": "github:sohee-lee7/Squire#812513279820be381f0182683e01ad7867e140c0",
+    "squire-rte": "github:sohee-lee7/Squire#e7e620ca30a280db62c9e2fee166470d241af234",
     "to-mark": "^1.1.7",
     "tui-chart": "^3.0.1",
     "tui-code-snippet": "^1.5.0",

--- a/src/js/domUtils.js
+++ b/src/js/domUtils.js
@@ -644,6 +644,35 @@ const mergeNode = function(node, targetNode) {
   }
 };
 
+/**
+ * Create hr that is not contenteditable
+ * @returns {node} hr is wraped div
+ * @ignore
+ */
+const createHorizontalRule = function() {
+  const div = document.createElement('div');
+  const hr = document.createElement('hr');
+
+  div.setAttribute('contenteditable', false);
+  hr.setAttribute('contenteditable', false);
+
+  div.appendChild(hr);
+
+  return div;
+};
+
+/**
+ * Create Empty Line
+ * @returns {node} <div><br></div>
+ * @private
+ */
+const createEmptyLine = function() {
+  const div = document.createElement('div');
+  div.appendChild(document.createElement('br'));
+
+  return div;
+};
+
 export default {
   getNodeName,
   isTextNode,
@@ -676,5 +705,7 @@ export default {
   isListNode,
   isFirstListItem,
   isFirstLevelListItem,
-  mergeNode
+  mergeNode,
+  createHorizontalRule,
+  createEmptyLine
 };

--- a/src/js/wwHrManager.js
+++ b/src/js/wwHrManager.js
@@ -47,7 +47,7 @@ class WwHrManager {
   _initEvent() {
     this.eventManager.listen('wysiwygSetValueAfter', () => {
       this._insertEmptyLineIfNeed();
-      this._changeHRContenteditableFalse();
+      this._changeHRForWysiwyg();
     });
   }
 
@@ -72,7 +72,7 @@ class WwHrManager {
    * @memberof WwHrManager
    * @private
    */
-  _changeHRContenteditableFalse() {
+  _changeHRForWysiwyg() {
     const editorContentBody = this.wwe.get$Body()[0];
     const hrNodes = editorContentBody.querySelectorAll('hr');
 

--- a/src/js/wwHrManager.js
+++ b/src/js/wwHrManager.js
@@ -3,6 +3,7 @@
  * @author NHN FE Development Lab <dl_javascript@nhn.com>
  */
 import util from 'tui-code-snippet';
+import domUtils from './domUtils';
 
 /**
  * Class WwHrManager
@@ -45,34 +46,40 @@ class WwHrManager {
    */
   _initEvent() {
     this.eventManager.listen('wysiwygSetValueAfter', () => {
-      this._unwrapDivOnHr();
+      this._insertEmptyLineIfNeed();
+      this._changeHRContenteditableFalse();
     });
   }
 
   /**
-   * _unwrapDivOnHr
-   * Unwrap default block on hr
+   * If <hr> is frist or last child of root, insert empty line before or after HR
+   * @private
+   */
+  _insertEmptyLineIfNeed() {
+    const editorContentBody = this.wwe.get$Body()[0];
+    const {firstChild, lastChild} = editorContentBody;
+
+    if (firstChild && firstChild.nodeName === 'HR') {
+      editorContentBody.insertBefore(domUtils.createEmptyLine(), firstChild);
+    } else if (lastChild && lastChild.nodeName === 'HR') {
+      editorContentBody.appendChild(domUtils.createEmptyLine());
+    }
+  }
+
+  /**
+   * <hr> is set contenteditable to false with wrapping div like below.
+   * <div contenteditable="false"><hr contenteditable="false"><div>
    * @memberof WwHrManager
    * @private
    */
-  _unwrapDivOnHr() {
+  _changeHRContenteditableFalse() {
     const editorContentBody = this.wwe.get$Body()[0];
     const hrNodes = editorContentBody.querySelectorAll('hr');
+
     util.forEachArray(hrNodes, hrNode => {
       const {parentNode} = hrNode;
 
-      if (parentNode !== editorContentBody) {
-        const {parentNode: parentOfparent} = parentNode;
-
-        parentOfparent.removeChild(parentNode);
-        parentOfparent.appendChild(hrNode);
-      }
-
-      while (hrNode.firstChild) {
-        hrNode.removeChild(hrNode.firstChild);
-      }
-
-      hrNode.setAttribute('contenteditable', false);
+      parentNode.replaceChild(domUtils.createHorizontalRule(), hrNode);
     });
   }
 }

--- a/src/js/wwPasteContentHelper.js
+++ b/src/js/wwPasteContentHelper.js
@@ -162,7 +162,7 @@ class WwPasteContentHelper {
    * @private
    */
   _unwrapNestedBlocks($container, blockTags) {
-    const $leafElements = $container.find(':not(:has(*))').not('b,s,i,em,code,span');
+    const $leafElements = $container.find(':not(:has(*))').not('b,s,i,em,code,span,hr');
 
     $leafElements.each((i, node) => {
       let leafElement = node.nodeName === 'BR' ? $(node.parentNode) : $(node);

--- a/src/js/wysiwygCommands/hr.js
+++ b/src/js/wysiwygCommands/hr.js
@@ -22,19 +22,24 @@ const HR = CommandManager.command('wysiwyg', /** @lends HR */{
   exec(wwe) {
     const sq = wwe.getEditor();
     const range = sq.getSelection();
-    let currentNode, nextBlockNode, previousSibling;
 
     if (range.collapsed && !sq.hasFormat('TABLE') && !sq.hasFormat('PRE')) {
-      currentNode = domUtils.getChildNodeByOffset(range.startContainer, range.startOffset);
-      nextBlockNode = domUtils.getTopNextNodeUnder(currentNode, wwe.get$Body()[0]);
+      const hr = document.createElement('hr');
+      const currentNode = domUtils.getChildNodeByOffset(range.startContainer, range.startOffset);
+      let nextBlockNode = domUtils.getTopNextNodeUnder(currentNode, wwe.get$Body()[0]);
 
-      if (!nextBlockNode) {
-        nextBlockNode = sq.createDefaultBlock();
-        wwe.get$Body().append(nextBlockNode);
+      // If nextBlockNode is div that has hr and has contenteditable as false,
+      // nextBlockNode should be set as nextSibling that is normal block.
+      if (nextBlockNode && !domUtils.isTextNode(nextBlockNode)) {
+        while (nextBlockNode && nextBlockNode.getAttribute('contenteditable') === 'false') {
+          nextBlockNode = nextBlockNode.nextSibling;
+        }
       }
 
-      const hr = sq.createElement('HR');
-      hr.setAttribute('contenteditable', false);
+      if (!nextBlockNode) {
+        nextBlockNode = domUtils.createEmptyLine();
+        wwe.get$Body().append(nextBlockNode);
+      }
 
       sq.modifyBlocks(frag => {
         frag.appendChild(hr);
@@ -42,7 +47,7 @@ const HR = CommandManager.command('wysiwyg', /** @lends HR */{
         return frag;
       });
 
-      ({previousSibling} = hr);
+      const {previousSibling} = hr;
       if (previousSibling
                 && domUtils.isTextNode(previousSibling)
                 && domUtils.getTextLength(previousSibling) === 0
@@ -50,10 +55,13 @@ const HR = CommandManager.command('wysiwyg', /** @lends HR */{
         hr.parentNode.removeChild(previousSibling);
       }
 
+      hr.parentNode.replaceChild(domUtils.createHorizontalRule(), hr);
+
       range.selectNodeContents(nextBlockNode);
       range.collapse(true);
 
       sq.setSelection(range);
+      sq.saveUndoState(range);
     }
 
     wwe.focus();

--- a/test/unit/wwHrManager.spec.js
+++ b/test/unit/wwHrManager.spec.js
@@ -7,7 +7,6 @@ import $ from 'jquery';
 import WysiwygEditor from '../../src/js/wysiwygEditor';
 import EventManager from '../../src/js/eventManager';
 import WwHrManager from '../../src/js/wwHrManager';
-import Hr from '../../src/js/wysiwygCommands/hr';
 
 describe('WwHrManager', () => {
   let $container, em, wwe, mgr;
@@ -36,10 +35,26 @@ describe('WwHrManager', () => {
   });
 
   it('hr has contenteditable="false" whene wysiwygSetValueAfter event fire', () => {
-    wwe.getEditor().setHTML('<hr><h1>abcd</h1>');
+    wwe.getEditor().setHTML('<div>test</div><hr><div>test</div>');
 
     em.emit('wysiwygSetValueAfter');
 
-    expect(wwe.getEditor().getHTML().replace(/<br \/>|<br>/g, '')).toEqual('<hr contenteditable="false"><h1>abcd</h1>');
+    expect(wwe.getEditor().getHTML().replace(/<br \/>|<br>/g, '')).toEqual('<div>test</div><div contenteditable="false"><hr contenteditable="false"></div><div>test</div>');
+  });
+
+  it('should insert empty line before hr if hr is first child of root', () => {
+    wwe.getEditor().setHTML('<hr><div>test</div>');
+
+    em.emit('wysiwygSetValueAfter');
+
+    expect(wwe.getEditor().getHTML().replace(/<br \/>|<br>/g, '')).toEqual('<div></div><div contenteditable="false"><hr contenteditable="false"></div><div>test</div>');
+  });
+
+  it('should insert empty line after hr if hr is last child of root', () => {
+    wwe.getEditor().setHTML('<div>test</div><hr>');
+
+    em.emit('wysiwygSetValueAfter');
+
+    expect(wwe.getEditor().getHTML().replace(/<br \/>|<br>/g, '')).toEqual('<div>test</div><div contenteditable="false"><hr contenteditable="false"></div><div></div>');
   });
 });

--- a/test/unit/wysiwygCommands/hr.spec.js
+++ b/test/unit/wysiwygCommands/hr.spec.js
@@ -44,13 +44,13 @@ describe('HR', () => {
     HR.exec(wwe);
 
     expect(wwe.get$Body().find('hr').length).toEqual(1);
-    expect(wwe.get$Body().find('div').length).toEqual(2);
+    expect(wwe.get$Body().find('div').length).toEqual(3);
   });
 
   it('add HR and if there is next block then dont make default block', () => {
     const range = sq.getSelection().cloneRange();
 
-    sq.setHTML('<div>test</div><div><br/></div>');
+    sq.setHTML('<div>test</div><div><br></div>');
 
     range.setStart(wwe.get$Body().find('div')[0], 0);
     range.collapse(true);
@@ -59,14 +59,13 @@ describe('HR', () => {
 
     HR.exec(wwe);
 
-    expect(wwe.get$Body().find('hr').length).toEqual(1);
-    expect(wwe.get$Body().find('div').length).toEqual(2);
+    expect(wwe.getEditor().getHTML().replace(/<br \/>|<br>/g, '')).toEqual('<div>test</div><div contenteditable="false"><hr contenteditable="false"></div><div></div>');
   });
 
   it('append hr then cursor to next block', () => {
     const range = sq.getSelection().cloneRange();
 
-    sq.setHTML('<div>test</div><div><br/></div>');
+    sq.setHTML('<div>test</div><div><br></div>');
 
     range.setStart(wwe.get$Body().find('div')[0], 0);
     range.collapse(true);
@@ -75,7 +74,6 @@ describe('HR', () => {
 
     HR.exec(wwe);
 
-    expect(wwe.get$Body().find('div').length).toEqual(2);
-    expect(sq.getSelection().startContainer).toBe(wwe.get$Body().find('div')[1]);
+    expect(sq.getSelection().startContainer).toBe(wwe.get$Body().find('div')[2]);
   });
 });


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description

fix: #543 

구분선 주변에서 좌우 키로 이동 시 커서(range)가 `<hr>` 테그 양옆에 위치하게 되고 (실제 랜더링은 css의 영향으로 `<hr>` 바로 아래에 렌더링 된다.) 그 순간 텍스트를 입력하면 구분선 위아래에 텍스트가 입력됩니다.

이를 수정하기 위해 구분선을 아래와 같은 형태의 돔으로 운영하도록 변경하였습니다.

```html
<div contenteditable="false">
  <hr contenteditable="false">
</div>
```

추가로 스콰이어에 의해서 보통의 텍스트를 나타내는 `<div>`가 `<div contenteditable="false">`로 머지될 소지가 있으며, delete키와 backspace 키로 구분선을 지울 때 `<div contenteditable="false">` 안에 있는 `<hr contenteditable="false">` 만 지우는 문제가 있는데, 이는 스콰이어 쪽에서 `contenteditable="false"`에 대해 예외처리하도록 수정하였습니다. (https://github.com/sohee-lee7/Squire/issues/7)

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
