### PR TITLE
fix:  rendering is different between preview and wysiwyg (fix: #528)

### DIFF
--- a/src/js/codeMirrorExt.js
+++ b/src/js/codeMirrorExt.js
@@ -122,7 +122,7 @@ class CodeMirrorExt {
    * @returns {string} - codeMirror text value
    */
   getValue() {
-    return this.cm.getValue('\n');
+    return this.cm.getValue('\n').replace(/<br>\n/g, '<br>');
   }
 
   /**

--- a/src/js/mdPreview.js
+++ b/src/js/mdPreview.js
@@ -35,7 +35,7 @@ class MarkdownPreview extends Preview {
       latestMarkdownValue = markdownEditor.getValue();
 
       if (this.isVisible()) {
-        this.lazyRunner.run('refresh', latestMarkdownValue.replace(/<br>\n/g, '<br>'));
+        this.lazyRunner.run('refresh', latestMarkdownValue);
       }
     });
 


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description

`<br>\n`을 `<br>`로 변경하는 것이 미리보기 렌더링할 때만 적용되서, 위지윅과 미리보기의 결과가 다릅니다.
추가적으로 `getValue()`시에도 `<br>\n`을 `<br>` 변경하는 것이 적용되지 않아서 `getValue()`한 것을 Viewer에 넣으면 렌더링 결과가 미리보기랑 다릅니다.

따라서 아예 CodeMirrorExt의 `getValue()` 시에 `<br>\n`을 `<br>`로 변경하는 것을 적용하여 모든 결과물이 동일하도록 하였습니다.

`<br>\n`을 `<br>`로 변환하지 않으면 Markdown 문법상 개행이 올바르게 표현되지 않습니다.


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
