### PR TITLE
fix: data-tomark-pass appear when bracket is used for text (fix: #551)

### DIFF
--- a/src/js/convertor.js
+++ b/src/js/convertor.js
@@ -70,10 +70,10 @@ const attrName = '[a-zA-Z_:][a-zA-Z0-9:._-]*';
 const unquoted = '[^"\'=<>`\\x00-\\x20]+';
 const singleQuoted = "'[^']*'";
 const doubleQuoted = '"[^"]*"';
-const attrValue = '(?:' + unquoted + '|' + singleQuoted + '|' + doubleQuoted + ')';
-const attributeProperty = '(?:\\s+' + attrName + '(?:\\s*=\\s*' + attrValue + ')?)*\\s*';
-const openTag = '(\\\\<|<)([A-Za-z][A-Za-z0-9\\-]*' + attributeProperty + ')(\\/?>)';
-const HTML_TAG_RE = new RegExp(openTag, 'g');
+const attrValue = `(?:${unquoted}|${singleQuoted}|${doubleQuoted})`;
+const attribute = `(?:\\s+${attrName}(?:\\s*=\\s*${attrValue})?)*\\s*`;
+const openingTag = `(\\\\<|<)([A-Za-z][A-Za-z0-9\\-]*${attribute})(\\/?>)`;
+const HTML_TAG_RX = new RegExp(openingTag, 'g');
 
 /**
  * Class Convertor
@@ -116,13 +116,8 @@ class Convertor {
    * @returns {string} html text
    */
   _markdownToHtml(markdown, env) {
-    markdown = markdown.replace(HTML_TAG_RE, (match, $1, $2, $3) => {
-      let result = match;
-      if (match[0] !== '\\') {
-        result = `${$1}${$2} data-tomark-pass ${$3}`;
-      }
-
-      return result;
+    markdown = markdown.replace(HTML_TAG_RX, (match, $1, $2, $3) => {
+      return match[0] !== '\\' ? `${$1}${$2} data-tomark-pass ${$3}` : match;
     });
 
     // eslint-disable-next-line
@@ -194,13 +189,13 @@ class Convertor {
   /**
    * set link attribute to markdownitHighlight, markdownit
    * using linkAttribute of markdownItInlinePlugin
-   * @param {object} attribute markdown text
+   * @param {object} attr markdown text
    */
-  setLinkAttribute(attribute) {
-    const keys = Object.keys(attribute);
+  setLinkAttribute(attr) {
+    const keys = Object.keys(attr);
     const setAttributeToToken = (tokens, idx) => {
       keys.forEach(key => {
-        tokens[idx].attrPush([key, attribute[key]]);
+        tokens[idx].attrPush([key, attr[key]]);
       });
     };
 

--- a/test/unit/convertor.spec.js
+++ b/test/unit/convertor.spec.js
@@ -330,4 +330,20 @@ describe('Convertor', () => {
       expect(convertor.toMarkdown(html)).toEqual(markdown);
     });
   });
+
+  describe('should not insert data-tomark-pass', () => {
+    it('when <> include korean', () => {
+      const markdown = '<AS 안내>';
+      const html = '<p>&lt;AS 안내&gt;</p>';
+
+      expect(convertor.toHTML(markdown).replace('\n', '')).toEqual(html);
+    });
+
+    it('when < start with backslash', () => {
+      const markdown = '\\<AS>';
+      const html = '<p>&lt;AS&gt;</p>';
+
+      expect(convertor.toHTML(markdown).replace('\n', '')).toEqual(html);
+    });
+  });
 });


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description

fix #551

마크다운에서 입력된 테그의 경우 `data-tomark-pass`를 넣어주는데, 꺽쇠괄호(`<`,`>`)가 테그가 아닌 단순히 텍스트로 이용되는 경우에 대한 예외 처리입니다.

* 테그 판별 코드는 마크다운잇에서 가져왔습니다. (마크다운잇과 동일하게 테그를 판별하기 위함)
* 백슬래시를 이용할 경우에 대한 예외처리 추가하였습니다.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
