### PR TITLE
fix: scroll sync bugs

### DIFF
--- a/src/css/tui-editor.css
+++ b/src/css/tui-editor.css
@@ -83,7 +83,7 @@
 }
 
 .te-md-container .te-preview .tui-editor-contents {
-    padding-top: 11px;
+    padding-top: 8px;
 }
 
 .tui-editor .te-preview-style-tab>.te-editor,
@@ -177,8 +177,8 @@
 }
 
 .tui-editor-defaultUI .CodeMirror-lines {
-    padding-top: 13px;
-    padding-bottom: 13px;
+    padding-top: 18px;
+    padding-bottom: 18px;
 }
 
 .tui-editor-defaultUI .CodeMirror-line {
@@ -929,10 +929,6 @@ only screen and (                min-resolution: 2dppx) {
 }
 .tui-colorpicker-svg-huebar {
     border: 1px solid #ebebeb;
-}
-
-.CodeMirror-sizer {
-    margin-top: 6px;
 }
 
 .CodeMirror .cm-header {

--- a/src/js/extensions/scrollSync/sectionManager.js
+++ b/src/js/extensions/scrollSync/sectionManager.js
@@ -103,8 +103,8 @@ class SectionManager {
   _eachLineState(iteratee) {
     let isSection, i, lineString, nextLineString, prevLineString,
       isTrimming = true,
-      onTable = false,
-      onCodeBlock = false,
+      isInTable = false,
+      isInCodeBlock = false,
       trimCapture = '';
     let isRightAfterImageSection = false;
     let isEnsuredSection = false;
@@ -119,22 +119,22 @@ class SectionManager {
       prevLineString = this.cm.getLine(i - 1) || '';
       const isCodeBlockEnded = this._isCodeBlockEnd(prevLineString) && (codeblockStartLineIndex !== (i - 1));
 
-      if (onTable && (!lineString || !this._isTableCode(lineString))) {
-        onTable = false;
-      } else if (!onTable && this._isTable(lineString, nextLineString)) {
-        onTable = true;
+      if (isInTable && (!lineString || !this._isTableCode(lineString))) {
+        isInTable = false;
+      } else if (!isInTable && this._isTable(lineString, nextLineString)) {
+        isInTable = true;
       }
 
-      if (onCodeBlock && isCodeBlockEnded) {
-        onCodeBlock = false;
+      if (isInCodeBlock && isCodeBlockEnded) {
+        isInCodeBlock = false;
       }
-      if (!onCodeBlock && this._isCodeBlockStart(lineString)) {
-        onCodeBlock = this._doFollowedLinesHaveCodeBlockEnd(i, lineLength);
+      if (!isInCodeBlock && this._isCodeBlockStart(lineString)) {
+        isInCodeBlock = this._doFollowedLinesHaveCodeBlockEnd(i, lineLength);
         codeblockStartLineIndex = i;
       }
 
       if (isEnsuredSection && lineString.length !== 0) {
-        if (this._isIndependentImage(onCodeBlock, onTable, lineString, prevLineString)) {
+        if (this._isIndependentImage(isInCodeBlock, isInTable, lineString, prevLineString)) {
           isRightAfterImageSection = true;
           isEnsuredSection = true;
         } else {
@@ -143,19 +143,19 @@ class SectionManager {
         }
 
         isSection = true;
-      } else if (!onCodeBlock && this._isAtxHeader(lineString)) {
+      } else if (!isInCodeBlock && this._isAtxHeader(lineString)) {
         isRightAfterImageSection = false;
         isSection = true;
         isEnsuredSection = false;
         // setext header
       } else if (!this._isCodeBlockEnd(lineString)
-                && !onTable
+                && !isInTable
                 && this._isSeTextHeader(lineString, nextLineString)
       ) {
         isRightAfterImageSection = false;
         isSection = true;
         isEnsuredSection = false;
-      } else if (this._isIndependentImage(onCodeBlock, onTable, lineString, prevLineString)) {
+      } else if (this._isIndependentImage(isInCodeBlock, isInTable, lineString, prevLineString)) {
         isRightAfterImageSection = true;
         isSection = true;
         isEnsuredSection = false;
@@ -181,15 +181,15 @@ class SectionManager {
 
   /**
    * Return whether is independent image line with padding lines top and bottom
-   * @param {boolean} onCodeBlock Is on codeblock
-   * @param {boolean} onTable Is on table
+   * @param {boolean} isInCodeBlock Is on codeblock
+   * @param {boolean} isInTable Is on table
    * @param {string} lineString Current line string
    * @param {string} prevLineString Previous line string
    * @returns {boolean}
    * @private
    */
-  _isIndependentImage(onCodeBlock, onTable, lineString, prevLineString) {
-    return !onCodeBlock && !onTable
+  _isIndependentImage(isInCodeBlock, isInTable, lineString, prevLineString) {
+    return !isInCodeBlock && !isInTable
             && this._isImage(lineString) && !this._isList(lineString) && !this._isQuote(lineString)
             && prevLineString.length === 0;
   }

--- a/src/js/extensions/scrollSync/sectionManager.js
+++ b/src/js/extensions/scrollSync/sectionManager.js
@@ -368,7 +368,7 @@ class SectionManager {
     this.$previewContent.contents().filter(findElementNodeFilter).each((index, el) => {
       const isParagraph = (el.tagName === 'P');
       const isHeading = el.tagName.match(/^(H1|H2|H3|H4|H5|H6)$/);
-      const isImage = (isParagraph && el.childNodes[0].nodeName === 'IMG');
+      const isImage = (isParagraph && el.hasChildNodes() && el.childNodes[0].nodeName === 'IMG');
 
       if ((isHeading || isImage || isRightAfterImageSection)
                 && sections[lastSection].length

--- a/src/js/extensions/scrollSync/sectionManager.js
+++ b/src/js/extensions/scrollSync/sectionManager.js
@@ -143,7 +143,7 @@ class SectionManager {
         }
 
         isSection = true;
-      } else if (this._isAtxHeader(lineString)) {
+      } else if (!onCodeBlock && this._isAtxHeader(lineString)) {
         isRightAfterImageSection = false;
         isSection = true;
         isEnsuredSection = false;


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description

스크롤 싱크 이슈들 처리입니다.

* #411 : 스크롤 싱크시 마지막 라인인지 판단 못하는 이슈
  * CodeMirror-size는 코드미러 내부적으로 height를 조정하고 사용하는 돔으로 여백을 주기 위해서는 CodeMirror-lines가 더 적합.
  * 그리고 두레이의 디자인 가이드가 여백이 18px이라서 현재 19px로 잡혀있는 것도 이번에 함께 변경.
* #97 : exception 처리
* #275 #92 : 코드블럭의 `#`이 섹션 판단 시 헤딩으로 인식되는 문제

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
