### PR TITLE
emhance: calculate scrollTop base cursor position

### DIFF
--- a/src/js/extensions/scrollSync/scrollManager.js
+++ b/src/js/extensions/scrollSync/scrollManager.js
@@ -158,7 +158,7 @@ class ScrollManager {
       factors = {
         section: cusrsorSection,
         sectionRatio: ratio,
-        cursorTop: cursorInfo.top - scrollInfo.top
+        relativeCursorTop: cursorInfo.top - scrollInfo.top
       };
     }
 
@@ -245,11 +245,11 @@ class ScrollManager {
     const cursorFactors = this._getCursorFactorsOfEditor();
 
     if (cursorFactors) {
-      const {section, sectionRatio, cursorTop} = cursorFactors;
+      const {section, sectionRatio, relativeCursorTop} = cursorFactors;
 
       scrollTop = section.$previewSectionEl[0].offsetTop;
       scrollTop += (section.$previewSectionEl.height() * sectionRatio) - SCROLL_TOP_PADDING;
-      scrollTop -= cursorTop;
+      scrollTop -= relativeCursorTop;
 
       scrollTop = scrollTop && Math.max(scrollTop, 0);
     }
@@ -292,7 +292,7 @@ class ScrollManager {
   /**
    * syncPreviewScrollTopToMarkdown
    * sync preview scroll to markdown
-   * @param isCursorBase boolean
+   * @param {boolean} isCursorBase whether sync according to cursor position
    */
   syncPreviewScrollTopToMarkdown(isCursorBase) {
     const {$previewContainerEl} = this;

--- a/src/js/extensions/scrollSync/scrollManager.js
+++ b/src/js/extensions/scrollSync/scrollManager.js
@@ -138,31 +138,28 @@ class ScrollManager {
   _getCursorFactorsOfEditor() {
     const {cm} = this;
     const cursorInfo = cm.cursorCoords(true, 'local');
-    let scrollInfo = cm.getScrollInfo();
-    let cursorLine, cusrsorSection, ratio, factors;
 
     // if codemirror has not visible scrollInfo have incorrect value
     // so we use saved scroll info for alternative
-    scrollInfo = this._fallbackScrollInfoIfIncorrect(scrollInfo);
-
-    cursorLine = cm.coordsChar({
+    const scrollInfo = this._fallbackScrollInfoIfIncorrect(cm.getScrollInfo());
+    const cursorLine = cm.coordsChar({
       left: cursorInfo.left,
       top: cursorInfo.top
     }, 'local').line;
 
-    cusrsorSection = this.sectionManager.sectionByLine(cursorLine);
+    const cusrsorSection = this.sectionManager.sectionByLine(cursorLine);
 
     if (cusrsorSection) {
-      ratio = this._getEditorSectionScrollRatio(cusrsorSection, cursorLine);
+      const ratio = this._getEditorSectionScrollRatio(cusrsorSection, cursorLine);
 
-      factors = {
+      return {
         section: cusrsorSection,
         sectionRatio: ratio,
         relativeCursorTop: cursorInfo.top - scrollInfo.top
       };
     }
 
-    return factors;
+    return null;
   }
 
   /**
@@ -236,23 +233,26 @@ class ScrollManager {
 
   /**
    * _getScrollTopForPreviewBaseCursor
-   * Return scrollTop value for preview accourding cursor position
+   * Return scrollTop value for preview according cursor position
    * @returns {number} scrollTop value
    */
   _getScrollTopForPreviewBaseCursor() {
-    let scrollTop = 0;
-
     const cursorFactors = this._getCursorFactorsOfEditor();
 
-    if (cursorFactors) {
-      const {section, sectionRatio, relativeCursorTop} = cursorFactors;
-
-      scrollTop = section.$previewSectionEl[0].offsetTop;
-      scrollTop += (section.$previewSectionEl.height() * sectionRatio) - SCROLL_TOP_PADDING;
-      scrollTop -= relativeCursorTop;
-
-      scrollTop = scrollTop && Math.max(scrollTop, 0);
+    if (!cursorFactors) {
+      return 0;
     }
+
+    const {section, sectionRatio, relativeCursorTop} = cursorFactors;
+    let scrollTop = section.$previewSectionEl[0].offsetTop;
+
+    // Moves the preview so that the line of cursor is positioned at top of the preview.
+    scrollTop += (section.$previewSectionEl.height() * sectionRatio) - SCROLL_TOP_PADDING;
+
+    // Moves the preview by the position of the cursor at markdown.
+    scrollTop -= relativeCursorTop;
+
+    scrollTop = scrollTop && Math.max(scrollTop, 0);
 
     return scrollTop;
   }

--- a/src/js/extensions/scrollSync/scrollSync.js
+++ b/src/js/extensions/scrollSync/scrollSync.js
@@ -94,11 +94,16 @@ function scrollSyncExtension(editor) {
   }
 
   editor.on('previewRenderAfter', () => {
-    sectionManager.sectionMatch();
-    if (isActive) {
-      scrollManager.syncPreviewScrollTopToMarkdown();
-    }
-    isScrollable = true;
+    // Immediately after the 'previewRenderAfter' event has occurred,
+    // brower rendering is not yet complete.
+    // So the size of elements can not be accurately measured.
+    setTimeout(() => {
+      sectionManager.sectionMatch();
+      if (isActive) {
+        scrollManager.syncPreviewScrollTopToMarkdown(true);
+      }
+      isScrollable = true;
+    }, 200);
   });
 
   editor.eventManager.listen('scroll', event => {
@@ -108,7 +113,7 @@ function scrollSyncExtension(editor) {
 
     if (isScrollable && editor.preview.isVisible()) {
       if (event.source === 'markdown' && !scrollManager.isMarkdownScrollEventBlocked) {
-        scrollManager.syncPreviewScrollTopToMarkdown();
+        scrollManager.syncPreviewScrollTopToMarkdown(false);
       } else if (event.source === 'preview' && !scrollManager.isPreviewScrollEventBlocked) {
         scrollManager.syncMarkdownScrollTopToPreview();
       }

--- a/src/js/extensions/scrollSync/scrollSync.js
+++ b/src/js/extensions/scrollSync/scrollSync.js
@@ -95,7 +95,7 @@ function scrollSyncExtension(editor) {
 
   editor.on('previewRenderAfter', () => {
     // Immediately after the 'previewRenderAfter' event has occurred,
-    // brower rendering is not yet complete.
+    // browser rendering is not yet complete.
     // So the size of elements can not be accurately measured.
     setTimeout(() => {
       sectionManager.sectionMatch();


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description

스크롤 싱크는 항상 마크다운의 최상단 라인을 기준으로 Preview가 싱크됩니다.
하지만 중간에 긴 이미지가 있을 경우 커서가 이미지를 지나 다음 줄을 작성하고 있어도 싱크가 최상단 라인을 기준으로 되기 때문에 현재 작성 중인 부분으로 싱크가 되지 않습니다.

따라서 에디팅에 의해서 싱크가 될 경우에는 커서 위치를 기준으로 싱크가 되도록 하였습니다.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
