### PR TITLE
docs(editor.js): fix typo in editor.js JSdoc

### DIFF
--- a/src/js/editor.js
+++ b/src/js/editor.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Implemtents Editor
+ * @fileoverview Implements Editor
  * @author NHN FE Development Lab <dl_javascript@nhn.com>
  */
 import $ from 'jquery';


### PR DESCRIPTION
#### Description: 

fixes typo in 2nd line of `editor.js`

