### PR TITLE
fix: remove data-tomark-pass property on empty element tag (fix #613)

### DIFF
--- a/src/js/convertor.js
+++ b/src/js/convertor.js
@@ -165,7 +165,7 @@ class Convertor {
 
     $wrapperDiv.find('code, pre').each((i, codeOrPre) => {
       const $code = $(codeOrPre);
-      $code.html($code.html().replace(/(\sdata-tomark-pass\s)(\/?)&gt;/g, '$2&gt;'));
+      $code.html($code.html().replace(/\sdata-tomark-pass\s(\/?)&gt;/g, '$1&gt;'));
     });
 
     renderedHTML = $wrapperDiv.html();

--- a/src/js/convertor.js
+++ b/src/js/convertor.js
@@ -165,7 +165,7 @@ class Convertor {
 
     $wrapperDiv.find('code, pre').each((i, codeOrPre) => {
       const $code = $(codeOrPre);
-      $code.html($code.html().replace(/ data-tomark-pass &gt;/g, '&gt;'));
+      $code.html($code.html().replace(/(\sdata-tomark-pass\s)(\/?)&gt;/g, '$2&gt;'));
     });
 
     renderedHTML = $wrapperDiv.html();

--- a/test/unit/convertor.spec.js
+++ b/test/unit/convertor.spec.js
@@ -111,31 +111,27 @@ describe('Convertor', () => {
 
     it('should insert data-tomark-pass in html tag even if attrubute has slash', () => {
       const imgTag = '<img src="https://user-images.githubusercontent.com/1215767/34336735-e7c9c4b0-e99c-11e7-853b-2449b51f0bab.png">';
-
       const expectedHTML = '<p><img src="https://user-images.githubusercontent.com/1215767/34336735-e7c9c4b0-e99c-11e7-853b-2449b51f0bab.png" data-tomark-pass=""></p>';
 
       expect(convertor.toHTML(imgTag).replace(/\n/g, '')).toEqual(expectedHTML);
     });
 
     it('should not insert data-tomark-pass in codeblock that has tag', () => {
-      const codeBlockMd = `\`\`\`\n<p>hello</p>\n\`\`\``;
-
+      const codeBlockMd = '```\n<p>hello</p>\n```';
       const expectedHTML = `<pre><code>&lt;p&gt;hello&lt;/p&gt;</code></pre>`;
 
       expect(convertor.toHTML(codeBlockMd).replace(/\n/g, '')).toEqual(expectedHTML);
     });
 
     it('should not insert data-tomark-pass in codeblock that has tag with attribute', () => {
-      const codeBlockMd = `\`\`\`\n<p class="test">hello</p>\n\`\`\``;
-
+      const codeBlockMd = '```\n<p class="test">hello</p>\n```';
       const expectedHTML = `<pre><code>&lt;p class="test"&gt;hello&lt;/p&gt;</code></pre>`;
 
       expect(convertor.toHTML(codeBlockMd).replace(/\n/g, '')).toEqual(expectedHTML);
     });
 
     it('should not insert data-tomark-pass in codeblock that has tag of empty element.', () => {
-      const codeBlockMd = `\`\`\`\n<br/><br /><input type="text" />\n\`\`\``;
-
+      const codeBlockMd = '```\n<br/><br /><input type="text" />\n```';
       const expectedHTML = `<pre><code>&lt;br/&gt;&lt;br /&gt;&lt;input type="text" /&gt;</code></pre>`;
 
       expect(convertor.toHTML(codeBlockMd).replace(/\n/g, '')).toEqual(expectedHTML);

--- a/test/unit/convertor.spec.js
+++ b/test/unit/convertor.spec.js
@@ -132,6 +132,14 @@ describe('Convertor', () => {
 
       expect(convertor.toHTML(codeBlockMd).replace(/\n/g, '')).toEqual(expectedHTML);
     });
+
+    it('should not insert data-tomark-pass in codeblock that has tag of empty element.', () => {
+      const codeBlockMd = `\`\`\`\n<br/><br /><input type="text" />\n\`\`\``;
+
+      const expectedHTML = `<pre><code>&lt;br/&gt;&lt;br /&gt;&lt;input type="text" /&gt;</code></pre>`;
+
+      expect(convertor.toHTML(codeBlockMd).replace(/\n/g, '')).toEqual(expectedHTML);
+    });
   });
 
   describe('html to markdown', () => {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description

* Fixed issue #613 (related to #511)
* 마크다운 -> 위지윅 변환 시 empty element인 경우에 프로퍼티가 남아있는 현상

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
