### PR TITLE
feat: add convertor function of to-mark (fix #617)

### DIFF
--- a/src/js/editor.js
+++ b/src/js/editor.js
@@ -24,6 +24,7 @@ import WwTableManager from './wwTableManager';
 import WwTableSelectionManager from './wwTableSelectionManager';
 import {CodeBlockManager} from './codeBlockManager';
 import codeBlockManager from './codeBlockManager';
+import toMarkRenderer from './toMarkRenderer';
 
 // markdown commands
 import mdBold from './markdownCommands/bold';
@@ -219,7 +220,7 @@ class ToastUIEditor {
       false,
       this.options.previewDelayTime);
     this.wwEditor = WysiwygEditor.factory(this.layout.getWwEditorContainerEl(), this.eventManager);
-    this.toMarkOptions = null;
+    this.toMarkOptions = {renderer: toMarkRenderer};
 
     if (this.options.linkAttribute) {
       const attribute = this._sanitizeLinkAttribute(this.options.linkAttribute);

--- a/src/js/toMarkRenderer.js
+++ b/src/js/toMarkRenderer.js
@@ -1,0 +1,18 @@
+import toMark from 'to-mark';
+
+export default toMark.Renderer.factory(toMark.basicRenderer, {
+  'TEXT_NODE': function(node) {
+    let managedText = this.trim(this.getSpaceCollapsedText(node.nodeValue));
+
+    managedText = managedText.replace(/[*_~]/g, matched => `\\${matched}`);
+
+    if (this._isNeedEscapeHtml(managedText)) {
+      managedText = this.escapeTextHtml(managedText);
+    }
+    if (this._isNeedEscape(managedText)) {
+      managedText = this.escapeText(managedText);
+    }
+
+    return this.getSpaceControlled(managedText, node);
+  }
+});


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description

* Issue related to #617 

---

## 이슈

위지윅 에디터에서 입력한 특수 문자(`*`, `~`, `_`) 일부가 이스케이프되지 않아서 마크다운 에디터로 변환한 후 하이라이팅되고 있다.

## 원인

`to-mark`에서 마크다운 구문을 체크하여 이스케이프 처리하는데, 강조 구문의 짝(pair)이 맞지 않는 상황에서 해당 현상이 발생하고 있다. 예를 들어서 `foo*bar*baz`를 입력한 경우에는 이스케이프 되고 `foo*bar`를 입력한 경우에는 이스케이프 되지 않는다.

* 위지윅에서 입력
```
foo*bar*baz

foo*bar

foo*bar
baz*qax
```
* 위지윅 -> 마크다운 변환
```
foo\*bar\*baz

foo*bar // not escape

foo*bar // not escape
baz*qax // not escape
```
이렇게 정상적으로 이스케이프가 되지 않은 상황에서 마크다운 에디터로 변환하면 마크다운 구문으로 인식된다. 다시 위지윅으로 변환하면 마크다운 문법으로 인식된 문자들이 html로 치환되어 사용자 입력 의도를 벗어나게 된다.

> e.g. 일반 텍스트로 입력하였으나 마크다운 구문으로 인식하는 과정

* 위지윅 -> 마크다운 변환
![스크린샷 2019-09-03 오후 5 16 21](https://user-images.githubusercontent.com/18183560/64155834-913e1480-ce6e-11e9-86aa-543387b26d83.png)

* 마크다운 -> 위지윅 변환
![스크린샷 2019-09-03 오후 5 18 48](https://user-images.githubusercontent.com/18183560/64156011-e9751680-ce6e-11e9-801e-334c49c76140.png)

## 해결점

`to-mark`에서 이스케이프 할 때 마크다운 강조 구문의 짝이 맞는 경우만 이스케이프를 하는 것이 아니라, 모든 강조 구문을 이스케이프 처리해야 한다.
```js
'foo*bar'.replace(/[*_~]/g, matched => `\\${matched}`);
```
~~`to-mark`에서 노드 단위로 이스케이프를 처리하는 것이 스펙으로 판단된다. 즉, 위 이슈는 마크다운 - 위지윅 에디터 변환 과정에서 발생하는 것이기 때문에 에디터 단에서 처리(`to-mark`의 컨버터 함수 오버라이드)하는 방향으로 한다.~~

에디터만의 이슈가 아니라 `to-mark` 자체의 이슈로 보아야 한다. 아래와 같은 경우를 정상적으로 처리할 수 없다.

* 위지윅에서 입력
```
*foo<strong>bar*ba</strong>z*
```
![wrong-case-wwe](https://user-images.githubusercontent.com/18183560/64247657-42fe4380-cf4a-11e9-834e-538ba6afb21d.png)

* 위지윅 -> 마크다운 변환

![wrong-case-md](https://user-images.githubusercontent.com/18183560/64247684-57dad700-cf4a-11e9-96a1-98eebeb7d51e.png)

## 결론

`to-mark`에서 이스케이프를 처리해야 한다. 즉, 현재 PR에서 처리한 로직을 `to-mark`로 이동한다. 이 PR은 클로즈한다.


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
