### PR TITLE
fix: remove empty line between text and code block (fix #624)

### DIFF
--- a/src/js/convertor.js
+++ b/src/js/convertor.js
@@ -260,8 +260,8 @@ class Convertor {
 
   _removeNewlinesBeforeAfterAndBlockElement(markdown) {
     // Newlines('\n\n') are created on to-mark.
-    const NEWLINES_BEFORE_BLOCK_RX = /<br>\n\n((#{1,6} .*)|(```)|(\|)|((\*+|-+|\d+\.) .*)|( *>[^\n]+.*))/g;
-    const NEWLINES_AFTER_BLOCK_RX = /((#{1,6} .*)|(```)|(\|))\n\n<br>/g;
+    const NEWLINES_BEFORE_BLOCK_RX = /<br>\n\n(#{1,6} .*|```|\||(\*+|-+|\d+\.) .*| *>[^\n]+.*)/g;
+    const NEWLINES_AFTER_BLOCK_RX = /(#{1,6} .*|```|\|)\n\n<br>/g;
 
     markdown = markdown.replace(NEWLINES_BEFORE_BLOCK_RX, '<br>$1');
     markdown = markdown.replace(NEWLINES_AFTER_BLOCK_RX, '$1\n<br>');

--- a/src/js/convertor.js
+++ b/src/js/convertor.js
@@ -240,14 +240,10 @@ class Convertor {
 
     html = this.eventManager.emitReduce('convertorBeforeHtmlToMarkdownConverted', html);
 
-    html = this._preventBrBetweenTextAndCodeBlock(html);
-    html = this._appendAttributeForBrIfNeed(html);
-
-    let markdown = toMark(html, toMarkOptions);
+    let markdown = toMark(this._appendAttributeForBrIfNeed(html), toMarkOptions);
 
     markdown = this.eventManager.emitReduce('convertorAfterHtmlToMarkdownConverted', markdown);
-
-    markdown = this._removeNewlinesBeforeAfterCodeblock(markdown);
+    markdown = this._removeNewlinesBeforeAfterAndBlockElement(markdown);
 
     util.forEach(markdown.split('\n'), (line, index) => {
       const FIND_TABLE_RX = /^\|[^|]*\|/ig;
@@ -262,18 +258,13 @@ class Convertor {
     return resultArray.join('\n');
   }
 
-  _preventBrBetweenTextAndCodeBlock(html) {
-    // first "br" is a line break and second "br" is an empty line on html
-    html = html.replace(/<br><br><pre>/g, '<br><br data-tomark-pass><pre>');
-    html = html.replace(/<\/pre><br>([^<\s])/g, '</pre><br data-tomark-pass>$1');
+  _removeNewlinesBeforeAfterAndBlockElement(markdown) {
+    // Newlines('\n\n') are created on to-mark.
+    const NEWLINES_BEFORE_BLOCK_RX = /<br>\n\n((#{1,6} .*)|(```)|(\|)|((\*+|-+|\d+\.) .*)|( *>[^\n]+.*))/g;
+    const NEWLINES_AFTER_BLOCK_RX = /((#{1,6} .*)|(```)|(\|))\n\n<br>/g;
 
-    return html;
-  }
-
-  _removeNewlinesBeforeAfterCodeblock(markdown) {
-    // newlines("\n\n") are created on to-mark
-    markdown = markdown.replace(/<br>\n\n```/g, '<br>```');
-    markdown = markdown.replace(/```\n\n(<br>[^<\s])/g, '```\n$1');
+    markdown = markdown.replace(NEWLINES_BEFORE_BLOCK_RX, '<br>$1');
+    markdown = markdown.replace(NEWLINES_AFTER_BLOCK_RX, '$1\n<br>');
 
     return markdown;
   }
@@ -288,11 +279,16 @@ class Convertor {
     const FIND_ATTRI_WITH_EMTPY_STR_RX = /<br data-tomark-pass="">/ig;
 
     html = html.replace(FIND_BR_RX, '<br />');
+
     html = html.replace(FIND_DOUBLE_BR_RX, '<br data-tomark-pass /><br data-tomark-pass />');
     html = html.replace(FIND_ATTRI_WITH_EMTPY_STR_RX, '<br data-tomark-pass />');
 
     html = html.replace(FIND_PASSING_AND_NORMAL_BR_RX, '<br data-tomark-pass /><br data-tomark-pass />$1');
     html = html.replace(FIND_FIRST_TWO_BRS_RX, '$1<br /><br />');
+
+    // Preserve <br> when there is only one empty line before or after a block element.
+    html = html.replace(/(.)<br \/><br \/>(<h[1-6]>|<pre>|<table>|<ul>|<ol>|<blockquote>)/g, '$1<br /><br data-tomark-pass />$2');
+    html = html.replace(/(<\/h[1-6]>|<\/pre>|<\/table>|<\/ul>|<\/ol>|<\/blockquote>)<br \/>(.)/g, '$1<br data-tomark-pass />$2');
 
     return html;
   }

--- a/test/unit/convertor.spec.js
+++ b/test/unit/convertor.spec.js
@@ -198,11 +198,9 @@ describe('Convertor', () => {
         .toBe('<span>text</span>\n\ntext');
     });
 
-    describe('should prevent <br> if there is only one empty line before or after the block element.', () => {
-      let html, markdown;
-
-      it('header', () => {
-        html = [
+    describe('should prevent <br> from being removed if there is only one empty line before or after the block element.', () => {
+      it('header with inline elements', () => {
+        const html = [
           'foo',
           '<br>', // Generated when a line break occurs after an inline element.
           '<br>',
@@ -210,7 +208,7 @@ describe('Convertor', () => {
           '<br>',
           'baz'
         ].join('');
-        markdown = [
+        const markdown = [
           'foo',
           '<br>',
           '# bar',
@@ -219,27 +217,10 @@ describe('Convertor', () => {
         ].join('\n');
 
         expect(convertor.toMarkdown(html)).toBe(markdown);
-
-        html = [
-          '<h1>foo</h1>',
-          '<br>',
-          '<h2>bar</h2>',
-          '<br>',
-          '<h3>baz</h3>'
-        ].join('');
-        markdown = [
-          '# foo',
-          '<br>',
-          '## bar',
-          '<br>',
-          '### baz'
-        ].join('\n');
-
-        expect(convertor.toMarkdown(html)).toBe(markdown);
       });
 
-      it('codeblock', () => {
-        html = [
+      it('codeblock with inline elements', () => {
+        const html = [
           'foo',
           '<br>', // Generated when a line break occurs after an inline element.
           '<br>',
@@ -247,7 +228,7 @@ describe('Convertor', () => {
           '<br>',
           'baz'
         ].join('');
-        markdown = [
+        const markdown = [
           'foo',
           '<br>',
           '```',
@@ -260,8 +241,8 @@ describe('Convertor', () => {
         expect(convertor.toMarkdown(html)).toBe(markdown);
       });
 
-      it('table', () => {
-        html = [
+      it('table with inline elements', () => {
+        const html = [
           'foo',
           '<br>', // Generated when a line break occurs after an inline element.
           '<br>',
@@ -269,7 +250,7 @@ describe('Convertor', () => {
           '<br>',
           'qux'
         ].join('');
-        markdown = [
+        const markdown = [
           'foo',
           '<br>',
           '| bar |',
@@ -282,8 +263,8 @@ describe('Convertor', () => {
         expect(convertor.toMarkdown(html)).toBe(markdown);
       });
 
-      it('list', () => {
-        html = [
+      it('list with inline elements', () => {
+        let html = [
           'foo',
           '<br>', // Generated when a line break occurs after an inline element.
           '<br>',
@@ -291,7 +272,7 @@ describe('Convertor', () => {
           '<br>',
           'qux'
         ].join('');
-        markdown = [
+        let markdown = [
           'foo',
           '<br>',
           '* bar',
@@ -328,8 +309,8 @@ describe('Convertor', () => {
         expect(convertor.toMarkdown(html)).toBe(markdown);
       });
 
-      it('blockquote', () => {
-        html = [
+      it('blockquote with inline elements', () => {
+        const html = [
           'foo',
           '<br>', // Generated when a line break occurs after an inline element.
           '<br>',
@@ -337,7 +318,7 @@ describe('Convertor', () => {
           '<br>',
           'baz'
         ].join('');
-        markdown = [
+        const markdown = [
           'foo',
           '<br>',
           '> bar',
@@ -346,6 +327,39 @@ describe('Convertor', () => {
           '',
           '<br>',
           'baz'
+        ].join('\n');
+
+        expect(convertor.toMarkdown(html)).toBe(markdown);
+      });
+
+      it('between block elements.', () => {
+        const html = [
+          '<h1>foo</h1>',
+          '<br>',
+          '<pre><code>bar</code></pre>',
+          '<br>',
+          '<table><thead><tr><th>bar</th></tr></thead><tbody><tr><td>baz</td></tr></tbody></table>',
+          '<br>',
+          '<ol><li>bar</li><li>baz</li></ol>',
+          '<br>',
+          '<blockquote>bar</blockquote>'
+        ].join('');
+        const markdown = [
+          '# foo',
+          '<br>',
+          '```',
+          'bar',
+          '```',
+          '<br>',
+          '| bar |',
+          '| --- |',
+          '| baz |',
+          '<br>',
+          '1. bar',
+          '2. baz',
+          '',
+          '<br>',
+          '> bar'
         ].join('\n');
 
         expect(convertor.toMarkdown(html)).toBe(markdown);

--- a/test/unit/convertor.spec.js
+++ b/test/unit/convertor.spec.js
@@ -197,6 +197,11 @@ describe('Convertor', () => {
       expect(convertor.toMarkdown('<span>text</span><br><br>text'))
         .toBe('<span>text</span>\n\ntext');
     });
+
+    it('should prevent 1 BR befere and after code block.', () => {
+      expect(convertor.toMarkdown('text<br><br><pre><code>code block</code></pre>')).toBe('text\n<br>\n```\ncode block\n```');
+      expect(convertor.toMarkdown('<pre><code>code block</code></pre><br>text')).toBe('```\ncode block\n```\n<br>\ntext');
+    });
   });
 
   describe('event', () => {

--- a/test/unit/convertor.spec.js
+++ b/test/unit/convertor.spec.js
@@ -265,17 +265,18 @@ describe('Convertor', () => {
           'foo',
           '<br>', // Generated when a line break occurs after an inline element.
           '<br>',
-          '<table><thead><tr><th>bar</th></tr></thead></table>',
+          '<table><thead><tr><th>bar</th></tr></thead><tbody><tr><td>baz</td></tr></tbody></table>',
           '<br>',
-          'baz'
+          'qux'
         ].join('');
         markdown = [
           'foo',
           '<br>',
           '| bar |',
           '| --- |',
+          '| baz |',
           '<br>',
-          'baz'
+          'qux'
         ].join('\n');
 
         expect(convertor.toMarkdown(html)).toBe(markdown);

--- a/test/unit/convertor.spec.js
+++ b/test/unit/convertor.spec.js
@@ -198,9 +198,157 @@ describe('Convertor', () => {
         .toBe('<span>text</span>\n\ntext');
     });
 
-    it('should prevent 1 BR befere and after code block.', () => {
-      expect(convertor.toMarkdown('text<br><br><pre><code>code block</code></pre>')).toBe('text\n<br>\n```\ncode block\n```');
-      expect(convertor.toMarkdown('<pre><code>code block</code></pre><br>text')).toBe('```\ncode block\n```\n<br>\ntext');
+    describe('should prevent <br> if there is only one empty line before or after the block element.', () => {
+      let html, markdown;
+
+      it('header', () => {
+        html = [
+          'foo',
+          '<br>', // Generated when a line break occurs after an inline element.
+          '<br>',
+          '<h1>bar</h1>',
+          '<br>',
+          'baz'
+        ].join('');
+        markdown = [
+          'foo',
+          '<br>',
+          '# bar',
+          '<br>',
+          'baz'
+        ].join('\n');
+
+        expect(convertor.toMarkdown(html)).toBe(markdown);
+
+        html = [
+          '<h1>foo</h1>',
+          '<br>',
+          '<h2>bar</h2>',
+          '<br>',
+          '<h3>baz</h3>'
+        ].join('');
+        markdown = [
+          '# foo',
+          '<br>',
+          '## bar',
+          '<br>',
+          '### baz'
+        ].join('\n');
+
+        expect(convertor.toMarkdown(html)).toBe(markdown);
+      });
+
+      it('codeblock', () => {
+        html = [
+          'foo',
+          '<br>', // Generated when a line break occurs after an inline element.
+          '<br>',
+          '<pre><code>bar</code></pre>',
+          '<br>',
+          'baz'
+        ].join('');
+        markdown = [
+          'foo',
+          '<br>',
+          '```',
+          'bar',
+          '```',
+          '<br>',
+          'baz'
+        ].join('\n');
+
+        expect(convertor.toMarkdown(html)).toBe(markdown);
+      });
+
+      it('table', () => {
+        html = [
+          'foo',
+          '<br>', // Generated when a line break occurs after an inline element.
+          '<br>',
+          '<table><thead><tr><th>bar</th></tr></thead></table>',
+          '<br>',
+          'baz'
+        ].join('');
+        markdown = [
+          'foo',
+          '<br>',
+          '| bar |',
+          '| --- |',
+          '<br>',
+          'baz'
+        ].join('\n');
+
+        expect(convertor.toMarkdown(html)).toBe(markdown);
+      });
+
+      it('list', () => {
+        html = [
+          'foo',
+          '<br>', // Generated when a line break occurs after an inline element.
+          '<br>',
+          '<ul><li>bar</li><li>baz</li></ul>',
+          '<br>',
+          'qux'
+        ].join('');
+        markdown = [
+          'foo',
+          '<br>',
+          '* bar',
+          '* baz',
+          // If <br> immediately follows the list, the next element is indented.
+          // So empty line(below '') must be maintained.
+          '',
+          '<br>',
+          'qux'
+        ].join('\n');
+
+        expect(convertor.toMarkdown(html)).toBe(markdown);
+
+        html = [
+          'foo',
+          '<br>', // Generated when a line break occurs after an inline element.
+          '<br>',
+          '<ol><li>bar</li><li>baz</li></ol>',
+          '<br>',
+          'qux'
+        ].join('');
+        markdown = [
+          'foo',
+          '<br>',
+          '1. bar',
+          '2. baz',
+          // If <br> immediately follows the list, the next element is indented.
+          // So empty line(below '') must be maintained.
+          '',
+          '<br>',
+          'qux'
+        ].join('\n');
+
+        expect(convertor.toMarkdown(html)).toBe(markdown);
+      });
+
+      it('blockquote', () => {
+        html = [
+          'foo',
+          '<br>', // Generated when a line break occurs after an inline element.
+          '<br>',
+          '<blockquote>bar</blockquote>',
+          '<br>',
+          'baz'
+        ].join('');
+        markdown = [
+          'foo',
+          '<br>',
+          '> bar',
+          // If <br> immediately follows the blockquote, the next element is indented.
+          // So empty line(below '') must be maintained.
+          '',
+          '<br>',
+          'baz'
+        ].join('\n');
+
+        expect(convertor.toMarkdown(html)).toBe(markdown);
+      });
     });
   });
 


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description

* Issue related to #624 

* * *

## 현상 및 원인

1. 위지윅에서 텍스트와 코드블럭 사이에 빈 줄을 한 번만 입력한다. (`<br>` 추가)

![wwe](https://user-images.githubusercontent.com/18183560/64523496-5ee15b00-d337-11e9-8185-ffd47a7f5ba5.png)

2. 마크다운으로 변환하면 텍스트와 코드블럭 사이의 빈 줄은 개행 문자로 변환(`<br><br>` -> `\n\n`)된다. 마크다운 스펙이 적용(개행 문자가 두 개 이상인 경우 무시됨)되면서 위지윅에서 입력한 개행이 사라진 것처럼 동작한다.

![md](https://user-images.githubusercontent.com/18183560/64523672-d0b9a480-d337-11e9-951d-628c274934ac.png)

## 스펙 정리

### 마크다운 에디터

블록 요소 전후에 빈 줄을 추가할 때 명시적으로 `<br>`을 입력한다.

* 인라인과 블록 요소 사이 개행 문자만 입력된 경우 : 라인만 구분

```
foo

\`\`\`
bar
\`\`\`

baz
```
![case1](https://user-images.githubusercontent.com/18183560/64532926-6a3f8100-d34d-11e9-8fda-708c6f0ab6e3.png)

* 인라인과 블록 요소 사이 `<br>` 입력된 경우 : 빈 줄 처리
```
foo
<br>
\`\`\`
bar
\`\`\`
<br>
baz
```
![case2](https://user-images.githubusercontent.com/18183560/64532936-6f9ccb80-d34d-11e9-9b0d-2f8d1a8d06bb.png)

### 위지윅 에디터

인라인과 블록 요소 사이에 입력된 빈 줄이 1개인 경우 마크다운 변환 시 `<br>`로 변환된다.


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
