### PR TITLE
fix: emphasis syntax broken with inner styles (fix: #557)

### DIFF
--- a/src/js/editor.js
+++ b/src/js/editor.js
@@ -217,7 +217,10 @@ class ToastUIEditor {
       false,
       this.options.previewDelayTime);
     this.wwEditor = WysiwygEditor.factory(this.layout.getWwEditorContainerEl(), this.eventManager);
-    this.toMarkOptions = {renderer: toMarkRenderer};
+    this.toMarkOptions = {
+      gfm: true,
+      renderer: toMarkRenderer
+    };
 
     if (this.options.linkAttribute) {
       const attribute = this._sanitizeLinkAttribute(this.options.linkAttribute);

--- a/src/js/editor.js
+++ b/src/js/editor.js
@@ -24,6 +24,7 @@ import WwTableManager from './wwTableManager';
 import WwTableSelectionManager from './wwTableSelectionManager';
 import {CodeBlockManager} from './codeBlockManager';
 import codeBlockManager from './codeBlockManager';
+import toMarkRenderer from './toMarkRenderer';
 
 // markdown commands
 import mdBold from './markdownCommands/bold';
@@ -216,7 +217,7 @@ class ToastUIEditor {
       false,
       this.options.previewDelayTime);
     this.wwEditor = WysiwygEditor.factory(this.layout.getWwEditorContainerEl(), this.eventManager);
-    this.toMarkOptions = null;
+    this.toMarkOptions = {renderer: toMarkRenderer};
 
     if (this.options.linkAttribute) {
       const attribute = this._sanitizeLinkAttribute(this.options.linkAttribute);

--- a/src/js/extensions/table/table.js
+++ b/src/js/extensions/table/table.js
@@ -8,7 +8,7 @@ import Editor from '../editorProxy';
 import './langs';
 import createMergedTable from './mergedTableCreator';
 import prepareTableUnmerge from './tableUnmergePreparer';
-import toMarkRenderer from './toMarkRenderer';
+import {createToMarkRenderer} from './toMarkRenderer';
 import WwMergedTableManager from './wwMergedTableManager';
 import WwMergedTableSelectionManager from './wwMergedTableSelectionManager';
 import wwAddRow from './mergedTableAddRow';
@@ -28,8 +28,7 @@ import mergedTableUI from './mergedTableUI';
 function tableExtension(editor) {
   const {eventManager} = editor;
 
-  editor.toMarkOptions = editor.toMarkOptions || {};
-  editor.toMarkOptions.renderer = toMarkRenderer;
+  editor.toMarkOptions = getExtendedToMarkOptions(editor.toMarkOptions);
   _bindEvents(eventManager);
 
   if (editor.isViewer()) {
@@ -45,6 +44,15 @@ function tableExtension(editor) {
   if (popupTableUtils) {
     mergedTableUI.updateContextMenu(popupTableUtils, eventManager, wwComponentManager.getManager('tableSelection'));
   }
+}
+
+function getExtendedToMarkOptions(toMarkOptions) {
+  const extendedOptions = toMarkOptions || {};
+  const baseRenderer = extendedOptions.renderer;
+
+  extendedOptions.renderer = createToMarkRenderer(baseRenderer);
+
+  return extendedOptions;
 }
 
 /**

--- a/src/js/extensions/table/table.js
+++ b/src/js/extensions/table/table.js
@@ -28,7 +28,6 @@ import mergedTableUI from './mergedTableUI';
 function tableExtension(editor) {
   const {eventManager} = editor;
 
-  editor.toMarkOptions = getExtendedToMarkOptions(editor.toMarkOptions);
   _bindEvents(eventManager);
 
   if (editor.isViewer()) {
@@ -40,6 +39,8 @@ function tableExtension(editor) {
 
   _addCommands(editor);
   _changeWysiwygManagers(wwComponentManager);
+
+  editor.toMarkOptions = getExtendedToMarkOptions(editor.toMarkOptions);
 
   if (popupTableUtils) {
     mergedTableUI.updateContextMenu(popupTableUtils, eventManager, wwComponentManager.getManager('tableSelection'));

--- a/src/js/extensions/table/toMarkRenderer.js
+++ b/src/js/extensions/table/toMarkRenderer.js
@@ -84,7 +84,8 @@ export function _createTheadMarkdown(theadElement, theadContentMarkdown) {
   return theadContentMarkdown ? `${theadContentMarkdown}|${align}\n` : '';
 }
 
-export default toMark.Renderer.factory(toMark.gfmRenderer, {
-  'THEAD': _createTheadMarkdown
-});
-
+export function createToMarkRenderer(baseRenderer) {
+  return toMark.Renderer.factory(baseRenderer || toMark.gfmRenderer, {
+    'THEAD': _createTheadMarkdown
+  });
+}

--- a/src/js/toMarkRenderer.js
+++ b/src/js/toMarkRenderer.js
@@ -1,0 +1,43 @@
+import toMark from 'to-mark';
+
+function isElementNode(node) {
+  return node && node.nodeType === Node.ELEMENT_NODE;
+}
+
+function isTextNode(node) {
+  return node && node.nodeType === Node.TEXT_NODE;
+}
+
+function isInvalidEmphasisToken(node) {
+  const isInvalidOpener = isTextNode(node.previousSibling) && isElementNode(node.firstChild);
+  const isInvalidCloser = isTextNode(node.nextSibling) && isElementNode(node.lastChild);
+
+  return isInvalidOpener || isInvalidCloser;
+}
+
+function convertEmphasis(node, subContent, token) {
+  if (isInvalidEmphasisToken(node)) {
+    const tagName = node.nodeName.toLowerCase();
+
+    return `<${tagName}>${subContent}</${tagName}>`;
+  }
+
+  return `${token}${subContent}${token}`;
+}
+
+export default toMark.Renderer.factory(toMark.gfmRenderer, {
+  'EM, I': function(node, subContent) {
+    if (this.isEmptyText(subContent)) {
+      return '';
+    }
+
+    return convertEmphasis(node, subContent, '*');
+  },
+  'STRONG, B': function(node, subContent) {
+    if (this.isEmptyText(subContent)) {
+      return '';
+    }
+
+    return convertEmphasis(node, subContent, '**');
+  }
+});

--- a/src/js/toMarkRenderer.js
+++ b/src/js/toMarkRenderer.js
@@ -8,21 +8,31 @@ function isTextNode(node) {
   return node && node.nodeType === Node.TEXT_NODE;
 }
 
-function isInvalidEmphasisToken(node) {
+/**
+ * Check if given node is valid delimiter run.
+ * According to common-mark spec, following examples are not valid delimiter runs.
+ * 1. opening (*|**) preceded by an alphanumeric and followed by a punctuation.
+ *    (ex: a**~~c~~b**)
+ * 2. closing (*|**) preceded by a punctuation and followed by an alphanumeric.
+ *    (ex: **b~~c~~**a)
+ * @See {@link https://spec.commonmark.org/0.29/#delimiter-run}
+ * @See {@link https://github.com/commonmark/commonmark-spec/issues/611#issuecomment-533578503}
+ **/
+function isValidDelimiterRun(node) {
   const isInvalidOpener = isTextNode(node.previousSibling) && isElementNode(node.firstChild);
   const isInvalidCloser = isTextNode(node.nextSibling) && isElementNode(node.lastChild);
 
-  return isInvalidOpener || isInvalidCloser;
+  return !isInvalidOpener && !isInvalidCloser;
 }
 
 function convertEmphasis(node, subContent, token) {
-  if (isInvalidEmphasisToken(node)) {
-    const tagName = node.nodeName.toLowerCase();
-
-    return `<${tagName}>${subContent}</${tagName}>`;
+  if (isValidDelimiterRun(node)) {
+    return `${token}${subContent}${token}`;
   }
 
-  return `${token}${subContent}${token}`;
+  const tagName = node.nodeName.toLowerCase();
+
+  return `<${tagName}>${subContent}</${tagName}>`;
 }
 
 export default toMark.Renderer.factory(toMark.gfmRenderer, {

--- a/src/js/toMarkRenderer.js
+++ b/src/js/toMarkRenderer.js
@@ -1,12 +1,5 @@
 import toMark from 'to-mark';
-
-function isElementNode(node) {
-  return node && node.nodeType === Node.ELEMENT_NODE;
-}
-
-function isTextNode(node) {
-  return node && node.nodeType === Node.TEXT_NODE;
-}
+import domUtils from './domUtils';
 
 /**
  * Check if given node is valid delimiter run.
@@ -15,19 +8,20 @@ function isTextNode(node) {
  *    (ex: a**~~c~~b**)
  * 2. closing (*|**) preceded by a punctuation and followed by an alphanumeric.
  *    (ex: **b~~c~~**a)
- * @See {@link https://spec.commonmark.org/0.29/#delimiter-run}
- * @See {@link https://github.com/commonmark/commonmark-spec/issues/611#issuecomment-533578503}
- **/
+ * @see {@link https://spec.commonmark.org/0.29/#delimiter-run}
+ * @see {@link https://github.com/commonmark/commonmark-spec/issues/611#issuecomment-533578503}
+ */
 function isValidDelimiterRun(node) {
-  const isInvalidOpener = isTextNode(node.previousSibling) && isElementNode(node.firstChild);
-  const isInvalidCloser = isTextNode(node.nextSibling) && isElementNode(node.lastChild);
+  const {isElemNode, isTextNode} = domUtils;
+  const isInvalidOpener = isTextNode(node.previousSibling) && isElemNode(node.firstChild);
+  const isInvalidCloser = isTextNode(node.nextSibling) && isElemNode(node.lastChild);
 
   return !isInvalidOpener && !isInvalidCloser;
 }
 
-function convertEmphasis(node, subContent, token) {
+function convertEmphasis(node, subContent, delimiter) {
   if (isValidDelimiterRun(node)) {
-    return `${token}${subContent}${token}`;
+    return `${delimiter}${subContent}${delimiter}`;
   }
 
   const tagName = node.nodeName.toLowerCase();

--- a/src/js/viewer.js
+++ b/src/js/viewer.js
@@ -48,7 +48,6 @@ class ToastUIEditorViewer {
     } else {
       this.convertor = new Convertor(this.eventManager);
     }
-    this.toMarkOptions = null;
 
     if (this.options.useDefaultHTMLSanitizer) {
       this.convertor.initHtmlSanitizer();

--- a/test/unit/convertor.spec.js
+++ b/test/unit/convertor.spec.js
@@ -4,6 +4,7 @@
  */
 import Convertor from '../../src/js/convertor';
 import EventManager from '../../src/js/eventManager';
+import toMarkRenderer from '../../src/js/toMarkRenderer';
 
 describe('Convertor', () => {
   let convertor, em;
@@ -139,62 +140,71 @@ describe('Convertor', () => {
   });
 
   describe('html to markdown', () => {
+    function toMark(html) {
+      return convertor.toMarkdown(html, {renderer: toMarkRenderer});
+    }
+
     it('converting markdown to html', () => {
-      expect(convertor.toMarkdown('<h1 id="hello-world">HELLO WORLD</h1>')).toEqual('# HELLO WORLD');
+      expect(toMark('<h1 id="hello-world">HELLO WORLD</h1>')).toEqual('# HELLO WORLD');
     });
+
     it('should reserve br on multi line breaks', () => {
-      expect(convertor.toMarkdown('HELLO WORLD<br><br><br>!')).toEqual('HELLO WORLD\n\n<br>\n!');
+      expect(toMark('HELLO WORLD<br><br><br>!')).toEqual('HELLO WORLD\n\n<br>\n!');
     });
+
     it('should not reserve br on normal line breaks', () => {
-      expect(convertor.toMarkdown('HELLO WORLD<br><br>!')).toEqual('HELLO WORLD\n\n!');
+      expect(toMark('HELLO WORLD<br><br>!')).toEqual('HELLO WORLD\n\n!');
     });
+
     it('should not reserve br in codeblock', () => {
-      expect(convertor.toMarkdown('<pre><code>HELLO WORLD\n\n\n\n\n!</code></pre>')).toEqual('```\nHELLO WORLD\n\n\n\n\n!\n```');
+      expect(toMark('<pre><code>HELLO WORLD\n\n\n\n\n!</code></pre>')).toEqual('```\nHELLO WORLD\n\n\n\n\n!\n```');
     });
+
     it('should reserve br to inline in table', () => {
       const html = '<table>' +
                 '<thead><th>1</th><th>2</th><th>3</th></thead>' +
                 '<tbody><td>HELLO WORLD<br><br><br><br><br>!</td><td>4</td><td>5</td></tbody>' +
                 '</table>';
       const markdown = '| 1 | 2 | 3 |\n| --- | --- | --- |\n| HELLO WORLD<br><br><br><br><br>! | 4 | 5 |';
-      expect(convertor.toMarkdown(html)).toEqual(markdown);
+      expect(toMark(html)).toEqual(markdown);
     });
+
     it('should escape html in html text', () => {
       // valid tags
-      expect(convertor.toMarkdown('im &lt;span&gt; text')).toEqual('im \\<span> text');
-      expect(convertor.toMarkdown('im &lt;span attr="value"&gt; text')).toEqual('im \\<span attr="value"> text');
-      expect(convertor.toMarkdown('im &lt;!-- comment --&gt; text')).toEqual('im \\<!-- comment --> text');
+      expect(toMark('im &lt;span&gt; text')).toEqual('im \\<span> text');
+      expect(toMark('im &lt;span attr="value"&gt; text')).toEqual('im \\<span attr="value"> text');
+      expect(toMark('im &lt;!-- comment --&gt; text')).toEqual('im \\<!-- comment --> text');
 
       // common mark auto link
-      expect(convertor.toMarkdown('im &lt;http://google.com&gt; text')).toEqual('im \\<http://google.com> text');
+      expect(toMark('im &lt;http://google.com&gt; text')).toEqual('im \\<http://google.com> text');
 
       // invalid tags
-      expect(convertor.toMarkdown('im &lt;\\span&gt; text')).toEqual('im <\\span> text');
-      expect(convertor.toMarkdown('im &lt;/span attr="value"&gt; text')).toEqual('im </span attr="value"> text');
+      expect(toMark('im &lt;\\span&gt; text')).toEqual('im <\\span> text');
+      expect(toMark('im &lt;/span attr="value"&gt; text')).toEqual('im </span attr="value"> text');
     });
 
     it('should print number of backticks for code according to data-backticks attribute', () => {
-      expect(convertor.toMarkdown('<code data-backticks="1">code span</code>').trim()).toEqual('`code span`');
-      expect(convertor.toMarkdown('<code data-backticks="3">code span</code>').trim()).toEqual('```code span```');
+      expect(toMark('<code data-backticks="1">code span</code>').trim()).toEqual('`code span`');
+      expect(toMark('<code data-backticks="3">code span</code>').trim()).toEqual('```code span```');
     });
 
     it('should print number of backticks for code block according to data-backticks attribute', () => {
-      expect(convertor.toMarkdown('<pre><code>code block</code></pre>').trim()).toEqual('```\ncode block\n```');
-      expect(convertor.toMarkdown('<pre><code data-backticks="4">code block</code></pre>').trim()).toEqual('````\ncode block\n````');
+      expect(toMark('<pre><code>code block</code></pre>').trim()).toEqual('```\ncode block\n```');
+      expect(toMark('<pre><code data-backticks="4">code block</code></pre>').trim()).toEqual('````\ncode block\n````');
     });
 
     it('should treat $ special characters', () => {
-      expect(convertor.toMarkdown('<span>,;:$&+=</span>').trim()).toEqual('<span>,;:$&+=</span>');
+      expect(toMark('<span>,;:$&+=</span>').trim()).toEqual('<span>,;:$&+=</span>');
     });
 
     it('should convert BRs to newline', () => {
-      expect(convertor.toMarkdown('text<br><br>text')).toBe('text\n\ntext');
-      expect(convertor.toMarkdown('<b>text</b><br><br>text')).toBe('**text**\n\ntext');
-      expect(convertor.toMarkdown('<i>text</i><br><br>text')).toBe('*text*\n\ntext');
-      expect(convertor.toMarkdown('<s>text</s><br><br>text')).toBe('~~text~~\n\ntext');
-      expect(convertor.toMarkdown('<code>text</code><br><br>text')).toBe('`text`\n\ntext');
-      expect(convertor.toMarkdown('<a href="some_url">text</a><br><br>text')).toBe('[text](some_url)\n\ntext');
-      expect(convertor.toMarkdown('<span>text</span><br><br>text'))
+      expect(toMark('text<br><br>text')).toBe('text\n\ntext');
+      expect(toMark('<b>text</b><br><br>text')).toBe('**text**\n\ntext');
+      expect(toMark('<i>text</i><br><br>text')).toBe('*text*\n\ntext');
+      expect(toMark('<s>text</s><br><br>text')).toBe('~~text~~\n\ntext');
+      expect(toMark('<code>text</code><br><br>text')).toBe('`text`\n\ntext');
+      expect(toMark('<a href="some_url">text</a><br><br>text')).toBe('[text](some_url)\n\ntext');
+      expect(toMark('<span>text</span><br><br>text'))
         .toBe('<span>text</span>\n\ntext');
     });
 
@@ -216,7 +226,7 @@ describe('Convertor', () => {
           'baz'
         ].join('\n');
 
-        expect(convertor.toMarkdown(html)).toBe(markdown);
+        expect(toMark(html)).toBe(markdown);
       });
 
       it('codeblock with inline elements', () => {
@@ -238,7 +248,7 @@ describe('Convertor', () => {
           'baz'
         ].join('\n');
 
-        expect(convertor.toMarkdown(html)).toBe(markdown);
+        expect(toMark(html)).toBe(markdown);
       });
 
       it('table with inline elements', () => {
@@ -260,7 +270,7 @@ describe('Convertor', () => {
           'qux'
         ].join('\n');
 
-        expect(convertor.toMarkdown(html)).toBe(markdown);
+        expect(toMark(html)).toBe(markdown);
       });
 
       it('list with inline elements', () => {
@@ -284,7 +294,7 @@ describe('Convertor', () => {
           'qux'
         ].join('\n');
 
-        expect(convertor.toMarkdown(html)).toBe(markdown);
+        expect(toMark(html)).toBe(markdown);
 
         html = [
           'foo',
@@ -306,7 +316,7 @@ describe('Convertor', () => {
           'qux'
         ].join('\n');
 
-        expect(convertor.toMarkdown(html)).toBe(markdown);
+        expect(toMark(html)).toBe(markdown);
       });
 
       it('blockquote with inline elements', () => {
@@ -329,7 +339,7 @@ describe('Convertor', () => {
           'baz'
         ].join('\n');
 
-        expect(convertor.toMarkdown(html)).toBe(markdown);
+        expect(toMark(html)).toBe(markdown);
       });
 
       it('between block elements.', () => {
@@ -362,7 +372,75 @@ describe('Convertor', () => {
           '> bar'
         ].join('\n');
 
-        expect(convertor.toMarkdown(html)).toBe(markdown);
+        expect(toMark(html)).toBe(markdown);
+      });
+    });
+
+    describe('should not convert <strong>,<b> to **', () => {
+      it('if preceded by normal text and first child is an element', () => {
+        // b
+        expect(toMark('a<b><code>c</code>b</b>')).toEqual('a<b>`c`b</b>');
+        expect(toMark('a<b><del>c</del>b</b>')).toEqual('a<b>~~c~~b</b>');
+        expect(toMark('a<b><span>c</span>b</b>')).toEqual('a<b><span>c</span>b</b>');
+
+        // strong
+        expect(toMark('a<strong><code>c</code>b</strong>')).toEqual('a<strong>`c`b</strong>');
+        expect(toMark('a<strong><del>c</del>b</strong>')).toEqual('a<strong>~~c~~b</strong>');
+        expect(toMark('a<strong><span>c</span>b</strong>')).toEqual('a<strong><span>c</span>b</strong>');
+
+        // should convert if an opening is not preceded by normal text
+        expect(toMark('<b><code>c</code>b</b>')).toEqual('**`c`b**');
+        expect(toMark('<strong><code>c</code>b</strong>')).toEqual('**`c`b**');
+      });
+
+      it('if followed by normal text and last child is an element', () => {
+        // b
+        expect(toMark('<b>b<code>c</code></b>a')).toEqual('<b>b`c`</b>a');
+        expect(toMark('<b>b<del>c</del></b>a')).toEqual('<b>b~~c~~</b>a');
+        expect(toMark('<b>b<span>c</span></b>a')).toEqual('<b>b<span>c</span></b>a');
+
+        // strong
+        expect(toMark('<strong>b<code>c</code></strong>a')).toEqual('<strong>b`c`</strong>a');
+        expect(toMark('<strong>b<del>c</del></strong>a')).toEqual('<strong>b~~c~~</strong>a');
+        expect(toMark('<strong>b<span>c</span></strong>a')).toEqual('<strong>b<span>c</span></strong>a');
+
+        // should convert if a closing tag is not followed by normal text
+        expect(toMark('<b>b<code>c</code></b>')).toEqual('**b`c`**');
+        expect(toMark('<strong>b<code>c</code></strong>')).toEqual('**b`c`**');
+      });
+    });
+
+    describe('should not convert <em>,<i> to *', () => {
+      it('if preceded by normal text and first child is an element', () => {
+        // i
+        expect(toMark('a<i><code>c</code>b</i>')).toEqual('a<i>`c`b</i>');
+        expect(toMark('a<i><del>c</del>b</i>')).toEqual('a<i>~~c~~b</i>');
+        expect(toMark('a<i><span>c</span>b</i>')).toEqual('a<i><span>c</span>b</i>');
+
+        // em
+        expect(toMark('a<em><code>c</code>b</em>')).toEqual('a<em>`c`b</em>');
+        expect(toMark('a<em><del>c</del>b</em>')).toEqual('a<em>~~c~~b</em>');
+        expect(toMark('a<em><span>c</span>b</em>')).toEqual('a<em><span>c</span>b</em>');
+
+        // should convert if an opening tag is not preceded by normal text
+        expect(toMark('<i><code>c</code>b</i>')).toEqual('*`c`b*');
+        expect(toMark('<em><code>c</code>b</em>')).toEqual('*`c`b*');
+      });
+
+      it('if followed by normal text and last child is an element', () => {
+        // i
+        expect(toMark('<i>b<code>c</code></i>a')).toEqual('<i>b`c`</i>a');
+        expect(toMark('<i>b<del>c</del></i>a')).toEqual('<i>b~~c~~</i>a');
+        expect(toMark('<i>b<span>c</span></i>a')).toEqual('<i>b<span>c</span></i>a');
+
+        // em
+        expect(toMark('<em>b<code>c</code></em>a')).toEqual('<em>b`c`</em>a');
+        expect(toMark('<em>b<del>c</del></em>a')).toEqual('<em>b~~c~~</em>a');
+        expect(toMark('<em>b<span>c</span></em>a')).toEqual('<em>b<span>c</span></em>a');
+
+        // should convert if a closing tag is not followed by normal text
+        expect(toMark('<i>b<code>c</code></i>')).toEqual('*b`c`*');
+        expect(toMark('<em>b<code>c</code></em>')).toEqual('*b`c`*');
       });
     });
   });

--- a/test/unit/convertor.spec.js
+++ b/test/unit/convertor.spec.js
@@ -141,7 +141,10 @@ describe('Convertor', () => {
 
   describe('html to markdown', () => {
     function toMark(html) {
-      return convertor.toMarkdown(html, {renderer: toMarkRenderer});
+      return convertor.toMarkdown(html, {
+        gfm: true,
+        renderer: toMarkRenderer
+      });
     }
 
     it('converting markdown to html', () => {
@@ -218,6 +221,7 @@ describe('Convertor', () => {
           '<br>',
           'baz'
         ].join('');
+
         const markdown = [
           'foo',
           '<br>',


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
see https://github.com/nhn/tui.editor/issues/557#issuecomment-533512939.
To fix this issue, the default renderer of to-mark should be modified, but using a raw HTML tag to deal with this issue is not a universal solution.
So instead of modifying to-mark, this PR is extending the default renderer of to-mark using `toMark.Renderer.factory`.
