### PR TITLE
fix: blank lines between lists of the same type are ignored (fix #653)

### DIFF
--- a/src/js/wwListManager.js
+++ b/src/js/wwListManager.js
@@ -58,7 +58,6 @@ class WwListManager {
     });
 
     this.eventManager.listen('wysiwygProcessHTMLText', html => {
-      html = this._insertBlankToBetweenSameList(html);
       html = this._convertFromArbitraryNestingList(html);
 
       return html;
@@ -66,9 +65,6 @@ class WwListManager {
 
     this.eventManager.listen('convertorBeforeHtmlToMarkdownConverted',
       html => this._insertDataToMarkPassForListInTable(html));
-
-    this.eventManager.listen('convertorAfterHtmlToMarkdownConverted',
-      markdown => markdown.replace(/:BLANK_LINE:\n/g, ''));
   }
 
   _initKeyHandler() {
@@ -174,10 +170,6 @@ class WwListManager {
     $branchRoot.prepend($list.children().unwrap());
 
     $firstLi.remove();
-  }
-
-  _insertBlankToBetweenSameList(html) {
-    return html.replace(/<\/(ul|ol)>(<br \/>|<br>){0,}<\1>/g, '</$1>:BLANK_LINE:<$1>');
   }
 
   /**

--- a/test/unit/convertor.spec.js
+++ b/test/unit/convertor.spec.js
@@ -378,6 +378,56 @@ describe('Convertor', () => {
 
         expect(toMark(html)).toBe(markdown);
       });
+
+      it('between list elements of the same type.', () => {
+        const html = [
+          '<ul><li>foo<ul><li>bar<ul><li>baz</li></ul></li></ul></li></ul>',
+          '<br>',
+          '<ul><li>foo</li><li>bar</li></ul>',
+          '<br>',
+          '<ul><li class="task-list-item">foo</li><li class="task-list-item">bar</li></ul>'
+        ].join('');
+        const markdown = [
+          '* foo',
+          '    * bar',
+          '        * baz',
+          '',
+          '<br>',
+          '* foo',
+          '* bar',
+          '',
+          '<br>',
+          '* [ ] foo',
+          '* [ ] bar'
+        ].join('\n');
+
+        expect(toMark(html)).toBe(markdown);
+      });
+
+      it('between list elements of different types.', () => {
+        const html = [
+          '<ul><li>foo<ul><li>bar<ul><li>baz</li></ul></li></ul></li></ul>',
+          '<br>',
+          '<ol><li>foo</li><li>bar</li></ol>',
+          '<br>',
+          '<ul><li class="task-list-item">foo</li><li class="task-list-item">bar</li></ul>'
+        ].join('');
+        const markdown = [
+          '* foo',
+          '    * bar',
+          '        * baz',
+          '',
+          '<br>',
+          '1. foo',
+          '2. bar',
+          '',
+          '<br>',
+          '* [ ] foo',
+          '* [ ] bar'
+        ].join('\n');
+
+        expect(toMark(html)).toBe(markdown);
+      });
     });
 
     describe('should not convert <b>, <strong> to **', () => {

--- a/test/unit/wwListManager.spec.js
+++ b/test/unit/wwListManager.spec.js
@@ -173,59 +173,6 @@ describe('WwListManager', () => {
     });
   });
 
-  describe('Control list blank line', () => {
-    it('ul - br - ul', () => {
-      const html = [
-        '<ul>',
-        '<li><div>1</div></li>',
-        '</ul>',
-        '<br />',
-        '<ul>',
-        '<li><div>2</div></li>',
-        '</ul>'
-      ].join('');
-
-      const result = mgr._insertBlankToBetweenSameList(html);
-
-      expect(result.indexOf(':BLANK_LINE:')).not.toBe(-1);
-      expect(result.indexOf('<br />')).toBe(-1);
-    });
-
-    it('ul - br - br - ul', () => {
-      const html = [
-        '<ul>',
-        '<li><div>1</div></li>',
-        '</ul>',
-        '<br />',
-        '<br />',
-        '<ul>',
-        '<li><div>2</div></li>',
-        '</ul>'
-      ].join('');
-
-      const result = mgr._insertBlankToBetweenSameList(html);
-
-      expect(result.indexOf(':BLANK_LINE:')).not.toBe(-1);
-      expect(result.indexOf('<br />')).toBe(-1);
-    });
-
-    it('ul - ul', () => {
-      const html = [
-        '<ul>',
-        '<li><div>1</div></li>',
-        '</ul>',
-        '<ul>',
-        '<li><div>2</div></li>',
-        '</ul>'
-      ].join('');
-
-      const result = mgr._insertBlankToBetweenSameList(html);
-
-      expect(result.indexOf(':BLANK_LINE:')).not.toBe(-1);
-      expect(result.indexOf('<br />')).toBe(-1);
-    });
-  });
-
   describe('_unwrap', () => {
     it('should unwrap itself and preserve the children', () => {
       const arbitraryNestingList = $(`


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description

* Issue related to #653 

### DEMO

#### Before
* https://nhn.github.io/tui.editor/api/latest/tutorial-example-e2e.html

```markdown
* foo
    * bar
        * baz

<br>
<br>
<br>
* foo
* bar
* baz

<br>
<br>
* [ ] foo
* [ ] bar
```


#### After
* http://10.78.9.170:8080/examples/example03-editor-extensions.html

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
