### PR TITLE
fix: remove conditions of blocking anchor tag for Wysiwig commands (fix #631)

### DIFF
--- a/src/js/wysiwygCommands/bold.js
+++ b/src/js/wysiwygCommands/bold.js
@@ -45,7 +45,7 @@ const Bold = CommandManager.command('wysiwyg', /** @lends Bold */{
 function styleBold(sq) {
   if (sq.hasFormat('b') || sq.hasFormat('strong')) {
     sq.changeFormat(null, {tag: 'b'});
-  } else if (!sq.hasFormat('a') && !sq.hasFormat('PRE')) {
+  } else if (!sq.hasFormat('PRE')) {
     if (sq.hasFormat('code')) {
       sq.changeFormat(null, {tag: 'code'});
     }

--- a/src/js/wysiwygCommands/italic.js
+++ b/src/js/wysiwygCommands/italic.js
@@ -46,7 +46,7 @@ const Italic = CommandManager.command('wysiwyg', /** @lends Italic */{
 function styleItalic(sq) {
   if (sq.hasFormat('i') || sq.hasFormat('em')) {
     sq.changeFormat(null, {tag: 'i'});
-  } else if (!sq.hasFormat('a') && !sq.hasFormat('PRE')) {
+  } else if (!sq.hasFormat('PRE')) {
     if (sq.hasFormat('code')) {
       sq.changeFormat(null, {tag: 'code'});
     }

--- a/src/js/wysiwygCommands/strike.js
+++ b/src/js/wysiwygCommands/strike.js
@@ -46,7 +46,7 @@ const Strike = CommandManager.command('wysiwyg', /** @lends Strike */{
 function styleStrike(sq) {
   if (sq.hasFormat('S')) {
     sq.changeFormat(null, {tag: 'S'});
-  } else if (!sq.hasFormat('a') && !sq.hasFormat('PRE')) {
+  } else if (!sq.hasFormat('PRE')) {
     if (sq.hasFormat('code')) {
       sq.changeFormat(null, {tag: 'code'});
     }

--- a/test/unit/wysiwygCommands/bold.spec.js
+++ b/test/unit/wysiwygCommands/bold.spec.js
@@ -46,19 +46,6 @@ describe('Bold', () => {
     expect(wwe.getValue()).toEqual('<b>line1</b><br />line2<br />');
   });
 
-  it('dont add bold in Achor tag', () => {
-    const range = wwe.getEditor().getSelection().cloneRange();
-
-    wwe.setValue('<a href="#">line1</a>');
-
-    range.selectNodeContents(wwe.get$Body().find('a')[0]);
-    wwe.getEditor().setSelection(range);
-
-    Bold.exec(wwe);
-
-    expect(wwe.getValue()).toEqual('<a href="#">line1</a><br />');
-  });
-
   it('if there have bold already remove format', () => {
     const range = wwe.getEditor().getSelection().cloneRange();
 

--- a/test/unit/wysiwygCommands/italic.spec.js
+++ b/test/unit/wysiwygCommands/italic.spec.js
@@ -46,19 +46,6 @@ describe('Italic', () => {
     expect(wwe.getValue()).toEqual('<i>line1</i><br />line2<br />');
   });
 
-  it('dont add italic in Achor tag', () => {
-    const range = wwe.getEditor().getSelection().cloneRange();
-
-    wwe.setValue('<a href="#">line1</a>');
-
-    range.selectNodeContents(wwe.get$Body().find('a')[0]);
-    wwe.getEditor().setSelection(range);
-
-    Italic.exec(wwe);
-
-    expect(wwe.getValue()).toEqual('<a href="#">line1</a><br />');
-  });
-
   it('if there have italic already remove format', () => {
     const range = wwe.getEditor().getSelection().cloneRange();
 

--- a/test/unit/wysiwygCommands/strike.spec.js
+++ b/test/unit/wysiwygCommands/strike.spec.js
@@ -46,19 +46,6 @@ describe('Strike', () => {
     expect(wwe.getValue()).toEqual('<s>line1</s><br />line2<br />');
   });
 
-  it('dont add Strike in Achor tag', () => {
-    const range = wwe.getEditor().getSelection().cloneRange();
-
-    wwe.setValue('<a href="#">line1</a>');
-
-    range.selectNodeContents(wwe.get$Body().find('a')[0]);
-    wwe.getEditor().setSelection(range);
-
-    Strike.exec(wwe);
-
-    expect(wwe.getValue()).toEqual('<a href="#">line1</a><br />');
-  });
-
   it('dont add Strike in PRE tag', () => {
     const range = wwe.getEditor().getSelection().cloneRange();
 


### PR DESCRIPTION
- fix https://github.com/nhn/tui.editor/issues/631
- According to https://github.com/nhn/tui.editor/commit/e13646a4ef95e2d36321ddff729e1e9052b9cc4f, blocking WYSIWYG bold command was done on purpose.
- However, it's hard to find out the reason behind it. 
- It seems that allowing bold/italic/strike for linked text makes no problem. 
- Removing related conditional code and tests.