### PR TITLE
feat: add findNodeAtPosition, findFirstNodeAtLine method

### DIFF
--- a/libs/markdown-parser/src/__test__/document.spec.ts
+++ b/libs/markdown-parser/src/__test__/document.spec.ts
@@ -98,6 +98,51 @@ describe('findNodeAtPosition()', () => {
   });
 });
 
+describe('findFirstNodeAtLine()', () => {
+  const markdown = [
+    '# Hello *World*',
+    '',
+    '- Item D1',
+    '  - Item D2',
+    '![Image](URL)',
+    '',
+    'Paragraph'
+  ].join('\n');
+
+  it('returns the first node at the given line', () => {
+    const doc = new MarkdownDocument(markdown);
+
+    expect(doc.findFirstNodeAtLine(1)).toMatchObject({ type: 'heading' });
+    expect(doc.findFirstNodeAtLine(3)).toMatchObject({
+      type: 'list',
+      prev: { type: 'heading' }
+    });
+    expect(doc.findFirstNodeAtLine(4)).toMatchObject({
+      type: 'list',
+      parent: { type: 'item' }
+    });
+    expect(doc.findFirstNodeAtLine(5)).toMatchObject({ type: 'image' });
+    expect(doc.findFirstNodeAtLine(7)).toMatchObject({ type: 'paragraph' });
+  });
+
+  it('if the given line is blank, returns the first node at the previous line', () => {
+    const doc = new MarkdownDocument(markdown);
+
+    expect(doc.findFirstNodeAtLine(2)).toMatchObject({ type: 'heading' });
+    expect(doc.findFirstNodeAtLine(6)).toMatchObject({ type: 'image' });
+    expect(doc.findFirstNodeAtLine(8)).toMatchObject({ type: 'paragraph' });
+  });
+
+  it('returns null if nothing mathces', () => {
+    const doc = new MarkdownDocument('\n\n');
+
+    expect(doc.findFirstNodeAtLine(0)).toBeNull();
+    expect(doc.findFirstNodeAtLine(1)).toBeNull();
+    expect(doc.findFirstNodeAtLine(2)).toBeNull();
+    expect(doc.findFirstNodeAtLine(3)).toBeNull();
+  });
+});
+
 describe('editText()', () => {
   describe('single paragraph', () => {
     it('insert character within a line', () => {

--- a/libs/markdown-parser/src/__test__/document.spec.ts
+++ b/libs/markdown-parser/src/__test__/document.spec.ts
@@ -36,6 +36,68 @@ function assertResultNodes(doc: MarkdownDocument, nodes: BlockNode[], startIdx =
   }
 }
 
+describe('findNodeAtPosition()', () => {
+  it('returns a node at the given position', () => {
+    const doc = new MarkdownDocument('# Hello *World*\n\n- Item 1\n- Item **2**');
+
+    expect(doc.findNodeAtPosition([1, 1])).toMatchObject({
+      type: 'heading'
+    });
+
+    expect(doc.findNodeAtPosition([1, 3])).toMatchObject({
+      type: 'text',
+      literal: 'Hello '
+    });
+
+    expect(doc.findNodeAtPosition([1, 9])).toMatchObject({
+      type: 'emph',
+      firstChild: {
+        type: 'text',
+        literal: 'World'
+      }
+    });
+
+    expect(doc.findNodeAtPosition([1, 10])).toMatchObject({
+      type: 'text',
+      literal: 'World'
+    });
+
+    expect(doc.findNodeAtPosition([3, 1])).toMatchObject({
+      type: 'item'
+    });
+
+    expect(doc.findNodeAtPosition([3, 3])).toMatchObject({
+      type: 'text',
+      literal: 'Item 1'
+    });
+
+    expect(doc.findNodeAtPosition([4, 8])).toMatchObject({
+      type: 'strong',
+      firstChild: {
+        type: 'text',
+        literal: '2'
+      }
+    });
+
+    expect(doc.findNodeAtPosition([4, 10])).toMatchObject({
+      type: 'text',
+      literal: '2'
+    });
+
+    expect(doc.findNodeAtPosition([5, 1])).toBeNull();
+  });
+
+  it('returns null if matched node does not exist', () => {
+    const doc = new MarkdownDocument('# Hello\n\nWorld');
+
+    // position in between two node (blank line)
+    expect(doc.findNodeAtPosition([2, 1])).toBeNull();
+
+    // position out of document range
+    expect(doc.findNodeAtPosition([4, 1])).toBeNull();
+  });
+});
+
 describe('editText()', () => {
   describe('single paragraph', () => {
     it('insert character within a line', () => {

--- a/libs/markdown-parser/src/document.ts
+++ b/libs/markdown-parser/src/document.ts
@@ -6,7 +6,8 @@ import {
   insertNodesBefore,
   prependChildNodes,
   updateNextLineNumbers,
-  findChildNodeByLine
+  findChildNodeAtLine,
+  findNodeAtPosition
 } from './nodeHelper';
 import { reBulletListMarker, reOrderedListMarker } from './commonmark/blockStarts';
 
@@ -109,8 +110,8 @@ export class MarkdownDocument {
   }
 
   private getNodeRange(start: Position, end: Position) {
-    let startNode = findChildNodeByLine(this.root, start[0]);
-    let endNode = findChildNodeByLine(this.root, end[0]);
+    let startNode = findChildNodeAtLine(this.root, start[0]);
+    let endNode = findChildNodeAtLine(this.root, end[0]);
 
     // extend node range to include a following block which doesn't have preceding blank line
     if (endNode && endNode.next && end[0] + 1 === endNode.next.sourcepos![0][0]) {
@@ -204,6 +205,14 @@ export class MarkdownDocument {
 
   public getRootNode() {
     return this.root;
+  }
+
+  public findNodeAtPosition(pos: Position) {
+    const node = findNodeAtPosition(this.root, pos);
+    if (!node || node === this.root) {
+      return null;
+    }
+    return node;
   }
 
   public on(eventName: EventName, callback: Function) {

--- a/libs/markdown-parser/src/document.ts
+++ b/libs/markdown-parser/src/document.ts
@@ -7,6 +7,7 @@ import {
   prependChildNodes,
   updateNextLineNumbers,
   findChildNodeAtLine,
+  findFirstNodeAtLine,
   findNodeAtPosition
 } from './nodeHelper';
 import { reBulletListMarker, reOrderedListMarker } from './commonmark/blockStarts';
@@ -213,6 +214,10 @@ export class MarkdownDocument {
       return null;
     }
     return node;
+  }
+
+  public findFirstNodeAtLine(line: number) {
+    return findFirstNodeAtLine(this.root, line);
   }
 
   public on(eventName: EventName, callback: Function) {

--- a/libs/markdown-parser/src/nodeHelper.ts
+++ b/libs/markdown-parser/src/nodeHelper.ts
@@ -126,6 +126,49 @@ export function findChildNodeAtLine(parent: Node, line: number) {
   return parent.lastChild;
 }
 
+function lastLeafNode(node: Node) {
+  while (node.lastChild) {
+    node = node.lastChild;
+  }
+  return node;
+}
+
+function sameLineTopAncestor(node: Node) {
+  while (
+    node.parent &&
+    node.parent.type !== 'document' &&
+    node.parent.sourcepos![0][0] === node.sourcepos![0][0]
+  ) {
+    node = node.parent;
+  }
+  return node;
+}
+
+export function findFirstNodeAtLine(parent: Node, line: number) {
+  let node = parent.firstChild;
+  let prev: Node | null = null;
+  while (node) {
+    const comp = compareRangeAndLine(node.sourcepos!, line);
+    if (comp === Compare.EQ) {
+      if (node.sourcepos![0][0] === line || !node.firstChild) {
+        return node;
+      }
+      prev = node;
+      node = node.firstChild;
+    } else if (comp === Compare.GT) {
+      break;
+    } else {
+      prev = node;
+      node = node.next;
+    }
+  }
+
+  if (prev) {
+    return sameLineTopAncestor(lastLeafNode(prev));
+  }
+  return null;
+}
+
 export function findNodeAtPosition(parent: Node, pos: Position) {
   let node: Node | null = parent;
   let prev: Node | null = null;

--- a/libs/markdown-parser/src/nodeHelper.ts
+++ b/libs/markdown-parser/src/nodeHelper.ts
@@ -7,6 +7,32 @@ export const enum Compare {
   GT = -1
 }
 
+function comparePos(p1: Position, p2: Position) {
+  if (p1[0] < p2[0]) {
+    return Compare.LT;
+  }
+  if (p1[0] > p2[0]) {
+    return Compare.GT;
+  }
+  if (p1[1] < p2[1]) {
+    return Compare.LT;
+  }
+  if (p1[1] > p2[1]) {
+    return Compare.GT;
+  }
+  return Compare.EQ;
+}
+
+function compareRangeAndPos([startPos, endPos]: [Position, Position], pos: Position) {
+  if (comparePos(endPos, pos) === Compare.LT) {
+    return Compare.LT;
+  }
+  if (comparePos(startPos, pos) === Compare.GT) {
+    return Compare.GT;
+  }
+  return Compare.EQ;
+}
+
 export function getAllParents(node: Node) {
   const parents = [];
   while (node.parent) {
@@ -85,7 +111,7 @@ function compareRangeAndLine([startPos, endPos]: [Position, Position], line: num
   return Compare.EQ;
 }
 
-export function findChildNodeByLine(parent: Node, line: number) {
+export function findChildNodeAtLine(parent: Node, line: number) {
   let node = parent.firstChild;
   while (node) {
     const comp = compareRangeAndLine(node.sourcepos!, line);
@@ -98,6 +124,28 @@ export function findChildNodeByLine(parent: Node, line: number) {
     node = node.next;
   }
   return parent.lastChild;
+}
+
+export function findNodeAtPosition(parent: Node, pos: Position) {
+  let node: Node | null = parent;
+  let prev: Node | null = null;
+
+  while (node) {
+    const comp = compareRangeAndPos(node.sourcepos!, pos);
+    if (comp === Compare.EQ) {
+      if (node.firstChild) {
+        prev = node;
+        node = node.firstChild;
+      } else {
+        return node;
+      }
+    } else if (comp === Compare.GT) {
+      return prev;
+    } else {
+      node = node.next;
+    }
+  }
+  return node;
 }
 
 export function toString(node: Node | null) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description
- findNodeAtPosition()
  - returns a node at the given position
  - returns null if nothing matches
- findFirstNodeAtLine()
  - returns the first node at the given line
  - if the given line is blank, returns the first node at the previous non-blank line
  - returns null if nothing matches

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
