### PR TITLE
fix: codeblock plugin lazy-run with empty nodes

### DIFF
--- a/apps/editor/examples/example08-editor-with-code-syntax-highlight-plugin.html
+++ b/apps/editor/examples/example08-editor-with-code-syntax-highlight-plugin.html
@@ -30,7 +30,7 @@
     <!-- Editor -->
     <script src="../dist/toastui-editor-all.js"></script>
     <!-- Editor's Plugin -->
-    <script src="http://localhost:8081/dist/cdn/toastui-editor-plugin-code-syntax-highlight-all.js"></script>
+    <script src="http://localhost:8082/dist/cdn/toastui-editor-plugin-code-syntax-highlight-all.js"></script>
     <script class="code-js">
       const { Editor } = toastui;
       const { codeSyntaxHighlight } = Editor.plugin;

--- a/apps/editor/src/js/mdPreview.js
+++ b/apps/editor/src/js/mdPreview.js
@@ -58,10 +58,13 @@ class MarkdownPreview extends Preview {
 
     codeBlockNodes.forEach(node => {
       const codeEl = contentEl.querySelector(`[data-nodeid="${node.id}"] > code`);
-      const lang = codeEl.getAttribute('data-language');
-      const html = codeBlockManager.createCodeBlockHtml(lang, codeEl.textContent);
 
-      codeEl.innerHTML = html;
+      if (codeEl) {
+        const lang = codeEl.getAttribute('data-language');
+        const html = codeBlockManager.createCodeBlockHtml(lang, codeEl.textContent);
+
+        codeEl.innerHTML = html;
+      }
     });
   }
 
@@ -98,10 +101,12 @@ class MarkdownPreview extends Preview {
       }
     }
     this.eventManager.emit('previewRenderAfter', this);
-    this.lazyRunner.run(
-      'invokeCodeBlock',
-      nodes.filter(node => node.type === 'codeBlock')
-    );
+
+    const codeBlockNodes = nodes.filter(node => node.type === 'codeBlock');
+
+    if (codeBlockNodes.length > 0) {
+      this.lazyRunner.run('invokeCodeBlock', codeBlockNodes);
+    }
   }
 
   /**


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
- fix: lazy-run for invokeCodeBlock is canceled due to the next call with empty nodes


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
