### PR TITLE
fix: domUtil.unwrap() receive parent node

### DIFF
--- a/apps/editor/src/js/squireExt.js
+++ b/apps/editor/src/js/squireExt.js
@@ -300,7 +300,7 @@ class SquireExt extends Squire {
 
     if (target) {
       domUtils.wrapInner(target, to);
-      domUtils.unwrap(target.children);
+      domUtils.unwrap(target);
     }
   }
 

--- a/apps/editor/src/js/utils/dom.js
+++ b/apps/editor/src/js/utils/dom.js
@@ -1168,28 +1168,20 @@ function wrapInner(nodeList, nodeName) {
 }
 
 /**
- * Removes parent element to target node
- * @param {Node|Array.<Node>} node - target node
- * @returns {Node} unwrapped node
+ * Removes target element and insert children at the same position
+ * @param {Node} node - parent node
+ * @returns {Array.<Node>} unwrapped nodes
  * @ignore
  */
-function unwrap(nodeList) {
-  nodeList = nodeList.length ? toArray(nodeList) : [nodeList];
-
+function unwrap(node) {
   const result = [];
 
-  nodeList.forEach(node => {
-    const target = node.parentNode;
+  while (node.firstChild) {
+    result.push(node.firstChild);
+    node.parentNode.insertBefore(node.firstChild, node);
+  }
 
-    if (target) {
-      while (target.firstChild) {
-        result.push(target.firstChild);
-        target.parentNode.insertBefore(target.firstChild, target);
-      }
-
-      target.parentNode.removeChild(target);
-    }
-  });
+  remove(node);
 
   return result;
 }

--- a/apps/editor/src/js/wwListManager.js
+++ b/apps/editor/src/js/wwListManager.js
@@ -169,7 +169,7 @@ class WwListManager {
     }
 
     const [firstLi] = domUtils.children(branchRoot, 'li');
-    const unwrappedLIs = domUtils.unwrap(list.children);
+    const unwrappedLIs = domUtils.unwrap(list);
 
     domUtils.prepend(branchRoot, unwrappedLIs);
     domUtils.remove(firstLi);

--- a/apps/editor/src/js/wwPManager.js
+++ b/apps/editor/src/js/wwPManager.js
@@ -104,8 +104,10 @@ class WwPManager {
    */
   _unwrapPtags() {
     domUtils.findAll(this.wwe.getBody(), 'div').forEach(node => {
-      if (domUtils.parent(node, 'p')) {
-        domUtils.unwrap(node);
+      const parent = node.parentNode;
+
+      if (parent.tagName === 'P') {
+        domUtils.unwrap(parent);
       }
     });
   }

--- a/apps/editor/src/js/wwPasteContentHelper.js
+++ b/apps/editor/src/js/wwPasteContentHelper.js
@@ -158,7 +158,7 @@ class WwPasteContentHelper {
       const brChildren = domUtils.children(node, 'br');
 
       if (brChildren.length && node.nodeName !== 'LI' && node.nodeName !== 'UL') {
-        domUtils.unwrap(brChildren[0]);
+        domUtils.unwrap(node);
       }
     });
   }
@@ -181,7 +181,7 @@ class WwPasteContentHelper {
         const parent = domUtils.parent(leafElement, blockTags);
 
         if (parent && parent !== container) {
-          domUtils.unwrap(leafElement);
+          domUtils.unwrap(parent);
         } else {
           leafElement = leafElement.parentElement;
         }
@@ -236,7 +236,7 @@ class WwPasteContentHelper {
       if (colorValue) {
         css(node, { color: colorValue });
       } else {
-        domUtils.unwrap(node.childNodes);
+        domUtils.unwrap(node);
       }
     }
   }

--- a/apps/editor/src/js/wwTableManager.js
+++ b/apps/editor/src/js/wwTableManager.js
@@ -690,7 +690,7 @@ class WwTableManager {
           domUtils.remove(node);
         }
       } else {
-        domUtils.unwrap(node.children);
+        domUtils.unwrap(node);
       }
     });
   }

--- a/apps/editor/test/unit/utils/dom.spec.js
+++ b/apps/editor/test/unit/utils/dom.spec.js
@@ -894,26 +894,13 @@ describe('domUtils', () => {
     });
   });
 
-  describe('unwrap() removes parent element from', () => {
-    beforeEach(() => {
-      container.innerHTML = '<b><i>foo</i></b><b><i>bar</i></b>';
-    });
+  it('unwrap() removes given element and insert children at the same position', () => {
+    const childrenHTML = '<i>emph1</i> text <i>emph2</i>';
 
-    it('only one target node', () => {
-      const target = container.querySelector('i');
+    container.innerHTML = `<p><b>${childrenHTML}</b></p>`;
+    domUtils.unwrap(container.querySelector('b'));
 
-      domUtils.unwrap(target);
-
-      expect(container.innerHTML).toBe('<i>foo</i><b><i>bar</i></b>');
-    });
-
-    it('all target nodes', () => {
-      const targets = container.querySelectorAll('i');
-
-      domUtils.unwrap(targets);
-
-      expect(container.innerHTML).toBe('<i>foo</i><i>bar</i>');
-    });
+    expect(container.innerHTML).toBe(`<p>${childrenHTML}</p>`);
   });
 
   it('remove() removes target node', () => {

--- a/apps/editor/test/unit/wwListManager.spec.js
+++ b/apps/editor/test/unit/wwListManager.spec.js
@@ -178,7 +178,7 @@ describe('WwListManager', () => {
 
       mgr._removeBranchListAll();
 
-      expect(wwe.getBody().querySelectorAll('ul').length).toEqual(0);
+      expect(wwe.getBody().querySelectorAll('ul').length).toEqual(1);
       expect(
         $(wwe.getBody())
           .find('ul li ul')


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
- domUtil.unwrap()
  - fix unexpected wrapping multiple times
  - receive parent node instead of children


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
