### PR TITLE
fix: apply plugins when preview.refresh() is invoked

### DIFF
--- a/apps/editor/index.d.ts
+++ b/apps/editor/index.d.ts
@@ -3,7 +3,6 @@
 
 /// <reference types="jquery" />
 /// <reference types="codemirror" />
-/// <reference types="markdown-it" />
 
 declare namespace tuiEditor {
   type SquireExt = any;
@@ -25,7 +24,6 @@ declare namespace tuiEditor {
   }
 
   interface IConvertor {
-    getMarkdownitHighlightRenderer(): markdownit;
     initHtmlSanitizer(): void;
     toHTML(makrdown: string): string;
     toHTMLWithCodeHightlight(markdown: string): string;
@@ -244,8 +242,6 @@ declare namespace tuiEditor {
   }
 
   class CodeBlockManager {
-    public static getHighlightJSLanguages(): string[];
-
     public createCodeBlockHtml(language: string, codeText: string): string;
     public getReplacer(language: string): ReplacerFunc;
     public setReplacer(language: string, replacer: ReplacerFunc): void;
@@ -427,8 +423,6 @@ declare namespace tuiEditor {
     public static domUtils: IDomUtil;
     public static i18n: I18n;
     public static isViewer: boolean;
-    public static markdownit: markdownit;
-    public static markdownitHighlight: markdownit;
     public static WwCodeBlockManager: typeof WwCodeBlockManager;
     public static WwTableManager: typeof WwTableManager;
     public static WwTableSelectionManager: typeof WwTableSelectionManager;
@@ -484,7 +478,6 @@ declare namespace tuiEditor {
     public static codeBlockManager: CodeBlockManager;
     public static domUtils: IDomUtil;
     public static isViewer: boolean;
-    public static markdownitHighlight: markdownit;
 
     public static defineExtension(name: string, ext: HandlerFunc): void;
 

--- a/apps/editor/src/js/codeBlockManager.js
+++ b/apps/editor/src/js/codeBlockManager.js
@@ -6,8 +6,6 @@
  * Class Code Block Manager
  */
 class CodeBlockManager {
-  static hljs = null;
-
   constructor() {
     this._replacers = {};
   }
@@ -38,28 +36,11 @@ class CodeBlockManager {
    */
   createCodeBlockHtml(language, codeText) {
     const replacer = this.getReplacer(language);
-    let html;
 
     if (replacer) {
-      html = replacer(codeText, language);
-    } else {
-      const { hljs } = CodeBlockManager;
-
-      html =
-        hljs && hljs.getLanguage(language)
-          ? hljs.highlight(language, codeText).value
-          : escape(codeText, false);
+      return replacer(codeText, language);
     }
-
-    return html;
-  }
-
-  /**
-   * Set highlight.js to code block manager
-   * @param {Object} hljs - instnace of highlight.js
-   */
-  setHighlightJS(hljs) {
-    CodeBlockManager.hljs = hljs;
+    return escape(codeText, false);
   }
 }
 

--- a/apps/editor/src/js/preview.js
+++ b/apps/editor/src/js/preview.js
@@ -5,6 +5,7 @@
 import css from 'tui-code-snippet/domUtil/css';
 import LazyRunner from './lazyRunner';
 import domUtils from './utils/dom';
+import codeBlockManager from './codeBlockManager';
 
 /**
  * Class Preview
@@ -36,12 +37,37 @@ class Preview {
     this.el.appendChild(this._previewContent);
   }
 
+  invokeCodeBlockPlugins(mdNodeIds) {
+    const contentEl = this._previewContent;
+    let targetEls;
+
+    if (mdNodeIds) {
+      targetEls = mdNodeIds
+        .map(id => contentEl.querySelector(`[data-nodeid="${id}"]`))
+        .filter(Boolean);
+    } else {
+      targetEls = [contentEl];
+    }
+
+    targetEls.forEach(targetEl => {
+      const codeEls = domUtils.findAll(targetEl, 'code[data-language]');
+
+      codeEls.forEach(codeEl => {
+        const lang = codeEl.getAttribute('data-language');
+        const html = codeBlockManager.createCodeBlockHtml(lang, codeEl.textContent);
+
+        codeEl.innerHTML = html;
+      });
+    });
+  }
+
   /**
    * Refresh rendering
    * @param {string} markdown Markdown text
    */
-  refresh(markdown) {
+  refresh(markdown = '') {
     this.render(this.convertor.toHTMLWithCodeHightlight(markdown));
+    this.invokeCodeBlockPlugins();
   }
 
   /**

--- a/apps/editor/test/unit/mdPreview.spec.js
+++ b/apps/editor/test/unit/mdPreview.spec.js
@@ -36,12 +36,6 @@ describe('Preview', () => {
     expect(listener).toHaveBeenCalled();
   });
 
-  it('listen to previewNeedsRefresh and fresh', () => {
-    eventManager.emit('previewNeedsRefresh', 'content');
-
-    expect(preview.getHTML()).toEqual('<p>content</p>\n');
-  });
-
   it('listen to contentChangedFromMarkdown and update', () => {
     const doc = new MarkdownDocument();
     const editResult = doc.editMarkdown([1, 7], [1, 7], 'changed');

--- a/plugins/code-syntax-highlight/src/js/helper.js
+++ b/plugins/code-syntax-highlight/src/js/helper.js
@@ -15,7 +15,8 @@ export function registerCodeBlockReplacer(editor, hljs) {
   editor.setCodeBlockLanguages(languages);
   languages.forEach(type => {
     const convertor = codeText => hljs.highlight(type, codeText).value;
-    const langTypes = [type, ...hljs.getLanguage(type).aliases];
+    const aliases = hljs.getLanguage(type).aliases || [];
+    const langTypes = [type, ...aliases];
 
     langTypes.forEach(lang => {
       codeBlockManager.setReplacer(lang, convertor);

--- a/plugins/code-syntax-highlight/src/js/helper.js
+++ b/plugins/code-syntax-highlight/src/js/helper.js
@@ -8,11 +8,17 @@
  * @param {Editor|Viewer} editor - instance of Editor or Viewer
  * @param {Object} [hljs] - object of highlight.js
  */
-export function registerHljsToEditor(editor, hljs) {
+export function registerCodeBlockReplacer(editor, hljs) {
   const { codeBlockManager } = Object.getPrototypeOf(editor).constructor;
   const languages = hljs.listLanguages();
 
   editor.setCodeBlockLanguages(languages);
+  languages.forEach(type => {
+    const convertor = codeText => hljs.highlight(type, codeText).value;
+    const langTypes = [type, ...hljs.getLanguage(type).aliases];
 
-  codeBlockManager.setHighlightJS(hljs);
+    langTypes.forEach(lang => {
+      codeBlockManager.setReplacer(lang, convertor);
+    });
+  });
 }

--- a/plugins/code-syntax-highlight/src/js/index.js
+++ b/plugins/code-syntax-highlight/src/js/index.js
@@ -12,8 +12,7 @@ import { registerCodeBlockReplacer } from './helper';
  * @param {Object} [options.hljs] - object of highlight.js
  */
 export default function codeSyntaxHighlightPlugin(editor, options = {}) {
-  const { hljs: externalHljs } = options;
-  const editorHljs = externalHljs || hljs;
+  const editorHljs = options.hljs || hljs;
 
   if (editorHljs) {
     registerCodeBlockReplacer(editor, editorHljs);

--- a/plugins/code-syntax-highlight/src/js/index.js
+++ b/plugins/code-syntax-highlight/src/js/index.js
@@ -3,7 +3,7 @@
  * @author NHN FE Development Lab <dl_javascript@nhn.com>
  */
 import hljs from 'highlight.js/lib/highlight';
-import { registerHljsToEditor } from './helper';
+import { registerCodeBlockReplacer } from './helper';
 
 /**
  * Code syntax highlight plugin to import selected languages
@@ -16,6 +16,6 @@ export default function codeSyntaxHighlightPlugin(editor, options = {}) {
   const editorHljs = externalHljs || hljs;
 
   if (editorHljs) {
-    registerHljsToEditor(editor, editorHljs);
+    registerCodeBlockReplacer(editor, editorHljs);
   }
 }

--- a/plugins/code-syntax-highlight/src/js/indexAll.js
+++ b/plugins/code-syntax-highlight/src/js/indexAll.js
@@ -3,12 +3,12 @@
  * @author NHN FE Development Lab <dl_javascript@nhn.com>
  */
 import hljs from 'highlight.js';
-import { registerHljsToEditor } from './helper';
+import { registerCodeBlockReplacer } from './helper';
 
 /**
  * Code syntax highlight plugin to import all languages
  * @param {Editor|Viewer} editor - instance of Editor or Viewer
  */
 export default function codeSyntaxHighlightPlugin(editor) {
-  registerHljsToEditor(editor, hljs);
+  registerCodeBlockReplacer(editor, hljs);
 }

--- a/plugins/code-syntax-highlight/test/plugin.spec.js
+++ b/plugins/code-syntax-highlight/test/plugin.spec.js
@@ -42,13 +42,13 @@ describe('codeSyntaxHighlightPlugin', () => {
 
     jasmine.clock().tick(800);
 
-    const conatiner = editor.preview.el;
+    const container = editor.preview.el;
 
-    expect(conatiner.querySelectorAll('pre').length).toBe(1);
-    expect(conatiner.querySelectorAll('pre code').length).toBe(1);
-    expect(conatiner.querySelectorAll('pre code span').length).toBe(2);
-    expect(conatiner.querySelector('pre code').getAttribute('data-language')).toBe('javascript');
-    expect(conatiner.querySelector('pre code').className).toBe('lang-javascript');
+    expect(container.querySelectorAll('pre').length).toBe(1);
+    expect(container.querySelectorAll('pre code').length).toBe(1);
+    expect(container.querySelectorAll('pre code span').length).toBe(2);
+    expect(container.querySelector('pre code').getAttribute('data-language')).toBe('javascript');
+    expect(container.querySelector('pre code').className).toBe('lang-javascript');
   });
 
   it('render codeblock element in viewer', () => {
@@ -67,13 +67,13 @@ describe('codeSyntaxHighlightPlugin', () => {
 
     jasmine.clock().tick(800);
 
-    const conatiner = editor.preview.el;
+    const container = editor.preview.el;
 
-    expect(conatiner.querySelectorAll('pre').length).toBe(1);
-    expect(conatiner.querySelectorAll('pre code').length).toBe(1);
-    expect(conatiner.querySelectorAll('pre code span').length).toBe(2);
-    expect(conatiner.querySelector('pre code').getAttribute('data-language')).toBe('javascript');
-    expect(conatiner.querySelector('pre code').className).toBe('lang-javascript');
+    expect(container.querySelectorAll('pre').length).toBe(1);
+    expect(container.querySelectorAll('pre code').length).toBe(1);
+    expect(container.querySelectorAll('pre code span').length).toBe(2);
+    expect(container.querySelector('pre code').getAttribute('data-language')).toBe('javascript');
+    expect(container.querySelector('pre code').className).toBe('lang-javascript');
   });
 
   it('render code in wysiwyg', () => {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
- fix: apply plugins when preview.refresh() is invoked
- refactor: remove highlight-js dependency from editor core


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
