### PR TITLE
fix: error when emphasis command executed in wysiwyg (fix #734)

### DIFF
--- a/apps/editor/src/js/utils/dom.js
+++ b/apps/editor/src/js/utils/dom.js
@@ -776,10 +776,9 @@ const optimizeRange = function(range, tagName) {
 
     if (startContainer !== endContainer) {
       const startNode = getParentUntil(startContainer, commonAncestorContainer);
+      const endNode = getParentUntil(endContainer, commonAncestorContainer);
 
-      if (startNode) {
-        const endNode = getParentUntil(endContainer, commonAncestorContainer);
-
+      if (startNode && endNode) {
         mergeSameNodes(startNode, endNode, tagName);
       }
 

--- a/apps/editor/src/js/utils/dom.js
+++ b/apps/editor/src/js/utils/dom.js
@@ -775,11 +775,13 @@ const optimizeRange = function(range, tagName) {
     let optimizedNode = null;
 
     if (startContainer !== endContainer) {
-      mergeSameNodes(
-        getParentUntil(startContainer, commonAncestorContainer),
-        getParentUntil(endContainer, commonAncestorContainer),
-        tagName
-      );
+      const startNode = getParentUntil(startContainer, commonAncestorContainer);
+
+      if (startNode) {
+        const endNode = getParentUntil(endContainer, commonAncestorContainer);
+
+        mergeSameNodes(startNode, endNode, tagName);
+      }
 
       optimizedNode = commonAncestorContainer;
     } else if (isTextNode(startContainer)) {

--- a/apps/editor/test/unit/wysiwygCommands/bold.spec.js
+++ b/apps/editor/test/unit/wysiwygCommands/bold.spec.js
@@ -113,4 +113,20 @@ describe('Bold', () => {
 
     expect(wwe.getValue()).toEqual('<b>line</b><br />');
   });
+
+  it('when some of the text is selected, the bold already applied should be removed', () => {
+    const range = wwe
+      .getEditor()
+      .getSelection()
+      .cloneRange();
+
+    wwe.setValue('<b>foo b</b>ar');
+
+    range.selectNodeContents(wwe.getBody().children[0].firstChild);
+    wwe.getEditor().setSelection(range);
+
+    Bold.exec(wwe);
+
+    expect(wwe.getValue()).toEqual('foo bar<br />');
+  });
 });

--- a/apps/editor/test/unit/wysiwygCommands/italic.spec.js
+++ b/apps/editor/test/unit/wysiwygCommands/italic.spec.js
@@ -112,4 +112,20 @@ describe('Italic', () => {
 
     expect(wwe.getValue()).toEqual('<i>line</i><br />');
   });
+
+  it('when some of the text is selected, the italic already applied should be removed', () => {
+    const range = wwe
+      .getEditor()
+      .getSelection()
+      .cloneRange();
+
+    wwe.setValue('<i>foo b</i>ar');
+
+    range.selectNodeContents(wwe.getBody().children[0].firstChild);
+    wwe.getEditor().setSelection(range);
+
+    Italic.exec(wwe);
+
+    expect(wwe.getValue()).toEqual('foo bar<br />');
+  });
 });

--- a/apps/editor/test/unit/wysiwygCommands/strike.spec.js
+++ b/apps/editor/test/unit/wysiwygCommands/strike.spec.js
@@ -160,4 +160,20 @@ describe('Strike', () => {
 
     expect(wwe.getValue()).toEqual('<s>line</s><br />');
   });
+
+  it('when some of the text is selected, the strike already applied should be removed', () => {
+    const range = wwe
+      .getEditor()
+      .getSelection()
+      .cloneRange();
+
+    wwe.setValue('<s>foo b</s>ar');
+
+    range.selectNodeContents(wwe.getBody().children[0].firstChild);
+    wwe.getEditor().setSelection(range);
+
+    Strike.exec(wwe);
+
+    expect(wwe.getValue()).toEqual('foo bar<br />');
+  });
 });


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description

* Related issue #734 

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
