### PR TITLE
fix: import decode module only from entities

### DIFF
--- a/libs/toastmark/src/commonmark/common.ts
+++ b/libs/toastmark/src/commonmark/common.ts
@@ -1,5 +1,5 @@
 import encode from 'mdurl/encode';
-import { decodeHTML } from 'entities';
+import { decodeHTML } from 'entities/lib/decode';
 
 export const ENTITY = '&(?:#x[a-f0-9]{1,6}|#[0-9]{1,7}|[a-z][a-z0-9]{1,31});';
 const C_BACKSLASH = 92;

--- a/libs/toastmark/src/commonmark/inlines.ts
+++ b/libs/toastmark/src/commonmark/inlines.ts
@@ -3,7 +3,7 @@ import { repeat, normalizeURI, unescapeString, ESCAPABLE, ENTITY } from './commo
 import { reHtmlTag } from './rawHtml';
 import fromCodePoint from './from-code-point';
 import { Options } from './blocks';
-import { decodeHTML } from 'entities';
+import { decodeHTML } from 'entities/lib/decode';
 import NodeWalker from './nodeWalker';
 import { convertExtAutoLinks } from './gfm/autoLinks';
 import { last, normalizeReference } from '../helper';


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
- reduced bundle size by importing `decode` module only from `entities`

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
