### PR TITLE
chore: edit wrong jsdoc of editor options (fix #772)

### DIFF
--- a/apps/editor/src/js/editor.js
+++ b/apps/editor/src/js/editor.js
@@ -90,33 +90,47 @@ const availableLinkAttributes = ['rel', 'target', 'contenteditable', 'hreflang',
  */
 
 /**
+ * @typedef {object} toolbarItemsValue
+ * @property {string} type - type of toolbar item (default value is 'button')
+ * @property {toolbarButtonOptions} options - options of toolbar item
+ */
+
+/**
+ * @typedef {object} toolbarButtonOptions
+ * @property {HTMLElement} el - target element
+ * @property {string} tooltip - text on tooltip
+ * @property {string} command - command name to execute on click
+ * @property {string} event - event name to trigger on click
+ */
+
+/**
  * ToastUI Editor
- * @param {object} options Option object
+ * @param {Object} options Option object
  *     @param {HTMLElement} options.el - container element
  *     @param {string} [options.height='300px'] - Editor's height style value. Height is applied as border-box ex) '300px', '100%', 'auto'
  *     @param {string} [options.minHeight='200px'] - Editor's min-height style value in pixel ex) '300px'
  *     @param {string} [options.initialValue] - Editor's initial value
  *     @param {string} [options.previewStyle] - Markdown editor's preview style (tab, vertical)
  *     @param {string} [options.initialEditType] - Initial editor type (markdown, wysiwyg)
- *     @param {object[]} [options.events] - eventlist Event list
- *         @param {function} options.events.load - It would be emitted when editor fully load
- *         @param {function} options.events.change - It would be emitted when content changed
- *         @param {function} options.events.stateChange - It would be emitted when format change by cursor position
- *         @param {function} options.events.focus - It would be emitted when editor get focus
- *         @param {function} options.events.blur - It would be emitted when editor loose focus
- *     @param {object[]} [options.hooks] - Hook list
- *         @param {function} options.hooks.previewBeforeHook - Submit preview to hook URL before preview be shown
- *         @param {addImageBlobHook} options.hooks.addImageBlobHook - hook for image upload.
+ *     @param {Object} [options.events] - Events
+ *         @param {function} [options.events.load] - It would be emitted when editor fully load
+ *         @param {function} [options.events.change] - It would be emitted when content changed
+ *         @param {function} [options.events.stateChange] - It would be emitted when format change by cursor position
+ *         @param {function} [options.events.focus] - It would be emitted when editor get focus
+ *         @param {function} [options.events.blur] - It would be emitted when editor loose focus
+ *     @param {Object} [options.hooks] - Hooks
+ *         @param {function} [options.hooks.previewBeforeHook] - Submit preview to hook URL before preview be shown
+ *         @param {addImageBlobHook} [options.hooks.addImageBlobHook] - hook for image upload
  *     @param {string} [options.language='en-US'] - language
  *     @param {boolean} [options.useCommandShortcut=true] - whether use keyboard shortcuts to perform commands
  *     @param {boolean} [options.useDefaultHTMLSanitizer=true] - use default htmlSanitizer
  *     @param {boolean} [options.usageStatistics=true] - send hostname to google analytics
- *     @param {string[]} [options.toolbarItems] - toolbar items.
+ *     @param {Array.<string|toolbarItemsValue>} [options.toolbarItems] - toolbar items.
  *     @param {boolean} [options.hideModeSwitch=false] - hide mode switch tab bar
- *     @param {Array.<Function|Array>} plugins - Array of plugins. A plugin can be either a function or an array in the form of [function, options].
- *     @param {object} [options.customConvertor] - convertor extention
+ *     @param {Array.<Function|Array>} [options.plugins] - Array of plugins. A plugin can be either a function or an array in the form of [function, options].
+ *     @param {Object} [options.customConvertor] - convertor extention
  *     @param {string} [options.placeholder] - The placeholder text of the editable element.
- *     @param {object} [options.linkAttribute] - Attributes of anchor element that shold be rel, target, contenteditable, hreflang, type
+ *     @param {Object} [options.linkAttribute] - Attributes of anchor element that shold be rel, target, contenteditable, hreflang, type
  */
 class ToastUIEditor {
   constructor(options) {

--- a/apps/editor/src/js/editor.js
+++ b/apps/editor/src/js/editor.js
@@ -98,9 +98,13 @@ const availableLinkAttributes = ['rel', 'target', 'contenteditable', 'hreflang',
 /**
  * @typedef {object} toolbarButtonOptions
  * @property {HTMLElement} el - target element
- * @property {string} tooltip - text on tooltip
+ * @property {string} className - class name
  * @property {string} command - command name to execute on click
  * @property {string} event - event name to trigger on click
+ * @property {string} text - text on button
+ * @property {string} tooltip - text on tooltip
+ * @property {string} style - button style
+ * @property {string} state - button state
  */
 
 /**

--- a/apps/editor/src/js/editor.js
+++ b/apps/editor/src/js/editor.js
@@ -131,7 +131,7 @@ const availableLinkAttributes = ['rel', 'target', 'contenteditable', 'hreflang',
  *     @param {boolean} [options.usageStatistics=true] - send hostname to google analytics
  *     @param {Array.<string|toolbarItemsValue>} [options.toolbarItems] - toolbar items.
  *     @param {boolean} [options.hideModeSwitch=false] - hide mode switch tab bar
- *     @param {Array.<Function|Array>} [options.plugins] - Array of plugins. A plugin can be either a function or an array in the form of [function, options].
+ *     @param {Array.<function|Array>} [options.plugins] - Array of plugins. A plugin can be either a function or an array in the form of [function, options].
  *     @param {Object} [options.customConvertor] - convertor extention
  *     @param {string} [options.placeholder] - The placeholder text of the editable element.
  *     @param {Object} [options.linkAttribute] - Attributes of anchor element that shold be rel, target, contenteditable, hreflang, type

--- a/apps/editor/src/js/editor.js
+++ b/apps/editor/src/js/editor.js
@@ -90,24 +90,6 @@ const availableLinkAttributes = ['rel', 'target', 'contenteditable', 'hreflang',
  */
 
 /**
- * @typedef {object} toolbarItemsValue
- * @property {string} type - type of toolbar item (default value is 'button')
- * @property {toolbarButtonOptions} options - options of toolbar item
- */
-
-/**
- * @typedef {object} toolbarButtonOptions
- * @property {HTMLElement} el - target element
- * @property {string} className - class name
- * @property {string} command - command name to execute on click
- * @property {string} event - event name to trigger on click
- * @property {string} text - text on button
- * @property {string} tooltip - text on tooltip
- * @property {string} style - button style
- * @property {string} state - button state
- */
-
-/**
  * ToastUI Editor
  * @param {Object} options Option object
  *     @param {HTMLElement} options.el - container element

--- a/apps/editor/src/js/viewer.js
+++ b/apps/editor/src/js/viewer.js
@@ -22,16 +22,17 @@ const TASK_CHECKED_CLASS_NAME = 'checked';
  * Class ToastUIEditorViewer
  * @param {object} options Option object
  *     @param {HTMLElement} options.el - container element
- *     @param {string} options.initialValue Editor's initial value
- *     @param {object} options.events eventlist Event list
- *         @param {function} options.events.load It would be emitted when editor fully load
- *         @param {function} options.events.change It would be emitted when content changed
- *         @param {function} options.events.stateChange It would be emitted when format change by cursor position
- *         @param {function} options.events.focus It would be emitted when editor get focus
- *         @param {function} options.events.blur It would be emitted when editor loose focus
- *     @param {object} options.hooks Hook list
- *     @param {function} options.hooks.previewBeforeHook Submit preview to hook URL before preview be shown
- *     @param {Array.<Function|Array>} plugins - Array of plugins. A plugin can be either a function or an array in the form of [function, options].
+ *     @param {string} [options.initialValue] Editor's initial value
+ *     @param {Object} [options.events] - Events
+ *         @param {function} [options.events.load] - It would be emitted when editor fully load
+ *         @param {function} [options.events.change] - It would be emitted when content changed
+ *         @param {function} [options.events.stateChange] - It would be emitted when format change by cursor position
+ *         @param {function} [options.events.focus] - It would be emitted when editor get focus
+ *         @param {function} [options.events.blur] - It would be emitted when editor loose focus
+ *     @param {Object} [options.hooks] - Hooks
+ *         @param {function} [options.hooks.previewBeforeHook] - Submit preview to hook URL before preview be shown
+ *         @param {addImageBlobHook} [options.hooks.addImageBlobHook] - hook for image upload
+ *     @param {Array.<string|toolbarItemsValue>} [options.toolbarItems] - toolbar items.
  */
 class ToastUIEditorViewer {
   constructor(options) {

--- a/apps/editor/src/js/viewer.js
+++ b/apps/editor/src/js/viewer.js
@@ -31,7 +31,6 @@ const TASK_CHECKED_CLASS_NAME = 'checked';
  *         @param {function} [options.events.blur] - It would be emitted when editor loose focus
  *     @param {Object} [options.hooks] - Hooks
  *         @param {function} [options.hooks.previewBeforeHook] - Submit preview to hook URL before preview be shown
- *         @param {addImageBlobHook} [options.hooks.addImageBlobHook] - hook for image upload
  *     @param {Array.<function|Array>} [options.plugins] - Array of plugins. A plugin can be either a function or an array in the form of [function, options].
  */
 class ToastUIEditorViewer {

--- a/apps/editor/src/js/viewer.js
+++ b/apps/editor/src/js/viewer.js
@@ -32,7 +32,7 @@ const TASK_CHECKED_CLASS_NAME = 'checked';
  *     @param {Object} [options.hooks] - Hooks
  *         @param {function} [options.hooks.previewBeforeHook] - Submit preview to hook URL before preview be shown
  *         @param {addImageBlobHook} [options.hooks.addImageBlobHook] - hook for image upload
- *         @param {Array.<Function|Array>} [options.plugins] - Array of plugins. A plugin can be either a function or an array in the form of [function, options].
+ *         @param {Array.<function|Array>} [options.plugins] - Array of plugins. A plugin can be either a function or an array in the form of [function, options].
  */
 class ToastUIEditorViewer {
   constructor(options) {

--- a/apps/editor/src/js/viewer.js
+++ b/apps/editor/src/js/viewer.js
@@ -32,7 +32,7 @@ const TASK_CHECKED_CLASS_NAME = 'checked';
  *     @param {Object} [options.hooks] - Hooks
  *         @param {function} [options.hooks.previewBeforeHook] - Submit preview to hook URL before preview be shown
  *         @param {addImageBlobHook} [options.hooks.addImageBlobHook] - hook for image upload
- *     @param {Array.<string|toolbarItemsValue>} [options.toolbarItems] - toolbar items.
+ *         @param {Array.<Function|Array>} [options.plugins] - Array of plugins. A plugin can be either a function or an array in the form of [function, options].
  */
 class ToastUIEditorViewer {
   constructor(options) {

--- a/apps/editor/src/js/viewer.js
+++ b/apps/editor/src/js/viewer.js
@@ -32,7 +32,7 @@ const TASK_CHECKED_CLASS_NAME = 'checked';
  *     @param {Object} [options.hooks] - Hooks
  *         @param {function} [options.hooks.previewBeforeHook] - Submit preview to hook URL before preview be shown
  *         @param {addImageBlobHook} [options.hooks.addImageBlobHook] - hook for image upload
- *         @param {Array.<function|Array>} [options.plugins] - Array of plugins. A plugin can be either a function or an array in the form of [function, options].
+ *     @param {Array.<function|Array>} [options.plugins] - Array of plugins. A plugin can be either a function or an array in the form of [function, options].
  */
 class ToastUIEditorViewer {
   constructor(options) {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
* Related issue #772


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
