### PR TITLE
fix: extending end-node for continued list item

### DIFF
--- a/libs/toastmark/src/__test__/toastmark.spec.ts
+++ b/libs/toastmark/src/__test__/toastmark.spec.ts
@@ -318,10 +318,10 @@ describe('editText()', () => {
     });
 
     it('prepend a new list before a padded paragraph', () => {
-      const doc = new ToastMark('\n\n  World');
+      const doc = new ToastMark('\n\n  My\n\n  World');
       const result = doc.editMarkdown([1, 1], [1, 1], '- Hello');
 
-      assertParseResult(doc, ['- Hello', '', '  World']);
+      assertParseResult(doc, ['- Hello', '', '  My', '', '  World']);
       assertResultNodes(doc, result.nodes);
     });
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
- refactor: rename symbols and extract methods
- fix: extending node-range when following node can be a continued list-item

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
