### PR TITLE
feat: improve custom-renderer API

### DIFF
--- a/libs/toastmark/src/commonmark/from-code-point.ts
+++ b/libs/toastmark/src/commonmark/from-code-point.ts
@@ -16,19 +16,19 @@ if (String.fromCodePoint) {
 } else {
   const stringFromCharCode = String.fromCharCode;
   const floor = Math.floor;
-  fromCodePoint = function() {
+  fromCodePoint = function(...args) {
     const MAX_SIZE = 0x4000;
     const codeUnits = [];
     let highSurrogate: number;
     let lowSurrogate: number;
     let index = -1;
-    const length = arguments.length;
+    const length = args.length;
     if (!length) {
       return '';
     }
     let result = '';
     while (++index < length) {
-      let codePoint = Number(arguments[index]);
+      let codePoint = Number(args[index]);
       if (
         !isFinite(codePoint) || // `NaN`, `+Infinity`, or `-Infinity`
         codePoint < 0 || // not a valid Unicode code point
@@ -49,7 +49,7 @@ if (String.fromCodePoint) {
         codeUnits.push(highSurrogate, lowSurrogate);
       }
       if (index + 1 === length || codeUnits.length > MAX_SIZE) {
-        result += stringFromCharCode.apply(null, codeUnits);
+        result += stringFromCharCode(...codeUnits);
         codeUnits.length = 0;
       }
     }

--- a/libs/toastmark/src/html/__test__/render.spec.ts
+++ b/libs/toastmark/src/html/__test__/render.spec.ts
@@ -1,5 +1,5 @@
 import { Parser } from '../../commonmark/blocks';
-import { createRenderHTML, OpenTagNode } from '../render';
+import { createRenderHTML, OpenTagToken } from '../render';
 
 const parser = new Parser();
 
@@ -90,7 +90,7 @@ describe('convertors options', () => {
         paragraph(_, { entering, origin }) {
           const result = origin!();
           if (entering) {
-            (result as OpenTagNode).classNames = ['my-class'];
+            (result as OpenTagToken).classNames = ['my-class'];
             return result;
           }
           return result;

--- a/libs/toastmark/src/html/__test__/render.spec.ts
+++ b/libs/toastmark/src/html/__test__/render.spec.ts
@@ -71,7 +71,7 @@ describe('convertors options', () => {
     expect(firstCall[0]).toBe(root.firstChild);
     expect(firstCall[1]).toMatchObject({
       entering: true,
-      leaf: true,
+      leaf: false,
       options
     });
 
@@ -79,7 +79,7 @@ describe('convertors options', () => {
     expect(secondCall[0]).toBe(root.firstChild);
     expect(secondCall[1]).toMatchObject({
       entering: false,
-      leaf: true,
+      leaf: false,
       options
     });
   });

--- a/libs/toastmark/src/html/baseConvertors.ts
+++ b/libs/toastmark/src/html/baseConvertors.ts
@@ -165,8 +165,10 @@ export const baseConvertors: HTMLConvertorMap = {
     return { type: 'closeTag', tagName: 'a' };
   },
 
-  image(node: Node, { getChildText }) {
+  image(node: Node, { getChildrenText, skipChildren }) {
     const { title, destination } = node as LinkNode;
+
+    skipChildren();
 
     return {
       type: 'openTag',
@@ -174,7 +176,7 @@ export const baseConvertors: HTMLConvertorMap = {
       selfClose: true,
       attributes: {
         src: escapeXml(destination!),
-        alt: getChildText(node),
+        alt: getChildrenText(node),
         ...(title && { title: escapeXml(title) })
       }
     };

--- a/libs/toastmark/src/html/baseConvertors.ts
+++ b/libs/toastmark/src/html/baseConvertors.ts
@@ -165,7 +165,7 @@ export const baseConvertors: HTMLConvertorMap = {
     return { type: 'closeTag', tagName: 'a' };
   },
 
-  image(node: Node, { childText }) {
+  image(node: Node, { getChildText }) {
     const { title, destination } = node as LinkNode;
 
     return {
@@ -174,7 +174,7 @@ export const baseConvertors: HTMLConvertorMap = {
       selfClose: true,
       attributes: {
         src: escapeXml(destination!),
-        alt: childText!,
+        alt: getChildText(node),
         ...(title && { title: escapeXml(title) })
       }
     };

--- a/libs/toastmark/src/html/gfmConvertors.ts
+++ b/libs/toastmark/src/html/gfmConvertors.ts
@@ -1,5 +1,5 @@
 import { Node, ListNode, TableNode, TableCellNode } from '../commonmark/node';
-import { HTMLConvertorMap, OpenTagNode, HTMLNode } from './render';
+import { HTMLConvertorMap, OpenTagToken, HTMLToken } from './render';
 
 export const gfmConvertors: HTMLConvertorMap = {
   strike(_, { entering }) {
@@ -13,7 +13,7 @@ export const gfmConvertors: HTMLConvertorMap = {
     const { checked, task } = (node as ListNode).listData!;
 
     if (entering) {
-      const itemTag: OpenTagNode = {
+      const itemTag: OpenTagToken = {
         type: 'openTag',
         tagName: 'li',
         outerNewLine: true
@@ -81,7 +81,7 @@ export const gfmConvertors: HTMLConvertorMap = {
       };
     }
 
-    const result: HTMLNode[] = [];
+    const result: HTMLToken[] = [];
     const table = node.parent!.parent as TableNode;
     const lastCell = node.lastChild as TableCellNode;
     for (let i = lastCell.columnIdx + 1; i < table.columns.length; i += 1) {

--- a/libs/toastmark/src/html/render.ts
+++ b/libs/toastmark/src/html/render.ts
@@ -211,6 +211,8 @@ function renderHTMLNode(node: HTMLToken, buffer: string[]) {
     case 'html':
       renderRawHtmlNode(node, buffer);
       break;
+    default:
+    // no-defualt-case
   }
 }
 

--- a/libs/toastmark/src/html/render.ts
+++ b/libs/toastmark/src/html/render.ts
@@ -21,39 +21,39 @@ interface Context {
   origin?: () => ReturnType<HTMLConvertor>;
 }
 
-export type HTMLConvertor = (node: Node, context: Context) => HTMLNode | HTMLNode[] | null;
+export type HTMLConvertor = (node: Node, context: Context) => HTMLToken | HTMLToken[] | null;
 
 export type HTMLConvertorMap = Partial<Record<NodeType, HTMLConvertor>>;
 
-interface TagNode {
+interface TagToken {
   tagName: string;
   outerNewLine?: boolean;
   innerNewLine?: boolean;
 }
 
-export interface OpenTagNode extends TagNode {
+export interface OpenTagToken extends TagToken {
   type: 'openTag';
   classNames?: string[];
   attributes?: Record<string, string>;
   selfClose?: boolean;
 }
 
-export interface CloseTagNode extends TagNode {
+export interface CloseTagToken extends TagToken {
   type: 'closeTag';
 }
 
-interface TextNode {
+interface TextToken {
   type: 'text';
   content: string;
 }
 
-export interface RawHTMLNode {
+export interface RawHTMLToken {
   type: 'html';
   content: string;
   outerNewLine?: boolean;
 }
 
-export type HTMLNode = OpenTagNode | CloseTagNode | TextNode | RawHTMLNode;
+export type HTMLToken = OpenTagToken | CloseTagToken | TextToken | RawHTMLToken;
 
 const defaultOptions: Options = {
   softbreak: '\n',
@@ -91,7 +91,7 @@ export function createRenderHTML(customOptions?: Partial<Options>) {
   return (node: Node) => render(node, convertors, options);
 }
 
-function generateOpenTagString(node: OpenTagNode): string {
+function generateOpenTagString(node: OpenTagToken): string {
   const buffer = [];
   const { tagName, classNames, attributes } = node;
 
@@ -116,7 +116,7 @@ function generateOpenTagString(node: OpenTagNode): string {
   return buffer.join('');
 }
 
-function generateCloseTagString({ tagName }: CloseTagNode) {
+function generateCloseTagString({ tagName }: CloseTagToken) {
   return `</${tagName}>`;
 }
 
@@ -126,13 +126,13 @@ function addNewLine(buffer: string[]) {
   }
 }
 
-function addOuterNewLine(node: TagNode | RawHTMLNode, buffer: string[]) {
+function addOuterNewLine(node: TagToken | RawHTMLToken, buffer: string[]) {
   if (node.outerNewLine) {
     addNewLine(buffer);
   }
 }
 
-function addInnerNewLine(node: TagNode, buffer: string[]) {
+function addInnerNewLine(node: TagToken, buffer: string[]) {
   if (node.innerNewLine) {
     addNewLine(buffer);
   }
@@ -199,7 +199,7 @@ function render(rootNode: Node, convertors: HTMLConvertorMap, options: Options):
   return buffer.join('');
 }
 
-function renderHTMLNode(node: HTMLNode, buffer: string[]) {
+function renderHTMLNode(node: HTMLToken, buffer: string[]) {
   switch (node.type) {
     case 'openTag':
     case 'closeTag':
@@ -214,17 +214,17 @@ function renderHTMLNode(node: HTMLNode, buffer: string[]) {
   }
 }
 
-function renderTextNode(node: TextNode, buffer: string[]) {
+function renderTextNode(node: TextToken, buffer: string[]) {
   buffer.push(escapeXml(node.content));
 }
 
-function renderRawHtmlNode(node: RawHTMLNode, buffer: string[]) {
+function renderRawHtmlNode(node: RawHTMLToken, buffer: string[]) {
   addOuterNewLine(node, buffer);
   buffer.push(node.content);
   addOuterNewLine(node, buffer);
 }
 
-function renderElementNode(node: OpenTagNode | CloseTagNode, buffer: string[]) {
+function renderElementNode(node: OpenTagToken | CloseTagToken, buffer: string[]) {
   if (node.type === 'openTag') {
     addOuterNewLine(node, buffer);
     buffer.push(generateOpenTagString(node));


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
- refactor: rename type name from `HTMLNode` to `HTMLToken`, and other related types
  > The term `Node` is normaly used for a tree structure, but the data structure used by HTMLRenderer is actually a series of token. In addition, as the type `Node` is already used parser to represent each node in AST, using a different term is clearer. 
- feat: remove `childText` value from `context` object 
- feat: add `getChildrenText`, `skipChildren` function to `context` object
  > `childText` value was only applied to `image` node before, but there might be cases for other nodes to control the process of child rendering. 

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
