### PR TITLE
fix: wrong position of the tooltip on the toolbar item

### DIFF
--- a/apps/editor/src/js/scroll/ui/button.js
+++ b/apps/editor/src/js/scroll/ui/button.js
@@ -28,7 +28,7 @@ export function createButton(editor) {
     type: 'button',
     options: {
       command: 'scrollSyncToggle',
-      tooltip: tooltip.active,
+      tooltip: tooltip.ACTIVE,
       el: buttonEl
     }
   });

--- a/apps/editor/src/js/ui/tooltip.js
+++ b/apps/editor/src/js/ui/tooltip.js
@@ -6,6 +6,7 @@ import css from 'tui-code-snippet/domUtil/css';
 import domUtils from '../utils/dom';
 
 const TOOLTIP_CONTENT = '<div class="arrow"></div><span class="text"></span></span>';
+const TOOLTIP_TOP_INDENT = 7;
 
 /**
  * Class Tooltip
@@ -26,10 +27,12 @@ class Tooltip {
    * @param {String} text - text to show
    */
   show(target, text) {
-    const { top, left } = domUtils.getOffset(target);
+    const targetRect = target.getBoundingClientRect();
+    const left = targetRect.left + window.pageXOffset;
+    const top = targetRect.top + window.pageYOffset;
 
     css(this.el, {
-      top: `${top + target.clientHeight + 13}px`, // below the button
+      top: `${top + target.clientHeight + TOOLTIP_TOP_INDENT}px`,
       left: `${left + 3}px`
     });
 


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
* fix the wrong calculated offset position of tooltip on toolbar item. The offset position should be calculated based on `document.body` because tooltip element is attached to `body`.


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
