### PR TITLE
fix: wrong ordered list regexp when extending list by pressing the enter key

### DIFF
--- a/apps/editor/src/js/codemirror/continuelist.js
+++ b/apps/editor/src/js/codemirror/continuelist.js
@@ -7,7 +7,7 @@ import CodeMirror from 'codemirror';
 
 /*eslint-disable */
 var listRE = /^(\s*)(>[> ]*|[*+-] \[[x ]\]\s|[*+-]\s|(\d+)([.)]\s))(\s*)/,
-  emptyListRE = /^(\s*)(>[> ]*|[*+-] \[[x ]\]|[*+-]|(\d+)[.)]\s)(\s*)$/,
+  emptyListRE = /^(\s*)(>[> ]*|[*+-] \[[x ]\]|[*+-]|(\d+)[.)])(\s*)$/,
   unorderedListRE = /[*+-]\s/;
 
 CodeMirror.commands.indentOrderedList = function(cm) {

--- a/apps/editor/src/js/codemirror/continuelist.js
+++ b/apps/editor/src/js/codemirror/continuelist.js
@@ -18,7 +18,7 @@ CodeMirror.commands.indentOrderedList = function(cm) {
     var line = cm.getLine(pos.line);
     var cursorBeforeTextInline = line.substr(0, pos.ch);
 
-    if (listRE.test(cursorBeforeTextInline) || cm.somethingSelected()) {
+    if (!cm.state.disableContinue && (listRE.test(cursorBeforeTextInline) || cm.somethingSelected())) {
       cm.indentSelection('add');
     } else {
       cm.execCommand('insertSoftTab');
@@ -28,9 +28,10 @@ CodeMirror.commands.indentOrderedList = function(cm) {
 };
 
 CodeMirror.commands.newlineAndIndentContinueMarkdownList = function(cm) {
-  if (cm.getOption('disableInput')) return CodeMirror.Pass;
+  if (cm.getOption('disableInput') || !!cm.state.disableContinue) return CodeMirror.Pass;
   var ranges = cm.listSelections(),
-    replacements = [];
+  replacements = [];
+  
   for (var i = 0; i < ranges.length; i++) {
     var pos = ranges[i].head;
     var line = cm.getLine(pos.line),

--- a/apps/editor/src/js/codemirror/continuelist.js
+++ b/apps/editor/src/js/codemirror/continuelist.js
@@ -30,7 +30,7 @@ CodeMirror.commands.indentOrderedList = function(cm) {
 CodeMirror.commands.newlineAndIndentContinueMarkdownList = function(cm) {
   if (cm.getOption('disableInput') || !!cm.state.isCursorInCodeBlock) return CodeMirror.Pass;
   var ranges = cm.listSelections(),
-  replacements = [];
+    replacements = [];
   
   for (var i = 0; i < ranges.length; i++) {
     var pos = ranges[i].head;

--- a/apps/editor/src/js/codemirror/continuelist.js
+++ b/apps/editor/src/js/codemirror/continuelist.js
@@ -18,7 +18,7 @@ CodeMirror.commands.indentOrderedList = function(cm) {
     var line = cm.getLine(pos.line);
     var cursorBeforeTextInline = line.substr(0, pos.ch);
 
-    if (!cm.state.disableContinue && (listRE.test(cursorBeforeTextInline) || cm.somethingSelected())) {
+    if (!cm.state.isCursorInCodeBlock && (listRE.test(cursorBeforeTextInline) || cm.somethingSelected())) {
       cm.indentSelection('add');
     } else {
       cm.execCommand('insertSoftTab');
@@ -28,7 +28,7 @@ CodeMirror.commands.indentOrderedList = function(cm) {
 };
 
 CodeMirror.commands.newlineAndIndentContinueMarkdownList = function(cm) {
-  if (cm.getOption('disableInput') || !!cm.state.disableContinue) return CodeMirror.Pass;
+  if (cm.getOption('disableInput') || !!cm.state.isCursorInCodeBlock) return CodeMirror.Pass;
   var ranges = cm.listSelections(),
   replacements = [];
   

--- a/apps/editor/src/js/codemirror/continuelist.js
+++ b/apps/editor/src/js/codemirror/continuelist.js
@@ -6,8 +6,8 @@
 import CodeMirror from 'codemirror';
 
 /*eslint-disable */
-var listRE = /^(\s*)(>[> ]*|[*+-] \[[x ]\]\s|[*+-]\s|(\d+)([.)]))(\s*)/,
-  emptyListRE = /^(\s*)(>[> ]*|[*+-] \[[x ]\]|[*+-]|(\d+)[.)])(\s*)$/,
+var listRE = /^(\s*)(>[> ]*|[*+-] \[[x ]\]\s|[*+-]\s|(\d+)([.)]\s))(\s*)/,
+  emptyListRE = /^(\s*)(>[> ]*|[*+-] \[[x ]\]|[*+-]|(\d+)[.)]\s)(\s*)$/,
   unorderedListRE = /[*+-]\s/;
 
 CodeMirror.commands.indentOrderedList = function(cm) {

--- a/apps/editor/src/js/codemirror/fixOrderedListNumber.js
+++ b/apps/editor/src/js/codemirror/fixOrderedListNumber.js
@@ -31,7 +31,7 @@ CodeMirror.commands.indentLessOrderedList = cm => {
  * @ignore
  */
 CodeMirror.commands.fixOrderedListNumber = cm => {
-  if (cm.getOption('disableInput') || !!cm.state.disableContinue) {
+  if (cm.getOption('disableInput') || !!cm.state.isCursorInCodeBlock) {
     return CodeMirror.Pass;
   }
 

--- a/apps/editor/src/js/codemirror/fixOrderedListNumber.js
+++ b/apps/editor/src/js/codemirror/fixOrderedListNumber.js
@@ -31,7 +31,7 @@ CodeMirror.commands.indentLessOrderedList = cm => {
  * @ignore
  */
 CodeMirror.commands.fixOrderedListNumber = cm => {
-  if (cm.getOption('disableInput')) {
+  if (cm.getOption('disableInput') || !!cm.state.disableContinue) {
     return CodeMirror.Pass;
   }
 

--- a/apps/editor/src/js/markdownEditor.js
+++ b/apps/editor/src/js/markdownEditor.js
@@ -394,6 +394,7 @@ class MarkdownEditor extends CodeMirrorExt {
     let mdNode = this.toastMark.findNodeAtPosition([mdLine, mdCh]);
     let state = null;
 
+    this.cm.state.disableContinue = mdNode && mdNode.type === 'codeBlock';
     this.eventManager.emit('cursorActivity', {
       source: 'markdown',
       cursor: { line, ch },

--- a/apps/editor/src/js/markdownEditor.js
+++ b/apps/editor/src/js/markdownEditor.js
@@ -394,7 +394,8 @@ class MarkdownEditor extends CodeMirrorExt {
     let mdNode = this.toastMark.findNodeAtPosition([mdLine, mdCh]);
     let state = null;
 
-    this.cm.state.disableContinue = mdNode && mdNode.type === 'codeBlock';
+    // To prevent to execute codemirror command in codeblock
+    this.cm.state.isCursorInCodeBlock = mdNode && mdNode.type === 'codeBlock';
     this.eventManager.emit('cursorActivity', {
       source: 'markdown',
       cursor: { line, ch },


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
* extend the ordered list by pressing the enter key when ordered list should include space like below 
  * `1. a`


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
