### PR TITLE
fix: syntax highlighting for setext heading

### DIFF
--- a/apps/editor/src/css/md-syntax-highlighting.css
+++ b/apps/editor/src/css/md-syntax-highlighting.css
@@ -28,6 +28,10 @@
   font-size: 14px;
 }
 
+.tui-md-heading.tui-md-delimiter.setext {
+  line-height: 15px;
+}
+
 .tui-md-strong,
 .tui-md-heading,
 .tui-md-list-item.tui-md-list-item-bullet,

--- a/apps/editor/src/js/markTextHelper.js
+++ b/apps/editor/src/js/markTextHelper.js
@@ -42,13 +42,16 @@ function markInfo(start, end, className) {
   return { start, end, className };
 }
 
-function heading({ level }, start, end) {
-  return {
-    marks: [
-      markInfo(start, end, cls('heading', `heading${level}`)),
-      markInfo(start, addChPos(start, level), classNameMap.DELIM)
-    ]
-  };
+function heading({ level, headingType }, start, end) {
+  const marks = [markInfo(start, end, cls('heading', `heading${level}`))];
+
+  if (headingType === 'atx') {
+    marks.push(markInfo(start, addChPos(start, level), classNameMap.DELIM));
+  } else {
+    marks.push(markInfo(setChPos(end, 0), end, `${classNameMap.DELIM} setext`));
+  }
+
+  return { marks };
 }
 
 function emphasisAndStrikethrough({ type }, start, end) {

--- a/libs/toastmark/src/commonmark/__test__/syntax-info.spec.ts
+++ b/libs/toastmark/src/commonmark/__test__/syntax-info.spec.ts
@@ -1,0 +1,20 @@
+import { Parser } from '../blocks';
+import { HeadingNode } from '../node';
+
+const parser = new Parser();
+
+describe('headingType ', () => {
+  it('atx heading', () => {
+    const root = parser.parse('# Heading');
+    const heading = root.firstChild as HeadingNode;
+
+    expect(heading.headingType).toBe('atx');
+  });
+
+  it('setext heading', () => {
+    const root = parser.parse('Heading\n----');
+    const heading = root.firstChild as HeadingNode;
+
+    expect(heading.headingType).toBe('setext');
+  });
+});

--- a/libs/toastmark/src/commonmark/blockStarts.ts
+++ b/libs/toastmark/src/commonmark/blockStarts.ts
@@ -160,6 +160,7 @@ const atxHeading: BlockStart = parser => {
 
     const container = parser.addChild('heading', parser.nextNonspace) as HeadingNode;
     container.level = match[0].trim().length; // number of #s
+    container.headingType = 'atx';
     // remove trailing ###s:
     container.stringContent = parser.currentLine
       .slice(parser.offset)
@@ -244,6 +245,7 @@ const seTextHeading: BlockStart = (parser, container) => {
     if (container.stringContent.length > 0) {
       const heading = createNode('heading', container.sourcepos);
       heading.level = match[0][0] === '=' ? 1 : 2;
+      heading.headingType = 'setext';
       heading.stringContent = container.stringContent;
       container.insertAfter(heading);
       container.unlink();

--- a/libs/toastmark/src/commonmark/node.ts
+++ b/libs/toastmark/src/commonmark/node.ts
@@ -222,6 +222,7 @@ export class ListNode extends BlockNode {
 
 export class HeadingNode extends BlockNode {
   public level = 0;
+  public headingType: 'atx' | 'setext' = 'atx';
 }
 
 export class LinkNode extends Node {


### PR DESCRIPTION
# Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
- fix: markdown syntax highlighting for setext heading

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
