### PR TITLE
fix: markdown syntax highlighting for extended autolinks

### DIFF
--- a/apps/editor/src/js/markTextHelper.js
+++ b/apps/editor/src/js/markTextHelper.js
@@ -90,10 +90,13 @@ function image({ lastChild }, start, end) {
   };
 }
 
-function link({ lastChild }, start, end) {
+function link({ lastChild, extendedAutolink }, start, end) {
   const lastChildCh = lastChild ? getMdEndCh(lastChild) + 1 : 2; // 2: length of '[]'
+  const marks = extendedAutolink
+    ? [markInfo(start, end, `${cls('link', 'link-desc')} ${classNameMap.TEXT}`)]
+    : markLink(start, end, start, lastChildCh);
 
-  return { marks: markLink(start, end, start, lastChildCh) };
+  return { marks };
 }
 
 function code({ tickCount }, start, end) {

--- a/libs/toastmark/src/commonmark/gfm/__test__/autolinks.spec.ts
+++ b/libs/toastmark/src/commonmark/gfm/__test__/autolinks.spec.ts
@@ -216,6 +216,7 @@ describe('custom autolink parser', () => {
 
     expect(link1).toMatchObject({
       destination: 'num:111',
+      extendedAutolink: true,
       sourcepos: pos(1, 3, 1, 5),
       firstChild: {
         literal: '111'
@@ -224,6 +225,7 @@ describe('custom autolink parser', () => {
 
     expect(link2).toMatchObject({
       destination: 'num:222',
+      extendedAutolink: true,
       sourcepos: pos(1, 9, 1, 11),
       firstChild: {
         literal: '222'
@@ -244,18 +246,17 @@ describe('GFM Examples', () => {
     const link = root.firstChild!.firstChild as LinkNode;
     const linkText = link.firstChild!;
 
-    expect(link.type).toBe('link');
-    expect(link.destination).toBe('http://www.commonmark.org');
-    expect(link.sourcepos).toEqual([
-      [1, 1],
-      [1, 18]
-    ]);
+    expect(link).toMatchObject({
+      type: 'link',
+      destination: 'http://www.commonmark.org',
+      extendedAutolink: true,
+      sourcepos: pos(1, 1, 1, 18)
+    });
 
-    expect(linkText.literal).toBe('www.commonmark.org');
-    expect(linkText.sourcepos).toEqual([
-      [1, 1],
-      [1, 18]
-    ]);
+    expect(linkText).toMatchObject({
+      literal: 'www.commonmark.org',
+      sourcepos: pos(1, 1, 1, 18)
+    });
 
     const html = render(root);
     expect(html).toBe('<p><a href="http://www.commonmark.org">www.commonmark.org</a></p>\n');
@@ -269,24 +270,18 @@ describe('GFM Examples', () => {
     const text2 = link.next!;
 
     expect(text1.literal).toBe('Visit ');
-    expect(link.type).toBe('link');
-    expect(link.destination).toBe('http://www.commonmark.org/help');
-    expect(link.sourcepos).toEqual([
-      [1, 7],
-      [1, 29]
-    ]);
+    expect(link).toMatchObject({
+      type: 'link',
+      extendedAutolink: true,
+      destination: 'http://www.commonmark.org/help',
+      sourcepos: pos(1, 7, 1, 29)
+    });
 
     expect(linkText.literal).toBe('www.commonmark.org/help');
-    expect(linkText.sourcepos).toEqual([
-      [1, 7],
-      [1, 29]
-    ]);
+    expect(linkText.sourcepos).toEqual(pos(1, 7, 1, 29));
 
     expect(text2.literal).toBe(' for more information.');
-    expect(text2.sourcepos).toEqual([
-      [1, 30],
-      [1, 51]
-    ]);
+    expect(text2.sourcepos).toEqual(pos(1, 30, 1, 51));
 
     const html = render(root);
     expect(html).toBe(

--- a/libs/toastmark/src/commonmark/gfm/autoLinks.ts
+++ b/libs/toastmark/src/commonmark/gfm/autoLinks.ts
@@ -121,6 +121,7 @@ export function convertExtAutoLinks(walker: NodeWalker, autolinkParser: boolean 
         const linkNode = createNode('link', sourcepos(...range));
         linkNode.appendChild(text(linkText, sourcepos(...range)));
         linkNode.destination = url;
+        linkNode.extendedAutolink = true;
         newNodes.push(linkNode);
         lastIdx = range[1] + 1;
       }

--- a/libs/toastmark/src/commonmark/node.ts
+++ b/libs/toastmark/src/commonmark/node.ts
@@ -228,6 +228,7 @@ export class HeadingNode extends BlockNode {
 export class LinkNode extends Node {
   public destination: string | null = null;
   public title: string | null = null;
+  public extendedAutolink = false;
 }
 
 export class CodeBlockNode extends BlockNode {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
- fix: markdown syntax highlighting for extended autolinks

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
