### PR TITLE
fix: edit inline code style

### DIFF
--- a/apps/editor/src/css/contents.css
+++ b/apps/editor/src/css/contents.css
@@ -208,7 +208,7 @@
 .tui-editor-contents ul > li::before {
   content: '';
   margin-top: 6px;
-  margin-left: -1em;
+  margin-left: -0.9em;
   width: 5px;
   height: 5px;
   border-radius: 50%;

--- a/apps/editor/src/css/md-syntax-highlighting.css
+++ b/apps/editor/src/css/md-syntax-highlighting.css
@@ -62,7 +62,8 @@
   color: #ccc;
 }
 
-.tui-md-code-block.tui-md-meta {
+.tui-md-code-block.tui-md-meta,
+.tui-md-code.tui-md-delimiter {
   color: #aaa;
 }
 
@@ -97,7 +98,7 @@
 }
 
 .tui-md-code {
-  background-color: #f9f2f4;
+  background-color: rgba(193, 121, 139, 0.1);
   padding: 2px 0;
   letter-spacing: -0.3px;
 }
@@ -120,8 +121,8 @@
   background-color: #f5f7f8;
 }
 
-.tui-md-code.tui-md-marked-text,
-.tui-md-code-block.tui-md-marked-text {
-  font-family: Consolas, Courier, 'Apple SD 산돌고딕 Neo', -apple-system, 'Lucida Grande',
-    'Apple SD Gothic Neo', '맑은 고딕', 'Malgun Gothic', 'Segoe UI', '돋움', dotum, sans-serif;
+.tui-md-code,
+.tui-md-code-block {
+  font-family: Consolas, Courier, 'Lucida Grande', '나눔바른고딕', 'Nanum Barun Gothic', '맑은고딕',
+    'Malgun Gothic', sans-serif;
 }

--- a/apps/editor/src/css/old/contents.css
+++ b/apps/editor/src/css/old/contents.css
@@ -92,8 +92,8 @@
 
 .tui-editor-contents pre,
 .tui-editor-contents code {
-  font-family: Consolas, Courier, 'Apple SD 산돌고딕 Neo', -apple-system, 'Lucida Grande',
-    'Apple SD Gothic Neo', '맑은 고딕', 'Malgun Gothic', 'Segoe UI', '돋움', dotum, sans-serif;
+  font-family: Consolas, Courier, 'Lucida Grande', '나눔바른고딕', 'Nanum Barun Gothic', '맑은고딕',
+    'Malgun Gothic', sans-serif;
   border: 0;
   border-radius: 0;
 }


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description

* To solve the selection problem, change the background color of the inline code to use `rgba` in the markdown editor.
* The delimiter's font style is unified with the code text.

**Before**

![스크린샷 2020-04-23 오전 1 36 16](https://user-images.githubusercontent.com/18183560/80048647-bab9c680-854b-11ea-9a5c-cf56011029da.png)

**After**

![스크린샷 2020-04-23 오전 1 33 26](https://user-images.githubusercontent.com/18183560/80048650-c3aa9800-854b-11ea-9f93-9cc589e54605.png)
![스크린샷 2020-04-23 오전 1 33 03](https://user-images.githubusercontent.com/18183560/80048658-c73e1f00-854b-11ea-8bcd-cab9cc911c5a.png)



---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
