### PR TITLE
fix: cannot apply linkAttribute to wysiwyg editor

### DIFF
--- a/apps/editor/src/js/codemirror/continuelist.js
+++ b/apps/editor/src/js/codemirror/continuelist.js
@@ -31,6 +31,7 @@ CodeMirror.commands.newlineAndIndentContinueMarkdownList = function(cm) {
   if (cm.getOption('disableInput') || !!cm.state.isCursorInCodeBlock) return CodeMirror.Pass;
   var ranges = cm.listSelections(),
     replacements = [];
+
   for (var i = 0; i < ranges.length; i++) {
     var pos = ranges[i].head;
     var line = cm.getLine(pos.line),

--- a/apps/editor/src/js/codemirror/continuelist.js
+++ b/apps/editor/src/js/codemirror/continuelist.js
@@ -31,7 +31,6 @@ CodeMirror.commands.newlineAndIndentContinueMarkdownList = function(cm) {
   if (cm.getOption('disableInput') || !!cm.state.isCursorInCodeBlock) return CodeMirror.Pass;
   var ranges = cm.listSelections(),
     replacements = [];
-  
   for (var i = 0; i < ranges.length; i++) {
     var pos = ranges[i].head;
     var line = cm.getLine(pos.line),

--- a/apps/editor/src/js/wysiwygEditor.js
+++ b/apps/editor/src/js/wysiwygEditor.js
@@ -56,13 +56,11 @@ class WysiwygEditor {
     this.editorContainerEl = el;
 
     this._height = 0;
-    this._linkAttribute = options.linkAttribute;
-
     this._silentChange = false;
 
     this._keyEventHandlers = {};
     this._managers = {};
-    this._linkAttribute = {};
+    this._linkAttribute = options.linkAttribute;
 
     this._initEvent();
     this._initDefaultKeyEventHandler();

--- a/apps/editor/src/js/wysiwygEditor.js
+++ b/apps/editor/src/js/wysiwygEditor.js
@@ -60,7 +60,7 @@ class WysiwygEditor {
 
     this._keyEventHandlers = {};
     this._managers = {};
-    this._linkAttribute = options.linkAttribute;
+    this._linkAttribute = options.linkAttribute || {};
 
     this._initEvent();
     this._initDefaultKeyEventHandler();

--- a/apps/editor/test/unit/wysiwygCommands/addLink.spec.js
+++ b/apps/editor/test/unit/wysiwygCommands/addLink.spec.js
@@ -10,10 +10,12 @@ describe('AddLink', () => {
   let container, wwe;
 
   beforeEach(() => {
+    const linkAttribute = { target: '_blank' };
+
     container = document.createElement('div');
     document.body.appendChild(container);
 
-    wwe = new WysiwygEditor(container, new EventManager());
+    wwe = new WysiwygEditor(container, new EventManager(), { linkAttribute });
 
     wwe.init();
     wwe.getEditor().focus();
@@ -90,5 +92,19 @@ describe('AddLink', () => {
         .querySelector('a')
         .getAttribute('href')
     ).toEqual('%28%29%5B%5D%3C%3E');
+  });
+
+  it('should apply linkAttribute option to link node', () => {
+    AddLink.exec(wwe, {
+      url: 'https://www.google.com',
+      linkText: 'google'
+    });
+
+    expect(
+      wwe
+        .getBody()
+        .querySelector('a')
+        .getAttribute('target')
+    ).toEqual('_blank');
   });
 });


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
* It is not possible to apply `linkAttribute` to wysiwyg editor. The cause of this problem is that `linkAttribute` is always initialized with empty object.


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
