### PR TITLE
feat: `disallowDeepHeading` option

### DIFF
--- a/apps/editor/src/js/convertor.js
+++ b/apps/editor/src/js/convertor.js
@@ -37,7 +37,8 @@ class Convertor {
     this.mdReader = new Parser({
       extendedAutolinks,
       disallowedHtmlBlockTags: ['br'],
-      useReferenceDefinition
+      useReferenceDefinition,
+      disallowDeepHeading: true
     });
 
     this.renderHTML = createRenderHTML({

--- a/apps/editor/src/js/editor.js
+++ b/apps/editor/src/js/editor.js
@@ -214,7 +214,8 @@ class ToastUIEditor {
     this.toastMark = new ToastMark('', {
       disallowedHtmlBlockTags: ['br'],
       extendedAutolinks,
-      useReferenceDefinition
+      useReferenceDefinition,
+      disallowDeepHeading: true
     });
 
     this.mdEditor = MarkdownEditor.factory(

--- a/apps/editor/src/js/markdownToHTML.js
+++ b/apps/editor/src/js/markdownToHTML.js
@@ -7,7 +7,8 @@ export function createMarkdownToHTML(options) {
   const parser = new Parser({
     disallowedHtmlBlockTags: ['br'],
     extendedAutolinks,
-    useReferenceDefinition
+    useReferenceDefinition,
+    disallowDeepHeading: true
   });
 
   const renderHTML = createRenderHTML({

--- a/apps/editor/test/unit/editor.spec.js
+++ b/apps/editor/test/unit/editor.spec.js
@@ -525,5 +525,43 @@ describe('Editor', () => {
         expect(editor.getHtml()).toBe('<p><a href="test">foo</a></p>\n');
       });
     });
+
+    describe('disallowDeepHeading internal parsing option', () => {
+      it('should disallow the nested seTextHeading in list', () => {
+        editor = new Editor({
+          el: container,
+          initialValue: '- item1\n\t-'
+        });
+
+        expect(editor.getHtml()).toBe('<ul>\n<li>\n<p>item1<br>\n-</p>\n</li>\n</ul>\n');
+      });
+
+      it('should disallow the nested atxHeading in list', () => {
+        editor = new Editor({
+          el: container,
+          initialValue: '- # item1'
+        });
+
+        expect(editor.getHtml()).toBe('<ul>\n<li>\n<p># item1</p>\n</li>\n</ul>\n');
+      });
+    });
+
+    it('should disallow the nested seTextHeading in blockquote', () => {
+      editor = new Editor({
+        el: container,
+        initialValue: '> item1\n> -'
+      });
+
+      expect(editor.getHtml()).toBe('<blockquote>\n<p>item1<br>\n-</p>\n</blockquote>\n');
+    });
+
+    it('should disallow the nested atxHeading in blockquote', () => {
+      editor = new Editor({
+        el: container,
+        initialValue: '> # item1'
+      });
+
+      expect(editor.getHtml()).toBe('<blockquote>\n<p># item1</p>\n</blockquote>\n');
+    });
   });
 });

--- a/libs/toastmark/src/commonmark/__test__/options.spec.ts
+++ b/libs/toastmark/src/commonmark/__test__/options.spec.ts
@@ -1,4 +1,5 @@
 import { Parser } from '../blocks';
+import { pos } from './helper.spec';
 
 it('tags in disallowedHtmlBlockTags should not be parsed as a HTML block', () => {
   const reader = new Parser({ disallowedHtmlBlockTags: ['br', 'span'] });
@@ -34,5 +35,128 @@ it('tags in disallowedHtmlBlockTags should not be parsed as a HTML block', () =>
         }
       }
     }
+  });
+});
+
+describe('disallowDeepHeading: true', () => {
+  it('the nested seTextHeading is disallowed in list', () => {
+    const reader = new Parser({ disallowDeepHeading: true });
+    const root = reader.parse('- item1\n\t-');
+
+    expect(root).toMatchObject({
+      type: 'document',
+      firstChild: {
+        type: 'list',
+        firstChild: {
+          type: 'item',
+          listData: {
+            bulletChar: '-',
+            markerOffset: 0,
+            padding: 2,
+            start: 0,
+            type: 'bullet'
+          },
+          firstChild: {
+            type: 'paragraph',
+            sourcepos: pos(1, 3, 2, 2),
+            firstChild: {
+              type: 'text',
+              literal: 'item1',
+              next: {
+                type: 'softbreak',
+                next: {
+                  type: 'text',
+                  literal: '-',
+                  sourcepos: pos(2, 2, 2, 2)
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+  });
+
+  it('the nested atxHeading is disallowed in list', () => {
+    const reader = new Parser({ disallowDeepHeading: true });
+    const root = reader.parse('- # item1');
+
+    expect(root).toMatchObject({
+      type: 'document',
+      firstChild: {
+        type: 'list',
+        firstChild: {
+          type: 'item',
+          listData: {
+            bulletChar: '-',
+            markerOffset: 0,
+            padding: 2,
+            start: 0,
+            type: 'bullet'
+          },
+          firstChild: {
+            type: 'paragraph',
+            sourcepos: pos(1, 3, 1, 9),
+            firstChild: {
+              type: 'text',
+              literal: '# item1',
+              sourcepos: pos(1, 3, 1, 9)
+            }
+          }
+        }
+      }
+    });
+  });
+
+  it('the nested seTextHeading is disallowed in blockquote', () => {
+    const reader = new Parser({ disallowDeepHeading: true });
+    const root = reader.parse('> item1\n> -');
+
+    expect(root).toMatchObject({
+      type: 'document',
+      firstChild: {
+        type: 'blockQuote',
+        sourcepos: pos(1, 1, 2, 3),
+        firstChild: {
+          type: 'paragraph',
+          sourcepos: pos(1, 3, 2, 3),
+          firstChild: {
+            type: 'text',
+            literal: 'item1',
+            sourcepos: pos(1, 3, 1, 7),
+            next: {
+              type: 'softbreak',
+              next: {
+                type: 'text',
+                literal: '-',
+                sourcepos: pos(2, 3, 2, 3)
+              }
+            }
+          }
+        }
+      }
+    });
+  });
+
+  it('the nested atxHeading is disallowed in blockquote', () => {
+    const reader = new Parser({ disallowDeepHeading: true });
+    const root = reader.parse('> # item1');
+
+    expect(root).toMatchObject({
+      type: 'document',
+      firstChild: {
+        type: 'blockQuote',
+        sourcepos: pos(1, 1, 1, 9),
+        firstChild: {
+          type: 'paragraph',
+          sourcepos: pos(1, 3, 1, 9),
+          firstChild: {
+            type: 'text',
+            literal: '# item1',
+            sourcepos: pos(1, 3, 1, 9)
+          }
+        }
+      }
+    });
   });
 });

--- a/libs/toastmark/src/commonmark/blockStarts.ts
+++ b/libs/toastmark/src/commonmark/blockStarts.ts
@@ -159,7 +159,7 @@ const atxHeading: BlockStart = (parser, container) => {
     !parser.indented &&
     (match = parser.currentLine.slice(parser.nextNonspace).match(reATXHeadingMarker))
   ) {
-    // The nested Heading is disallowed in list and blockquote with 'disallowedDeepHeading' option
+    // The nested Heading is disallowed in list and blockquote with 'disallowDeepHeading' option
     if (isDisallowedDeepHeading(parser, container)) {
       return Matched.Skip;
     }
@@ -242,7 +242,7 @@ const seTextHeading: BlockStart = (parser, container) => {
     container.type === 'paragraph' &&
     (match = parser.currentLine.slice(parser.nextNonspace).match(reSetextHeadingLine))
   ) {
-    // The nested Heading is disallowed in list and blockquote with 'disallowedDeepHeading' option
+    // The nested Heading is disallowed in list and blockquote with 'disallowDeepHeading' option
     if (isDisallowedDeepHeading(parser, container.parent as BlockNode)) {
       return Matched.Skip;
     }

--- a/libs/toastmark/src/commonmark/blockStarts.ts
+++ b/libs/toastmark/src/commonmark/blockStarts.ts
@@ -25,8 +25,7 @@ import { tableHead, tableBody } from './gfm/tableBlockStart';
 export const enum Matched {
   None = 0, // No Match
   Container, // Keep Going
-  Leaf, // No more block starts
-  Skip // Skip the block
+  Leaf // No more block starts
 }
 export interface BlockStart {
   (parser: Parser, container: BlockNode): Matched;
@@ -161,7 +160,7 @@ const atxHeading: BlockStart = (parser, container) => {
   ) {
     // The nested Heading is disallowed in list and blockquote with 'disallowDeepHeading' option
     if (isDisallowedDeepHeading(parser, container)) {
-      return Matched.Skip;
+      return Matched.None;
     }
     parser.advanceNextNonspace();
     parser.advanceOffset(match[0].length, false);
@@ -244,7 +243,7 @@ const seTextHeading: BlockStart = (parser, container) => {
   ) {
     // The nested Heading is disallowed in list and blockquote with 'disallowDeepHeading' option
     if (isDisallowedDeepHeading(parser, container.parent as BlockNode)) {
-      return Matched.Skip;
+      return Matched.None;
     }
     parser.closeUnmatchedBlocks();
     // resolve reference link definitions

--- a/libs/toastmark/src/commonmark/blocks.ts
+++ b/libs/toastmark/src/commonmark/blocks.ts
@@ -314,13 +314,9 @@ export class Parser {
       }
 
       let i = 0;
-      let skipped = false;
       while (i < blockStartsLen) {
         const res = blockStarts[i](this, container);
-        if (res === Matched.Skip) {
-          skipped = true;
-          break;
-        } else if (res === Matched.Container) {
+        if (res === Matched.Container) {
           container = this.tip;
           break;
         } else if (res === Matched.Leaf) {
@@ -332,7 +328,7 @@ export class Parser {
         }
       }
 
-      if (skipped || i === blockStartsLen) {
+      if (i === blockStartsLen) {
         // nothing matched
         this.advanceNextNonspace();
         break;

--- a/libs/toastmark/src/commonmark/blocks.ts
+++ b/libs/toastmark/src/commonmark/blocks.ts
@@ -40,7 +40,8 @@ const defaultOptions = {
   tagFilter: false,
   extendedAutolinks: false,
   disallowedHtmlBlockTags: [],
-  useReferenceDefinition: false
+  useReferenceDefinition: false,
+  disallowDeepHeading: false
 };
 
 export interface Options {
@@ -49,6 +50,7 @@ export interface Options {
   extendedAutolinks: boolean | AutolinkParser;
   disallowedHtmlBlockTags: string[];
   useReferenceDefinition: boolean;
+  disallowDeepHeading: boolean;
 }
 
 export class Parser {
@@ -312,9 +314,13 @@ export class Parser {
       }
 
       let i = 0;
+      let skipped = false;
       while (i < blockStartsLen) {
         const res = blockStarts[i](this, container);
-        if (res === Matched.Container) {
+        if (res === Matched.Skip) {
+          skipped = true;
+          break;
+        } else if (res === Matched.Container) {
           container = this.tip;
           break;
         } else if (res === Matched.Leaf) {
@@ -326,7 +332,7 @@ export class Parser {
         }
       }
 
-      if (i === blockStartsLen) {
+      if (skipped || i === blockStartsLen) {
         // nothing matched
         this.advanceNextNonspace();
         break;

--- a/libs/toastmark/src/commonmark/gfm/tableBlockStart.ts
+++ b/libs/toastmark/src/commonmark/gfm/tableBlockStart.ts
@@ -95,11 +95,13 @@ export const tableHead: BlockStart = (parser, container) => {
     const reValidDelimCell = /^[ \t]*:?-+:?[ \t]*$/;
 
     if (
-      !headerCells.length ||
-      !delimCells.length ||
-      delimCells.some(cell => !reValidDelimCell.test(cell))
       // not checking if the number of header cells and delimiter cells are the same
       // to consider the case of merged-column (via plugin)
+      !headerCells.length ||
+      !delimCells.length ||
+      delimCells.some(cell => !reValidDelimCell.test(cell)) ||
+      // to prevent to regard setTextHeading as tabel delim cell with 'disallowDeepHeading' option
+      (delimCells.length === 1 && delimContent.indexOf('|') !== 0)
     ) {
       return Matched.None;
     }


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
* added `disallowDeepHeading` option to `toastmark` for preventing to define heading(`atx`, `setText`) node in **list** or **blockquote**.
* editor's `disallowDeepHeading` internal option is always `true`

**before**
<img width="1421" alt="스크린샷 2020-04-23 오후 8 00 01" src="https://user-images.githubusercontent.com/37766175/80092187-4f004980-859d-11ea-87ac-bb67158f8f9e.png">

**after**
<img width="1428" alt="스크린샷 2020-04-23 오후 7 58 44" src="https://user-images.githubusercontent.com/37766175/80092204-56275780-859d-11ea-93d8-033a2ca9ff49.png">


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
