### PR TITLE
fix: not working shortcut of codemirror in markdown editor

### DIFF
--- a/apps/editor/src/js/codeMirrorExt.js
+++ b/apps/editor/src/js/codeMirrorExt.js
@@ -42,21 +42,20 @@ class CodeMirrorExt {
 
     this.editorContainerEl.appendChild(cmTextarea);
 
-    options = extend(
-      {
-        lineWrapping: true,
-        theme: 'default',
-        extraKeys: {
-          'Shift-Tab': 'indentLess',
-          'Alt-Up': 'replaceLineTextToUpper',
-          'Alt-Down': 'replaceLineTextToLower'
-        },
-        indentUnit: 4,
-        cursorScrollMargin: 12,
-        specialCharPlaceholder: () => document.createElement('span')
+    options = {
+      ...options,
+      lineWrapping: true,
+      theme: 'default',
+      extraKeys: {
+        ...options.extraKeys,
+        'Shift-Tab': 'indentLess',
+        'Alt-Up': 'replaceLineTextToUpper',
+        'Alt-Down': 'replaceLineTextToLower'
       },
-      options
-    );
+      indentUnit: 4,
+      cursorScrollMargin: 12,
+      specialCharPlaceholder: () => document.createElement('span')
+    };
 
     this.cm = CodeMirror.fromTextArea(cmTextarea, options);
   }


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description

* When CodeMirror is created, the `extraKey` value is overwritten and the shortcut does not work in the markdown editor.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
