### PR TITLE
fix: remove content in codeBlock when pressing the tab key

### DIFF
--- a/apps/editor/src/js/codemirror/continuelist.js
+++ b/apps/editor/src/js/codemirror/continuelist.js
@@ -18,7 +18,7 @@ CodeMirror.commands.indentOrderedList = function(cm) {
     var line = cm.getLine(pos.line);
     var cursorBeforeTextInline = line.substr(0, pos.ch);
 
-    if (!cm.state.isCursorInCodeBlock && (listRE.test(cursorBeforeTextInline) || cm.somethingSelected())) {
+    if ((listRE.test(cursorBeforeTextInline) || cm.somethingSelected())) {
       cm.indentSelection('add');
     } else {
       cm.execCommand('insertSoftTab');


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
* fixed that removing content in `codeBlock` when pressing the tab key


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
