### PR TITLE
fix: remove paragraph from tight list item

### DIFF
--- a/apps/editor/src/js/htmlRenderConvertors.js
+++ b/apps/editor/src/js/htmlRenderConvertors.js
@@ -1,10 +1,16 @@
 const baseConvertors = {
-  paragraph(_, { entering }) {
-    return {
-      type: entering ? 'openTag' : 'closeTag',
-      outerNewLine: true,
-      tagName: 'p'
-    };
+  paragraph(_, { entering, origin, options }) {
+    // prevent paragraph from being removed when it's child of tight list item
+    // to show highlight style in live-preview mode
+    if (options.nodeId) {
+      return {
+        type: entering ? 'openTag' : 'closeTag',
+        outerNewLine: true,
+        tagName: 'p'
+      };
+    }
+
+    return origin();
   },
 
   softbreak(node) {

--- a/apps/editor/test/unit/convertor.spec.js
+++ b/apps/editor/test/unit/convertor.spec.js
@@ -165,12 +165,8 @@ describe('Convertor', () => {
       const taskItemMd = ['- [ ] Task1', '- [x] Task2'].join('\n');
       const expectedHTML = [
         '<ul>',
-        '<li class="task-list-item" data-te-task="">',
-        '<p>Task1</p>',
-        '</li>',
-        '<li class="task-list-item checked" data-te-task="">',
-        '<p>Task2</p>',
-        '</li>',
+        '<li class="task-list-item" data-te-task="">Task1</li>',
+        '<li class="task-list-item checked" data-te-task="">Task2</li>',
         '</ul>',
         ''
       ].join('\n');
@@ -675,14 +671,10 @@ describe('Convertor', () => {
       ].join('\n');
       const expectedHTML = [
         '<ul>',
-        '<li>',
-        '<p>codeblock</p>',
-        '</li>',
+        '<li>codeblock</li>',
         '</ul>',
         '<ol>',
-        '<li>',
-        '<p>codeblock</p>',
-        '</li>',
+        '<li>codeblock</li>',
         '</ol>',
         '<p>paragraph</p>',
         '<pre><code>code',

--- a/apps/editor/test/unit/editor.spec.js
+++ b/apps/editor/test/unit/editor.spec.js
@@ -533,7 +533,7 @@ describe('Editor', () => {
           initialValue: '- item1\n\t-'
         });
 
-        expect(editor.getHtml()).toBe('<ul>\n<li>\n<p>item1<br>\n-</p>\n</li>\n</ul>\n');
+        expect(editor.getHtml()).toBe('<ul>\n<li>item1<br>\n-</li>\n</ul>\n');
       });
 
       it('should disallow the nested atxHeading in list', () => {
@@ -542,7 +542,7 @@ describe('Editor', () => {
           initialValue: '- # item1'
         });
 
-        expect(editor.getHtml()).toBe('<ul>\n<li>\n<p># item1</p>\n</li>\n</ul>\n');
+        expect(editor.getHtml()).toBe('<ul>\n<li># item1</li>\n</ul>\n');
       });
     });
 

--- a/apps/editor/test/unit/markdownCustomRenderer.spec.js
+++ b/apps/editor/test/unit/markdownCustomRenderer.spec.js
@@ -56,16 +56,16 @@ describe('Custom HTMLRender', () => {
       expect(container.querySelectorAll('ul').length).toBe(1);
       expect(lis.length).toBe(3);
       expect(li0.getAttribute('data-te-task')).toBe('');
-      expect(li0.firstElementChild.textContent).toBe('study');
+      expect(li0.textContent).toBe('study');
       expect(hasClass(li0, 'task-list-item')).toBe(true);
       expect(hasClass(li0, 'checked')).toBe(false);
 
-      expect(li1.firstElementChild.textContent).toBe('workout');
+      expect(li1.textContent).toBe('workout');
       expect(li1.getAttribute('data-te-task')).toBe('');
       expect(hasClass(li1, 'task-list-item')).toBe(true);
       expect(hasClass(li1, 'checked')).toBe(true);
 
-      expect(li2.firstElementChild.textContent).toBe('eat breakfast');
+      expect(li2.textContent).toBe('eat breakfast');
       expect(li2.getAttribute('data-te-task')).toBe('');
       expect(hasClass(li2, 'task-list-item')).toBe(true);
       expect(hasClass(li2, 'checked')).toBe(true);

--- a/apps/editor/test/unit/mdPreview.spec.js
+++ b/apps/editor/test/unit/mdPreview.spec.js
@@ -93,6 +93,16 @@ describe('listen cursorActivity event', () => {
     assertHighlighted('P', 'World');
   });
 
+  it('paragraph inside tight list item should not be removed', () => {
+    setValue('- Item1\n- Item2');
+
+    setCursor({ line: 0, ch: 3 });
+    expect(assertHighlighted('P', 'Item1'));
+
+    setCursor({ line: 1, ch: 3 });
+    expect(assertHighlighted('P', 'Item2'));
+  });
+
   describe('table cell', () => {
     beforeEach(() => {
       setValue('| a | b |\n| - | - |\n| c | d |\n\n');


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description
- Remove paragraph from tight list items (only when `options.nodeId` is `false`)

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
