### PR TITLE
feat: improve types, close #970

### DIFF
--- a/apps/editor/examples/example19-customizing-toolbar-buttons.html
+++ b/apps/editor/examples/example19-customizing-toolbar-buttons.html
@@ -88,8 +88,8 @@
       // Using Method: Customize the first button
       const toolbar = editor.getUI().getToolbar();
 
-      editor.eventManager.addEventType('clickCustomButton');
-      editor.eventManager.listen('clickCustomButton', function() {
+      editor.addEventType('clickCustomButton');
+      editor.on('clickCustomButton', function() {
         alert('Click!');
       });
 

--- a/apps/editor/index.d.ts
+++ b/apps/editor/index.d.ts
@@ -570,8 +570,19 @@ declare namespace toastui {
     public styleToSelectedCells(onStyle: SquireExt, options?: object): void;
   }
 
+  interface MarkdownRange {
+    from: CodeMirror.Position;
+    to: CodeMirror.Position;
+    ollapsed: boolean;
+  }
+
+  class CodeMirrorExt {
+    getCurrentRange(): MarkdownRange;
+    getEditor(): CodeMirrorType;
+  }
+
   // @TODO: change toastMark type definition to @toast-ui/toastmark type file through importing
-  class MarkdownEditor {
+  class MarkdownEditor extends CodeMirrorExt {
     static factory(
       el: HTMLElement,
       eventManager: EventManager,

--- a/apps/editor/index.d.ts
+++ b/apps/editor/index.d.ts
@@ -835,8 +835,6 @@ declare namespace toastui {
 
     public setMarkdown(markdown: string): void;
 
-    public setValue(markdown: string): void;
-
     public setCodeBlockLanguages(languages?: string[]): void;
   }
 }

--- a/apps/editor/index.d.ts
+++ b/apps/editor/index.d.ts
@@ -729,6 +729,12 @@ declare namespace toastui {
 
     public addWidget(selection: Range, node: Node, style: string, offset?: number): void;
 
+    public addCommand(type: Command): void;
+
+    public addCommand(type: string, props: CommandPropsOptions): void;
+
+    public addEventType(type: string): void;
+
     public afterAddedCommand(): void;
 
     public blur(): void;

--- a/apps/editor/index.d.ts
+++ b/apps/editor/index.d.ts
@@ -8,7 +8,7 @@ declare namespace toastui {
   type HandlerFunc = (...args: any[]) => void;
   type ReplacerFunc = (inputString: string) => string;
   type CodeMirrorType = CodeMirror.EditorFromTextArea;
-  type CommandManagerExecFunc = (name: string, ...args: any[]) => any;
+  type CommandManagerExecFunc = (editor: Editor | MarkdownEditor | WysiwygEditor, ...args: any[]) => any;
   type PopupTableUtils = LayerPopup;
   type AddImageBlobHook = (fileOrBlob: File | Blob, callback: Function, source: string) => void;
   type Plugin = (editor: Editor | Viewer, options: any) => void;

--- a/apps/editor/index.d.ts
+++ b/apps/editor/index.d.ts
@@ -695,7 +695,7 @@ declare namespace toastui {
   class EventManager {
     public addEventType(type: string): void;
 
-    public emit(eventName: string): any[];
+    public emit(eventName: string, ...args: any): any[];
 
     public emitReduce(eventName: string, sourceText: string): string;
 

--- a/apps/editor/src/js/editor.js
+++ b/apps/editor/src/js/editor.js
@@ -365,6 +365,14 @@ class ToastUIEditor {
   }
 
   /**
+   * Add event type when given event not exists
+   * @param {string} type Event type name
+   */
+  addEventType(type) {
+    this.eventManager.addEventType(type);
+  }
+
+  /**
    * After added command.
    */
   afterAddedCommand() {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description

As discussed in #970, I've found some types that I'd like to change. I've left each separate change in its own commit for easier discussion / reversion if necessary. I've tried to mark whether it was a fix (type was wrong) or feat (new public type).

setValue was present under the functions of Viewer, but calling it crashed the application as it doesn't exist any more.

When using custom events, you can pass additional arguments through emit. The first arg is always the name of the event, so I left it in.

eventManager wasn't available under Editor: I added a method to call-through for the method you need to call when adding a custom button, and updated the example to use it. I also noted that addCommand should be public: there is the same issue with commandManager.

CommandManagerExecFunc incorrectly said the first argument was a string -- I think it's actually one of Editor (for global commands), MarkdownEditor (for markdown commands) or WysiwygEditor (for wysiwyg commands).

Finally, there are some methods in MarkdownEditor that are accessible through CodeMirrorExt (that MarkdownEditor extends) that are useful when writing custom commands. I added the two I used.

Closes #970

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
