### PR TITLE
fix: remove type of setValue method from Editor and Viewer (fix #970)

### DIFF
--- a/apps/editor/index.d.ts
+++ b/apps/editor/index.d.ts
@@ -799,8 +799,6 @@ declare namespace toastui {
 
     public setUI(UI: UI): void;
 
-    public setValue(value: string, cursorToEnd?: boolean): void;
-
     public show(): void;
 
     public setCodeBlockLanguages(languages?: string[]): void;
@@ -834,8 +832,6 @@ declare namespace toastui {
     public remove(): void;
 
     public setMarkdown(markdown: string): void;
-
-    public setValue(markdown: string): void;
 
     public setCodeBlockLanguages(languages?: string[]): void;
   }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description

Split out from #974: includes removing setValue from Editor and Viewer only.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
