### PR TITLE
fix: stored xss in wysiwyg mode only while removing blockquotes pr (fix #1021)

### DIFF
--- a/apps/editor/src/js/wwCodeBlockManager.js
+++ b/apps/editor/src/js/wwCodeBlockManager.js
@@ -351,7 +351,7 @@ class WwCodeBlockManager {
       const firstDiv = document.createElement('div');
       const firstLine = strArray.shift();
 
-      firstDiv.innerHTML = `${firstLine}${brString}`;
+      firstDiv.innerHTML = `${sanitizeHtmlCode(firstLine)}${brString}`;
       newFrag.appendChild(firstDiv);
 
       if (strArray.length) {

--- a/apps/editor/test/unit/wwCodeBlockManager.spec.js
+++ b/apps/editor/test/unit/wwCodeBlockManager.spec.js
@@ -156,6 +156,31 @@ describe('WwCodeBlockManager', () => {
         expect(wwe.getBody().querySelectorAll('pre').length).toEqual(2);
       });
     });
+
+    it('_onBackspaceKeyEventHandler() sanitize HTML properly when removing codeblock ', () => {
+      const range = wwe
+        .getEditor()
+        .getSelection()
+        .cloneRange();
+
+      wwe.setValue('<pre><svg></svg></pre>');
+
+      range.setStart(wwe.getBody().querySelectorAll('pre')[0].childNodes[0], 0);
+      range.collapse(true);
+
+      wwe.getEditor().setSelection(range);
+
+      em.emit('wysiwygKeyEvent', {
+        keyMap: 'BACK_SPACE',
+        data: {
+          preventDefault: () => {}
+        }
+      });
+
+      expect(wwe.getBody().querySelectorAll('div').length).toEqual(2);
+      expect(wwe.getBody().querySelectorAll('svg').length).toEqual(0);
+      expect(wwe.getBody().querySelectorAll('pre').length).toEqual(0);
+    });
   });
 
   describe('_copyCodeblockTypeFromRangeCodeblock', () => {


### PR DESCRIPTION

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description

Before: 
![tui editor before](https://user-images.githubusercontent.com/5072452/83628363-a4fede80-a598-11ea-9f85-8b665436af68.gif)
After:
![tui editor after](https://user-images.githubusercontent.com/5072452/83628384-a92afc00-a598-11ea-9dd3-ef51165b030d.gif)


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
