### PR TITLE
fix: mode switch buttons triggering form submit (fix #969)

### DIFF
--- a/apps/editor/src/js/ui/modeSwitch.js
+++ b/apps/editor/src/js/ui/modeSwitch.js
@@ -90,10 +90,10 @@ class ModeSwitch extends UIController {
 
   _render(rootElement) {
     this._buttons.markdown = domUtils.createElementWith(
-      `<button class="te-switch-button markdown">${i18n.get('Markdown')}</button>`
+      `<button class="te-switch-button markdown" type="button">${i18n.get('Markdown')}</button>`
     );
     this._buttons.wysiwyg = domUtils.createElementWith(
-      `<button class="te-switch-button wysiwyg">${i18n.get('WYSIWYG')}</button>`
+      `<button class="te-switch-button wysiwyg" type="button">${i18n.get('WYSIWYG')}</button>`
     );
 
     this.el.appendChild(this._buttons.markdown);

--- a/apps/editor/test/unit/ui/modeSwitch.spec.js
+++ b/apps/editor/test/unit/ui/modeSwitch.spec.js
@@ -79,4 +79,16 @@ describe('ModeSwitch', () => {
       expect(modeSwitch._rootElement.style.display).toBe('block');
     });
   });
+
+  it('form interaction should not trigger form submit on click', () => {
+    const $form = $('<form action="javascript:void(0)">').get(0);
+    spyOnEvent($form, 'submit');
+
+    $container.append($form);
+
+    modeSwitch = new ModeSwitch($form, null, eventManager);
+
+    $('button').trigger('click');
+    expect('submit').not.toHaveBeenTriggeredOn($form);
+  });
 });


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description

When using the toast ui editor inside a form element, switching between markdown/wysiwyg causes the form to be submitted which is undesired. This is fixed by setting the button types to button.

I hope this is the right way to do it. I wanted to add tests but I'm not really familiar with them so maybe somebody could help me with that? :)

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
