### PR TITLE
fix: the attributes defined by custom renderer cannot be applied to paragraph in WYSIWYG(fix #998)

### DIFF
--- a/apps/editor/src/js/wwPManager.js
+++ b/apps/editor/src/js/wwPManager.js
@@ -49,11 +49,12 @@ class WwPManager {
       const wrapper = domUtils.createElementWith(`<div>${html}</div>`);
 
       domUtils.findAll(wrapper, 'p').forEach(para => {
+        const { attributes, nextElementSibling, nextSibling } = para;
         const content = para.innerHTML;
         const lines = content.split(/<br>/gi);
         const lastIndex = lines.length - 1;
         // cross browsing: old browser not has nextElementSibling attribute
-        const nextElement = para.nextElementSibling || para.nextSibling;
+        const nextElement = nextElementSibling || nextSibling;
         let splitedContent = '';
 
         splitedContent = lines.map((line, index) => {
@@ -64,14 +65,20 @@ class WwPManager {
           }
 
           if (line) {
-            result = `<div>${line}</div>`;
+            const block = document.createElement('div');
+
+            for (const { name, value } of attributes) {
+              block.setAttribute(name, value);
+            }
+            block.innerHTML = line;
+            result = block.outerHTML;
           }
 
           return result;
         });
 
         // For paragraph, we add empty line
-        if (nextElement && nextElement.nodeName === 'P') {
+        if ((nextElement && nextElement.nodeName === 'P') || this._isNotEditable(para)) {
           splitedContent.push('<div><br></div>');
         }
         domUtils.replaceWith(para, splitedContent.join(''));
@@ -122,6 +129,10 @@ class WwPManager {
     }
 
     return nextElementSibling;
+  }
+
+  _isNotEditable(node) {
+    return node.getAttribute('contenteditable') === 'false';
   }
 }
 

--- a/apps/editor/src/js/wwPManager.js
+++ b/apps/editor/src/js/wwPManager.js
@@ -49,17 +49,13 @@ class WwPManager {
       const wrapper = domUtils.createElementWith(`<div>${html}</div>`);
 
       domUtils.findAll(wrapper, 'p').forEach(para => {
-        const { attributes, nextElementSibling, nextSibling } = para;
+        const { attributes, nextElementSibling } = para;
         const content = para.innerHTML;
         const lines = content.split(/<br>/gi);
         const lastIndex = lines.length - 1;
-        // cross browsing: old browser not has nextElementSibling attribute
-        const nextElement = nextElementSibling || nextSibling;
         let splitedContent = '';
 
         splitedContent = lines.map((line, index) => {
-          let result = '';
-
           if (index > 0 && index < lastIndex) {
             line = line ? line : '<br>';
           }
@@ -67,18 +63,25 @@ class WwPManager {
           if (line) {
             const block = document.createElement('div');
 
-            for (const { name, value } of attributes) {
+            Object.keys(attributes).forEach(key => {
+              const { name, value } = attributes[key];
+
               block.setAttribute(name, value);
-            }
+            });
+
             block.innerHTML = line;
-            result = block.outerHTML;
+
+            return block.outerHTML;
           }
 
-          return result;
+          return '';
         });
 
         // For paragraph, we add empty line
-        if ((nextElement && nextElement.nodeName === 'P') || this._isNotEditable(para)) {
+        if (
+          (nextElementSibling && nextElementSibling.nodeName === 'P') ||
+          para.getAttribute('contenteditable') === 'false'
+        ) {
           splitedContent.push('<div><br></div>');
         }
         domUtils.replaceWith(para, splitedContent.join(''));
@@ -129,10 +132,6 @@ class WwPManager {
     }
 
     return nextElementSibling;
-  }
-
-  _isNotEditable(node) {
-    return node.getAttribute('contenteditable') === 'false';
   }
 }
 

--- a/apps/editor/test/unit/wwPManager.spec.js
+++ b/apps/editor/test/unit/wwPManager.spec.js
@@ -45,4 +45,26 @@ describe('WwPManager', () => {
 
     expect(html).toEqual('<div>text</div><div><br></div><div><a href="#">link</a></div>');
   });
+
+  it('should keep the attributes when wysiwygSetValueBefore event is triggered', () => {
+    const html = em.emitReduce(
+      'wysiwygSetValueBefore',
+      '<p data-custom="custom">text<br><br><a href="#">link</a><br></p>'
+    );
+
+    expect(html).toEqual(
+      '<div data-custom="custom">text</div><div data-custom="custom"><br></div><div data-custom="custom"><a href="#">link</a></div>'
+    );
+  });
+
+  it('should add the empth line when paragraph has contenteditable="false"', () => {
+    const html = em.emitReduce(
+      'wysiwygSetValueBefore',
+      '<p contenteditable="false">text<br><br><a href="#">link</a><br></p>'
+    );
+
+    expect(html).toEqual(
+      '<div contenteditable="false">text</div><div contenteditable="false"><br></div><div contenteditable="false"><a href="#">link</a></div><div><br></div>'
+    );
+  });
 });

--- a/apps/editor/test/unit/wwPManager.spec.js
+++ b/apps/editor/test/unit/wwPManager.spec.js
@@ -57,7 +57,7 @@ describe('WwPManager', () => {
     );
   });
 
-  it('should add the empth line when paragraph has contenteditable="false"', () => {
+  it('should add the empty line when paragraph has contenteditable="false"', () => {
     const html = em.emitReduce(
       'wysiwygSetValueBefore',
       '<p contenteditable="false">text<br><br><a href="#">link</a><br></p>'


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
* related issue(#998)
* additional context
When the attributes is defined in custom renderer option, the attributes cannot be applied to **paragraph**. Because the **paragraph** is converted to `div` block in WYSIWYG for changing the html to markdown through `to-mark`.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
