### PR TITLE
fix: preserve trailing, leading space in b, i tag (fix #742)

### DIFF
--- a/apps/editor/src/js/wysiwygEditor.js
+++ b/apps/editor/src/js/wysiwygEditor.js
@@ -35,8 +35,6 @@ const keyMapper = KeyMapper.getSharedInstance();
 const FIND_EMPTY_LINE = /<([a-z]+|h\d)>(<br>|<br \/>)<\/\1>/gi;
 const FIND_UNNECESSARY_BR = /(?:<br>|<br \/>)<\/(.+?)>/gi;
 const FIND_BLOCK_TAGNAME_RX = /\b(H[\d]|LI|P|BLOCKQUOTE|TD|PRE)\b/;
-const FIND_OPENING_SPAN_WITH_SPACE = /<span([^>]*)>[\u0020]/g;
-const FIND_CLOSING_SPAN_WITH_SPACE = /[\u0020]<\/span>/g;
 const FIND_TABLE_AND_HEADING_RX = /^(TABLE|H[1-6])$/;
 
 const EDITOR_CONTENT_CSS_CLASSNAME = 'tui-editor-contents';
@@ -860,9 +858,9 @@ class WysiwygEditor {
       return result;
     });
 
-    // replace a space of the first and end in sapn tag to &nbsp;.
-    html = html.replace(FIND_OPENING_SPAN_WITH_SPACE, '<span$1>&nbsp;');
-    html = html.replace(FIND_CLOSING_SPAN_WITH_SPACE, '&nbsp;</span>');
+    // replace a space of the first and end in b, i, span to &nbsp;.
+    html = html.replace(/<(b|i|span)([^>]*)>[\u0020]/g, '<$1$2>&nbsp;');
+    html = html.replace(/[\u0020]<\/(b|i|span)>/g, '&nbsp;</$1>');
 
     // remove unnecessary brs
     html = html.replace(FIND_UNNECESSARY_BR, '</$1>');

--- a/apps/editor/test/unit/wysiwygEditor.spec.js
+++ b/apps/editor/test/unit/wysiwygEditor.spec.js
@@ -324,6 +324,46 @@ describe('WysiwygEditor', () => {
       expect(wwe.getValue()).toEqual(`${expectedHtml}<br />`);
     });
 
+    it('should replace space(32) to &nbsp; in the front/back b tag', () => {
+      const html = [
+        '<b>foo </b><br />',
+        '<b>foo </b><i>bar</i>',
+        '<b class="foo">bar </b><i>baz</i>',
+        '<b class="foo"> bar</b><i>baz</i>'
+      ].join('');
+
+      wwe.setValue(html);
+
+      const expectedHtml = [
+        '<b>foo&nbsp;</b><br />',
+        '<b>foo&nbsp;</b><i>bar</i>',
+        '<b class="foo">bar&nbsp;</b><i>baz</i>',
+        '<b class="foo">&nbsp;bar</b><i>baz</i>'
+      ].join('');
+
+      expect(wwe.getValue()).toEqual(`${expectedHtml}<br />`);
+    });
+
+    it('should replace space(32) to &nbsp; in the front/back i tag', () => {
+      const html = [
+        '<i>bar </i><br />',
+        '<i>bar </i><b>foo</b>',
+        '<i class="foo">bar </i><b>baz</b>',
+        '<i class="foo"> bar</i><b>baz</b>'
+      ].join('');
+
+      wwe.setValue(html);
+
+      const expectedHtml = [
+        '<i>bar&nbsp;</i><br />',
+        '<i>bar&nbsp;</i><b>foo</b>',
+        '<i class="foo">bar&nbsp;</i><b>baz</b>',
+        '<i class="foo">&nbsp;bar</i><b>baz</b>'
+      ].join('');
+
+      expect(wwe.getValue()).toEqual(`${expectedHtml}<br />`);
+    });
+
     it('the line break is working between <br> to <img>.', () => {
       let html = '<p>test<br><img src="" alt="image"></p>';
 


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description

fixes #742.
I changed it to preserve first trailing or leading space in i, b tags.
I'm not sure whether there is a reason not to be. If It shouldn't be I don't mind close this PR :)

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
