### PR TITLE
fix: fenced code block is broken depending on input order (fix #1167)

### DIFF
--- a/apps/editor/src/js/codemirror/continuelist.js
+++ b/apps/editor/src/js/codemirror/continuelist.js
@@ -18,7 +18,7 @@ CodeMirror.commands.indentOrderedList = function(cm) {
     var line = cm.getLine(pos.line);
     var cursorBeforeTextInline = line.substr(0, pos.ch);
 
-    if ((listRE.test(cursorBeforeTextInline) || cm.somethingSelected())) {
+    if (listRE.test(cursorBeforeTextInline) || cm.somethingSelected()) {
       cm.indentSelection('add');
     } else {
       cm.execCommand('insertSoftTab');
@@ -28,7 +28,10 @@ CodeMirror.commands.indentOrderedList = function(cm) {
 };
 
 CodeMirror.commands.newlineAndIndentContinueMarkdownList = function(cm) {
-  if (cm.getOption('disableInput') || !!cm.state.isCursorInCodeBlock) return CodeMirror.Pass;
+  if (cm.getOption('disableInput') || !!cm.state.isCursorInCodeBlock) {
+    cm.execCommand('newlineAndIndent');
+    return;
+  }
   var ranges = cm.listSelections(),
     replacements = [];
 

--- a/libs/toastmark/src/__test__/toastmark.spec.ts
+++ b/libs/toastmark/src/__test__/toastmark.spec.ts
@@ -298,6 +298,14 @@ describe('editText()', () => {
       assertParseResult(doc, ['Hey,', 'Hello', '', 'My', '', 'World *!!*']);
       assertResultNodes(doc, result.nodes);
     });
+
+    it('update to fenced code blocks to the end of the document', () => {
+      const doc = new ToastMark('``\nHello\n\nMy World');
+      const result = doc.editMarkdown([1, 3], [1, 3], '`')[0];
+
+      assertParseResult(doc, ['```', 'Hello', '', 'My World']);
+      assertResultNodes(doc, result.nodes);
+    });
   });
 
   describe('list item', () => {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description

* Related issue #1167 

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
