### PR TITLE
feat: Adding Custom Markdown Renderer option to Editor (close #485)

### DIFF
--- a/apps/editor/docs/README.md
+++ b/apps/editor/docs/README.md
@@ -6,7 +6,8 @@
 - [👀 Viewer](./viewer.md)
 - [🧩 Plugins](./plugins.md)
 - [🌏 Internationalization (i18n)](./i18n.md)
-- [🎨Custom HTML Renderer](./custom-html-renderer.md)
+- [🎨 Custom HTML Renderer](./custom-html-renderer.md)
+- [📝 Custom Markdown Renderer](./custom-markdown-renderer.md)
 - [🔗 Extended Autolinks](./extended-autolinks.md)
 
 ### Migration Guide

--- a/apps/editor/docs/custom-markdown-renderer.md
+++ b/apps/editor/docs/custom-markdown-renderer.md
@@ -6,7 +6,7 @@ This is useful for converting initial WYSIWYG content into markdown. They WYSIWY
 
 ## Basic Usage
 
-The Editor accepts the `customMarkdownRenderer` option, which is a key-value object. The keys of the object is types of node of the AST, and the values are convertor functions to be used for converting a node to string that will be used in the final markdown. 
+The Editor accepts the `customMarkdownRenderer` option, which is a key-value object. The keys of the object are types of node of the AST, and the values are convertor functions to be used for converting a node to string that will be used in the final markdown. 
 
 The following code is a basic example of using `customMarkdownRenderer` option.
 
@@ -28,7 +28,7 @@ If we set the following wysiwyg content,
 Hello World
 ```
 
-The final markdown content will be like below.
+The final markdown content will be
 
 ```markdown
 Hello World!

--- a/apps/editor/docs/custom-markdown-renderer.md
+++ b/apps/editor/docs/custom-markdown-renderer.md
@@ -1,0 +1,35 @@
+# Custom Markdown Renderer
+
+The TOAST UI Editor (henceforth referred to as 'Editor') provides a way to customize the final Markdown contents. 
+
+This is useful for converting initial WYSIWYG content into markdown. They WYSIWYG gets converted into the internal AST, which then uses this markdown rendering to produce the final markdown string.
+
+## Basic Usage
+
+The Editor accepts the `customMarkdownRenderer` option, which is a key-value object. The keys of the object is types of node of the AST, and the values are convertor functions to be used for converting a node to string that will be used in the final markdown. 
+
+The following code is a basic example of using `customMarkdownRenderer` option.
+
+```js
+const editor = new Editor({
+  el: container,
+  initialEditType: 'wysiwyg',
+  customMarkdownRenderer: {
+    TEXT_NODE(node) {
+      return `${node.nodeValue}!`;
+    }
+  }
+});
+```
+
+If we set the following wysiwyg content,
+
+```html
+Hello World
+```
+
+The final markdown content will be like below.
+
+```markdown
+Hello World!
+```

--- a/apps/editor/index.d.ts
+++ b/apps/editor/index.d.ts
@@ -149,6 +149,10 @@ declare namespace toastui {
     context: Context
   ) => HTMLToken | HTMLToken[] | null;
 
+  export type CustomMarkdownRenderer = {
+    [NODE_TYPE: string]: (node: Node) => string;
+  };
+
   type CustomHTMLRendererMap = Partial<Record<NodeType, CustomHTMLRenderer>>;
   // Toastmark custom renderer type end
   interface SelectionRange {
@@ -259,6 +263,7 @@ declare namespace toastui {
     placeholder?: string;
     linkAttribute?: LinkAttribute;
     customHTMLRenderer?: CustomHTMLRenderer;
+    customMarkdownRenderer?: CustomMarkdownRenderer;
     referenceDefinition?: boolean;
     customHTMLSanitizer?: CustomHTMLSanitizer;
     previewHighlight?: boolean;

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -48,7 +48,8 @@
     "note": "tui-note --tag=$(git describe --tags)",
     "tslint": "tslint index.d.ts",
     "doc:serve": "tuidoc --serv",
-    "doc": "tuidoc"
+    "doc": "tuidoc",
+    "debug": "karma run --grep=customMarkdownRenderer"
   },
   "devDependencies": {
     "@babel/core": "^7.8.3",

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -48,8 +48,7 @@
     "note": "tui-note --tag=$(git describe --tags)",
     "tslint": "tslint index.d.ts",
     "doc:serve": "tuidoc --serv",
-    "doc": "tuidoc",
-    "debug": "karma run --grep=customMarkdownRenderer"
+    "doc": "tuidoc"
   },
   "devDependencies": {
     "@babel/core": "^7.8.3",

--- a/apps/editor/src/js/editor.js
+++ b/apps/editor/src/js/editor.js
@@ -124,6 +124,7 @@ const __nedInstance = [];
  *     @param {string} [options.placeholder] - The placeholder text of the editable element.
  *     @param {Object} [options.linkAttribute] - Attributes of anchor element that should be rel, target, contenteditable, hreflang, type
  *     @param {Object} [options.customHTMLRenderer] - Object containing custom renderer functions correspond to markdown node
+ *     @param {Object} [options.customMarkdownRenderer] - Object containing custom renderer functions correspond to HTML node
  *     @param {boolean} [options.referenceDefinition=false] - whether use the specification of link reference definition
  *     @param {function} [options.customHTMLSanitizer=null] - custom HTML sanitizer
  */
@@ -170,6 +171,7 @@ class ToastUIEditor {
         extendedAutolinks: false,
         customConvertor: null,
         customHTMLRenderer: null,
+        customMarkdownRenderer: null,
         referenceDefinition: false,
         customHTMLSanitizer: null
       },
@@ -190,6 +192,7 @@ class ToastUIEditor {
     const { renderer, parser, plugins } = getPluginInfo(this.options.plugins);
     const {
       customHTMLRenderer,
+      customMarkdownRenderer,
       customHTMLSanitizer,
       extendedAutolinks,
       referenceDefinition,
@@ -267,7 +270,9 @@ class ToastUIEditor {
 
     this.toMarkOptions = {
       gfm: true,
-      renderer: toMarkRenderer
+      renderer: customMarkdownRenderer 
+        ? toMarkRenderer.constructor.factory(toMarkRenderer, customMarkdownRenderer)
+        : toMarkRenderer
     };
 
     if (plugins) {

--- a/apps/editor/test/unit/editor.spec.js
+++ b/apps/editor/test/unit/editor.spec.js
@@ -506,6 +506,38 @@ describe('Editor', () => {
       });
     });
 
+    describe('customMarkdownRenderer', () => {
+      it('should pass customMarkdownRenderer option for creating convertor instance', () => {
+        editor = new Editor({
+          el: container,
+          initialValue: 'Hello World',
+          initialEditType: 'wysiwyg',
+          customMarkdownRenderer: {
+            TEXT_NODE(node) {
+              return `${node.nodeValue}!`;
+            }
+          }
+        });
+
+        expect(editor.getMarkdown()).toBe('Hello World!');
+      });
+
+      it('should properly parse line breaks in Markdown', () => {
+        editor = new Editor({
+          el: container,
+          initialValue: 'a\na',
+          initialEditType: 'wysiwyg',
+          customMarkdownRenderer: {
+            BR() {
+              return '\n\n';
+            }
+          }
+        });
+
+        expect(editor.getMarkdown()).toBe('a\n\na');
+      });
+    });
+
     describe('extendedAutolinks option', () => {
       it('should convert url-like strings to anchor tags', () => {
         editor = new Editor({


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description
I was interested in resolving the issue mentioned in https://github.com/nhn/tui.editor/issues/485. In case there are any future markdown inconsistencies from going WYSIWYG first, I thought to add a custom markdown renderer based on the feedback here: https://github.com/nhn/tui.editor/issues/485#issuecomment-681170206. This should resolve all issues of this type in the future and not be blocked on the underlying squire refactor. Let me know what you think!


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
