### PR TITLE
fix: remove startsWith, endsWith for IE

### DIFF
--- a/libs/toastmark/src/commonmark/frontMatter/helper.ts
+++ b/libs/toastmark/src/commonmark/frontMatter/helper.ts
@@ -10,7 +10,7 @@ function hasFrontMatter(input: string) {
 export function replaceFrontMatter(input: string) {
   const trimmed = input.trim();
 
-  if (trimmed.startsWith('---') && hasFrontMatter(trimmed)) {
+  if (/^---/.test(trimmed) && hasFrontMatter(trimmed)) {
     return input.replace(reFrontMatter, `${frontMatterOpen}$1${frontMatterClose}`);
   }
 

--- a/libs/toastmark/src/commonmark/frontMatter/parser.ts
+++ b/libs/toastmark/src/commonmark/frontMatter/parser.ts
@@ -5,6 +5,7 @@ import { frontMatterOpen, frontMatterClose } from './helper';
 
 const reFrontMatterOpen = new RegExp(frontMatterOpen);
 const reFrontMatterClose = new RegExp(frontMatterClose);
+const reEndFrontMatterClose = new RegExp(`${frontMatterClose}$`);
 
 let inFrontMatter = false;
 
@@ -37,7 +38,7 @@ export const frontMatterParser: CustomParserMap = {
          * ---
          * I'm normal paragraph
          */
-        if (!content.endsWith(frontMatterClose)) {
+        if (!reEndFrontMatterClose.test(content)) {
           const closeLen = frontMatterClose.length;
           const frontMatterClosePos = content.indexOf(frontMatterClose);
           const frontMatterContent = content.substring(0, frontMatterClosePos + closeLen);


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
* remove `startsWith`, `endsWith` to support IE


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
