### PR TITLE
feat: Improve replacer function for code block plugin

### DIFF
--- a/apps/editor/index.d.ts
+++ b/apps/editor/index.d.ts
@@ -6,7 +6,7 @@
 declare namespace toastui {
   type SquireExt = any;
   type HandlerFunc = (...args: any[]) => void;
-  type ReplacerFunc = (inputString: string) => string;
+  type ReplacerFunc = (inputString: string, language: string, codeBlockElement: Element) => (string | Element);
   type CodeMirrorType = CodeMirror.EditorFromTextArea;
   type CommandManagerExecFunc = (name: string, ...args: any[]) => any;
   type PopupTableUtils = LayerPopup;

--- a/apps/editor/src/js/codeBlockManager.js
+++ b/apps/editor/src/js/codeBlockManager.js
@@ -36,13 +36,13 @@ class CodeBlockManager {
    * @param {string} codeText - code text
    * @returns {string}
    */
-  createCodeBlockHtml(language, codeText) {
+  createCodeBlockHtml(language, codeText, codeBlock) {
     language = language.toLowerCase();
 
     const replacer = this.getReplacer(language);
 
     if (replacer) {
-      return replacer(codeText, language);
+      return replacer(codeText, language, codeBlock);
     }
     return escape(codeText, false);
   }

--- a/apps/editor/src/js/preview.js
+++ b/apps/editor/src/js/preview.js
@@ -59,9 +59,14 @@ class Preview {
   invokeCodeBlockPlugins(codeBlocks) {
     codeBlocks.forEach(codeBlock => {
       const lang = codeBlock.getAttribute('data-language');
-      const html = codeBlockManager.createCodeBlockHtml(lang, codeBlock.textContent);
+      const html = codeBlockManager.createCodeBlockHtml(lang, codeBlock.textContent, codeBlock);
 
-      codeBlock.innerHTML = html;
+      if (typeof html === 'string') {
+        codeBlock.innerHTML = html;
+      } else {
+        codeBlock.innerHTML = '';
+        codeBlock.appendChild(html);
+      }
     });
   }
 


### PR DESCRIPTION
Adapt typing of ReplacerFunc to include language
  (which is effectively passed)

Add the code block element to the replacer function,
to allow to retrieve extra information that would be placed on
the html element (for example through a customHTMLRenderer)

Allow the replacerFunc to return an element, instead
of the html string, which is more convenient when
the plugin generates complex html with interactions.

