### PR TITLE
fix: ms-word list is not pasted when editor's wrapper is list

### DIFF
--- a/apps/editor/src/js/wwPasteContentHelper.js
+++ b/apps/editor/src/js/wwPasteContentHelper.js
@@ -558,11 +558,12 @@ class WwPasteContentHelper {
    * @private
    */
   _getListDepth(el) {
-    const root = this.wwe.getBody();
     let depth = 0;
 
-    // Since the parent of the editor's container is searched until the list,
-    // a condition for comparing root has been added.
+    // Since the list outside the editor can be found,
+    // so make sure to traverse only the editor's container.
+    const root = this.wwe.getBody();
+
     while (el && el !== root) {
       if (el.tagName === 'UL' || el.tagName === 'OL') {
         depth += 1;

--- a/apps/editor/src/js/wwPasteContentHelper.js
+++ b/apps/editor/src/js/wwPasteContentHelper.js
@@ -558,9 +558,12 @@ class WwPasteContentHelper {
    * @private
    */
   _getListDepth(el) {
+    const root = this.wwe.getBody();
     let depth = 0;
 
-    while (el) {
+    // Since the parent of the editor's container is searched until the list,
+    // a condition for comparing root has been added.
+    while (el && el !== root) {
       if (el.tagName === 'UL' || el.tagName === 'OL') {
         depth += 1;
       }


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description

When the wrapper of the editor is a list, the list copied from MS Office is not pasted.
This is a side effect that occurred while dealing with issues #1230 and #1259 together.

#### AS-IS

![wrong](https://user-images.githubusercontent.com/18183560/99947021-af1ccf80-2dba-11eb-8283-738ec05c0f8b.gif)

#### TO-BE

![correct](https://user-images.githubusercontent.com/18183560/99947036-b5ab4700-2dba-11eb-8ef6-9a7a32cf8352.gif)

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
