### PR TITLE
feat: change table selection

### DIFF
--- a/apps/editor/src/__test__/wysiwyg/wwTableCommand.spec.ts
+++ b/apps/editor/src/__test__/wysiwyg/wwTableCommand.spec.ts
@@ -5,10 +5,12 @@ import EventEmitter from '@/event/eventEmitter';
 import CommandManager from '@/commands/commandManager';
 import CellSelection from '@/wysiwyg/plugins/tableSelection/cellSelection';
 
+import { getCellsPosInfo } from '@/wysiwyg/helper/table';
+
 describe('wysiwyg table commands', () => {
   let container: HTMLElement, wwe: WysiwygEditor, em: EventEmitter, cmd: CommandManager;
 
-  function setCellSelection(from: number, to: number) {
+  function selectCells(from: number, to: number) {
     const { state, dispatch } = wwe.view;
     const { doc, tr } = state;
 
@@ -17,6 +19,26 @@ describe('wysiwyg table commands', () => {
     const selection = new CellSelection(startCellPos, endCellPos);
 
     dispatch!(tr.setSelection(selection));
+  }
+
+  function setCellSelection(
+    [startRowIndex, startColumnIndex]: number[],
+    [endRowIndex, endColumnIndex]: number[],
+    cellSelection = true
+  ) {
+    const doc = wwe.getModel();
+    const cellsPosInfo = getCellsPosInfo(doc.resolve(1));
+
+    const startCellOffset = cellsPosInfo[startRowIndex][startColumnIndex].offset;
+    const endCellOffset = cellsPosInfo[endRowIndex][endColumnIndex].offset;
+
+    if (startCellOffset === endCellOffset && !cellSelection) {
+      const from = startCellOffset + 1;
+
+      wwe.setSelection(from, from);
+    } else {
+      selectCells(startCellOffset, endCellOffset);
+    }
   }
 
   beforeEach(() => {
@@ -91,10 +113,16 @@ describe('wysiwyg table commands', () => {
       const expected = oneLineTrim`
         <table>
           <thead>
-            <tr><th>foo</th><th>bar</th></tr>
+            <tr>
+              <th>foo</th>
+              <th>bar</th>
+            </tr>
           </thead>
           <tbody>
-            <tr><td>baz</td><td>qux</td></tr>
+            <tr>
+              <td>baz</td>
+              <td>qux</td>
+            </tr>
           </tbody>
         </table>
       `;
@@ -109,7 +137,7 @@ describe('wysiwyg table commands', () => {
     });
 
     it('should remove table when cursor is in table hedaer', () => {
-      wwe.setSelection(4, 4);
+      setCellSelection([0, 0], [0, 0], false);
 
       cmd.exec('wysiwyg', 'removeTable');
 
@@ -117,7 +145,7 @@ describe('wysiwyg table commands', () => {
     });
 
     it('should remove table when cursor is in table body', () => {
-      wwe.setSelection(11, 11);
+      setCellSelection([1, 0], [1, 0], false);
 
       cmd.exec('wysiwyg', 'removeTable');
 
@@ -125,7 +153,7 @@ describe('wysiwyg table commands', () => {
     });
 
     it('should remove table when selected cells', () => {
-      setCellSelection(4, 11);
+      setCellSelection([0, 0], [1, 0]);
 
       cmd.exec('wysiwyg', 'removeTable');
 
@@ -133,44 +161,19 @@ describe('wysiwyg table commands', () => {
     });
   });
 
-  describe('addRow command', () => {
+  describe('addRowToNext command', () => {
     beforeEach(() => {
-      cmd.exec('wysiwyg', 'addTable', { columns: 2, rows: 1, data: ['foo', 'bar', 'baz', 'qux'] });
+      cmd.exec('wysiwyg', 'addTable', {
+        columns: 2,
+        rows: 2,
+        data: ['foo', 'bar', 'baz', 'qux', 'quux', 'quuz']
+      });
     });
 
-    it('should add row to table body when cursor is in table head', () => {
-      wwe.setSelection(5, 5); // select 'foo' cell
+    it('should add a row to next row of current cursor cell', () => {
+      setCellSelection([1, 1], [1, 1], false);
 
-      cmd.exec('wysiwyg', 'addRow');
-
-      const expected = oneLineTrim`
-        <table>
-          <thead>
-            <tr>
-              <th>foo</th>
-              <th>bar</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td><br></td>
-              <td><br></td>
-            </tr>
-            <tr>
-              <td>baz</td>
-              <td>qux</td>
-            </tr>
-          </tbody>
-        </table>
-      `;
-
-      expect(wwe.getHTML()).toBe(expected);
-    });
-
-    it('should add row when cursor is in table body', () => {
-      wwe.setSelection(19, 19); // select 'baz' cell
-
-      cmd.exec('wysiwyg', 'addRow');
+      cmd.exec('wysiwyg', 'addRowToNext');
 
       const expected = oneLineTrim`
         <table>
@@ -189,6 +192,10 @@ describe('wysiwyg table commands', () => {
               <td><br></td>
               <td><br></td>
             </tr>
+            <tr>
+              <td>quux</td>
+              <td>quuz</td>
+            </tr>
           </tbody>
         </table>
       `;
@@ -196,10 +203,10 @@ describe('wysiwyg table commands', () => {
       expect(wwe.getHTML()).toBe(expected);
     });
 
-    it('should add row when cells of same row are selected in table hedaer', () => {
-      setCellSelection(3, 8); // select from 'foo' to 'bar' cell
+    it('should add rows as selected row count after selection', () => {
+      setCellSelection([0, 0], [1, 1]);
 
-      cmd.exec('wysiwyg', 'addRow');
+      cmd.exec('wysiwyg', 'addRowToNext');
 
       const expected = oneLineTrim`
         <table>
@@ -211,12 +218,20 @@ describe('wysiwyg table commands', () => {
           </thead>
           <tbody>
             <tr>
+              <td class="te-cell-selected">baz</td>
+              <td class="te-cell-selected">qux</td>
+            </tr>
+            <tr>
               <td><br></td>
               <td><br></td>
             </tr>
             <tr>
-              <td>baz</td>
-              <td>qux</td>
+              <td><br></td>
+              <td><br></td>
+            </tr>
+            <tr>
+              <td>quux</td>
+              <td>quuz</td>
             </tr>
           </tbody>
         </table>
@@ -225,10 +240,49 @@ describe('wysiwyg table commands', () => {
       expect(wwe.getHTML()).toBe(expected);
     });
 
-    it('should add row when cells of same row are selected in table body', () => {
-      setCellSelection(17, 22); // select from 'baz' to 'qux' cell
+    it('should not add a row when selection is only at table head', () => {
+      setCellSelection([0, 0], [0, 1]);
 
-      cmd.exec('wysiwyg', 'addRow');
+      cmd.exec('wysiwyg', 'addRowToNext');
+
+      const expected = oneLineTrim`
+        <table>
+          <thead>
+            <tr>
+              <th class="te-cell-selected">foo</th>
+              <th class="te-cell-selected">bar</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>baz</td>
+              <td>qux</td>
+            </tr>
+            <tr>
+              <td>quux</td>
+              <td>quuz</td>
+            </tr>
+          </tbody>
+        </table>
+      `;
+
+      expect(wwe.getHTML()).toBe(expected);
+    });
+  });
+
+  describe('addRowToPrev command', () => {
+    beforeEach(() => {
+      cmd.exec('wysiwyg', 'addTable', {
+        columns: 2,
+        rows: 2,
+        data: ['foo', 'bar', 'baz', 'qux', 'quux', 'quuz']
+      });
+    });
+
+    it('should add a row to previous row of current cursor cell', () => {
+      setCellSelection([1, 1], [1, 1], false);
+
+      cmd.exec('wysiwyg', 'addRowToPrev');
 
       const expected = oneLineTrim`
         <table>
@@ -240,12 +294,16 @@ describe('wysiwyg table commands', () => {
           </thead>
           <tbody>
             <tr>
-              <td class="te-cell-selected">baz</td>
-              <td class="te-cell-selected">qux</td>
+              <td><br></td>
+              <td><br></td>
             </tr>
             <tr>
-              <td><br></td>
-              <td><br></td>
+              <td>baz</td>
+              <td>qux</td>
+            </tr>
+            <tr>
+              <td>quux</td>
+              <td>quuz</td>
             </tr>
           </tbody>
         </table>
@@ -254,31 +312,35 @@ describe('wysiwyg table commands', () => {
       expect(wwe.getHTML()).toBe(expected);
     });
 
-    it('should add rows by selected row count when cells of multiple rows are selected from table head to table body', () => {
-      setCellSelection(8, 22); // select from 'bar' to 'qux' cell
+    it('should add rows as selected row count before selection', () => {
+      setCellSelection([1, 1], [2, 1]);
 
-      cmd.exec('wysiwyg', 'addRow');
+      cmd.exec('wysiwyg', 'addRowToPrev');
 
       const expected = oneLineTrim`
         <table>
           <thead>
             <tr>
               <th>foo</th>
-              <th class="te-cell-selected">bar</th>
+              <th>bar</th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <td class="te-cell-selected">baz</td>
+              <td><br></td>
+              <td><br></td>
+            </tr>
+            <tr>
+              <td><br></td>
+              <td><br></td>
+            </tr>
+            <tr>
+              <td>baz</td>
               <td class="te-cell-selected">qux</td>
             </tr>
             <tr>
-              <td><br></td>
-              <td><br></td>
-            </tr>
-            <tr>
-              <td><br></td>
-              <td><br></td>
+              <td>quux</td>
+              <td class="te-cell-selected">quuz</td>
             </tr>
           </tbody>
         </table>
@@ -287,31 +349,27 @@ describe('wysiwyg table commands', () => {
       expect(wwe.getHTML()).toBe(expected);
     });
 
-    it('should add rows by selected row count when cells of multiple rows are selected from table body to table heaer', () => {
-      setCellSelection(22, 8); // select from 'qux' to 'bar' cell
+    it('should not add a row when selection include table head', () => {
+      setCellSelection([0, 0], [1, 0]);
 
-      cmd.exec('wysiwyg', 'addRow');
+      cmd.exec('wysiwyg', 'addRowToPrev');
 
       const expected = oneLineTrim`
         <table>
           <thead>
             <tr>
-              <th>foo</th>
-              <th class="te-cell-selected">bar</th>
+              <th class="te-cell-selected">foo</th>
+              <th>bar</th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <td class="te-cell-selected"><br></td>
-              <td class="te-cell-selected"><br></td>
-            </tr>
-            <tr>
-              <td class="te-cell-selected"><br></td>
-              <td class="te-cell-selected"><br></td>
-            </tr>
-            <tr>
               <td class="te-cell-selected">baz</td>
-              <td class="te-cell-selected">qux</td>
+              <td>qux</td>
+            </tr>
+            <tr>
+              <td>quux</td>
+              <td>quuz</td>
             </tr>
           </tbody>
         </table>
@@ -330,41 +388,8 @@ describe('wysiwyg table commands', () => {
       });
     });
 
-    it('should not remove row when cursor is in table head', () => {
-      wwe.setSelection(5, 5); // select 'foo' cell
-
-      cmd.exec('wysiwyg', 'removeRow');
-
-      const expected = oneLineTrim`
-        <table>
-          <thead>
-            <tr>
-              <th>foo</th>
-              <th>bar</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>baz</td>
-              <td>qux</td>
-            </tr>
-            <tr>
-              <td>quux</td>
-              <td>quuz</td>
-            </tr>
-            <tr>
-              <td>corge</td>
-              <td><br></td>
-            </tr>
-          </tbody>
-        </table>
-      `;
-
-      expect(wwe.getHTML()).toBe(expected);
-    });
-
-    it('should remove row when cursor is in table body', () => {
-      wwe.setSelection(19, 19); // select 'baz' cell
+    it('should remove a row where current cursor cell is located', () => {
+      setCellSelection([1, 1], [1, 1], false);
 
       cmd.exec('wysiwyg', 'removeRow');
 
@@ -392,101 +417,8 @@ describe('wysiwyg table commands', () => {
       expect(wwe.getHTML()).toBe(expected);
     });
 
-    it('should not remove row when cells of same row are selected in table head', () => {
-      setCellSelection(3, 8); // select from 'foo' to 'bar' cell
-
-      cmd.exec('wysiwyg', 'removeRow');
-
-      const expected = oneLineTrim`
-        <table>
-          <thead>
-            <tr>
-              <th class="te-cell-selected">foo</th>
-              <th class="te-cell-selected">bar</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>baz</td>
-              <td>qux</td>
-            </tr>
-            <tr>
-              <td>quux</td>
-              <td>quuz</td>
-            </tr>
-            <tr>
-              <td>corge</td>
-              <td><br></td>
-            </tr>
-          </tbody>
-        </table>
-      `;
-
-      expect(wwe.getHTML()).toBe(expected);
-
-      setCellSelection(3, 8); // select from 'bar' to 'foo' cell
-    });
-
-    it('should remove row when cells of same row are selected in table body from left to right selection', () => {
-      setCellSelection(29, 35); // select from 'quux' to 'quuz' cell
-
-      cmd.exec('wysiwyg', 'removeRow');
-
-      const expected = oneLineTrim`
-        <table>
-          <thead>
-            <tr>
-              <th>foo</th>
-              <th>bar</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>baz</td>
-              <td>qux</td>
-            </tr>
-            <tr>
-              <td>corge</td>
-              <td><br></td>
-            </tr>
-          </tbody>
-        </table>
-      `;
-
-      expect(wwe.getHTML()).toBe(expected);
-    });
-
-    it('should remove row when cells of same row are selected in table body  from right to left selection', () => {
-      setCellSelection(50, 43); // select from last to 'corge' cell
-
-      cmd.exec('wysiwyg', 'removeRow');
-
-      const expected = oneLineTrim`
-        <table>
-          <thead>
-            <tr>
-              <th>foo</th>
-              <th>bar</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>baz</td>
-              <td>qux</td>
-            </tr>
-            <tr>
-              <td>quux</td>
-              <td>quuz</td>
-            </tr>
-          </tbody>
-        </table>
-      `;
-
-      expect(wwe.getHTML()).toBe(expected);
-    });
-
-    it('should remove rows by selected row count when cells of multiple rows are selected in table body', () => {
-      setCellSelection(29, 43); // select from 'quux' to 'corge' cell
+    it('should remove columns as selected column count in selection', () => {
+      setCellSelection([3, 1], [2, 1]);
 
       cmd.exec('wysiwyg', 'removeRow');
 
@@ -510,34 +442,8 @@ describe('wysiwyg table commands', () => {
       expect(wwe.getHTML()).toBe(expected);
     });
 
-    it('should not remove row when there is one row in table body', () => {
-      wwe.setSelection(22, 22);
-
-      cmd.exec('wysiwyg', 'removeRow');
-      cmd.exec('wysiwyg', 'removeRow');
-
-      const expected = oneLineTrim`
-        <table>
-          <thead>
-            <tr>
-              <th>foo</th>
-              <th>bar</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>corge</td>
-              <td><br></td>
-            </tr>
-          </tbody>
-        </table>
-      `;
-
-      expect(wwe.getHTML()).toBe(expected);
-    });
-
-    it('should remove rows except last row when all cells are selected in table body', () => {
-      setCellSelection(8, 43); // select from 'bar' to 'corge' cell
+    it('should not remove rows when selection include table head', () => {
+      setCellSelection([0, 1], [2, 1]);
 
       cmd.exec('wysiwyg', 'removeRow');
 
@@ -551,7 +457,15 @@ describe('wysiwyg table commands', () => {
           </thead>
           <tbody>
             <tr>
-              <td class="te-cell-selected">corge</td>
+              <td>baz</td>
+              <td class="te-cell-selected">qux</td>
+            </tr>
+            <tr>
+              <td>quux</td>
+              <td class="te-cell-selected">quuz</td>
+            </tr>
+            <tr>
+              <td>corge</td>
               <td><br></td>
             </tr>
           </tbody>
@@ -561,8 +475,8 @@ describe('wysiwyg table commands', () => {
       expect(wwe.getHTML()).toBe(expected);
     });
 
-    it('should not remove rows when cells are selected from table body to table hedaer', () => {
-      setCellSelection(43, 8); // select from 'corge' to 'bar' cell
+    it('should not remove rows when all rows of table body are selected', () => {
+      setCellSelection([1, 0], [3, 0]);
 
       cmd.exec('wysiwyg', 'removeRow');
 
@@ -571,17 +485,17 @@ describe('wysiwyg table commands', () => {
           <thead>
             <tr>
               <th>foo</th>
-              <th class="te-cell-selected">bar</th>
+              <th>bar</th>
             </tr>
           </thead>
           <tbody>
             <tr>
               <td class="te-cell-selected">baz</td>
-              <td class="te-cell-selected">qux</td>
+              <td>qux</td>
             </tr>
             <tr>
               <td class="te-cell-selected">quux</td>
-              <td class="te-cell-selected">quuz</td>
+              <td>quuz</td>
             </tr>
             <tr>
               <td class="te-cell-selected">corge</td>
@@ -595,37 +509,40 @@ describe('wysiwyg table commands', () => {
     });
   });
 
-  describe('addColumn command', () => {
+  describe('addColumnToNext command', () => {
     beforeEach(() => {
       cmd.exec('wysiwyg', 'addTable', {
-        columns: 2,
+        columns: 3,
         rows: 2,
-        data: ['foo', 'bar', 'baz', 'qux', 'quux', '']
+        data: ['foo', 'bar', 'baz', 'qux', 'quux', 'quuz', 'corge', 'grault', '']
       });
     });
 
-    it('should add column after cell with cursor in table head', () => {
-      wwe.setSelection(5, 5); // select 'foo' cell
+    it('should add a column to next column of current cursor cell', () => {
+      setCellSelection([1, 1], [1, 1], false);
 
-      cmd.exec('wysiwyg', 'addColumn');
+      cmd.exec('wysiwyg', 'addColumnToNext');
 
       const expected = oneLineTrim`
         <table>
           <thead>
             <tr>
               <th>foo</th>
-              <th><br></th>
               <th>bar</th>
+              <th><br></th>
+              <th>baz</th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <td>baz</td>
-              <td><br></td>
               <td>qux</td>
+              <td>quux</td>
+              <td><br></td>
+              <td>quuz</td>
             </tr>
             <tr>
-              <td>quux</td>
+              <td>corge</td>
+              <td>grault</td>
               <td><br></td>
               <td><br></td>
             </tr>
@@ -636,42 +553,10 @@ describe('wysiwyg table commands', () => {
       expect(wwe.getHTML()).toBe(expected);
     });
 
-    it('should add column after cell with cursor in table body', () => {
-      wwe.setSelection(23, 23); // select 'bar' cell
+    it('should add columns as selected column count to right of selection', () => {
+      setCellSelection([0, 0], [1, 1]);
 
-      cmd.exec('wysiwyg', 'addColumn');
-
-      const expected = oneLineTrim`
-        <table>
-          <thead>
-            <tr>
-              <th>foo</th>
-              <th>bar</th>
-              <th><br></th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>baz</td>
-              <td>qux</td>
-              <td><br></td>
-            </tr>
-            <tr>
-              <td>quux</td>
-              <td><br></td>
-              <td><br></td>
-            </tr>
-          </tbody>
-        </table>
-      `;
-
-      expect(wwe.getHTML()).toBe(expected);
-    });
-
-    it('should add columns when cells of same row are selected in table head from left to right selection', () => {
-      setCellSelection(3, 8); // select from 'foo' to 'bar' cell
-
-      cmd.exec('wysiwyg', 'addColumn');
+      cmd.exec('wysiwyg', 'addColumnToNext');
 
       const expected = oneLineTrim`
         <table>
@@ -681,160 +566,106 @@ describe('wysiwyg table commands', () => {
               <th class="te-cell-selected">bar</th>
               <th><br></th>
               <th><br></th>
+              <th>baz</th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <td>baz</td>
+              <td class="te-cell-selected">qux</td>
+              <td class="te-cell-selected">quux</td>
+              <td><br></td>
+              <td><br></td>
+              <td>quuz</td>
+            </tr>
+            <tr>
+              <td>corge</td>
+              <td>grault</td>
+              <td><br></td>
+              <td><br></td>
+              <td><br></td>
+            </tr>
+          </tbody>
+        </table>
+      `;
+
+      expect(wwe.getHTML()).toBe(expected);
+    });
+  });
+
+  describe('addColumnToPrev command', () => {
+    beforeEach(() => {
+      cmd.exec('wysiwyg', 'addTable', {
+        columns: 3,
+        rows: 2,
+        data: ['foo', 'bar', 'baz', 'qux', 'quux', 'quuz', 'corge', 'grault', '']
+      });
+    });
+
+    it('should add a column to previous column of current cursor cell', () => {
+      setCellSelection([1, 1], [1, 1], false);
+
+      cmd.exec('wysiwyg', 'addColumnToPrev');
+
+      const expected = oneLineTrim`
+        <table>
+          <thead>
+            <tr>
+              <th>foo</th>
+              <th><br></th>
+              <th>bar</th>
+              <th>baz</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>qux</td>
+              <td><br></td>
+              <td>quux</td>
+              <td>quuz</td>
+            </tr>
+            <tr>
+              <td>corge</td>
+              <td><br></td>
+              <td>grault</td>
+              <td><br></td>
+            </tr>
+          </tbody>
+        </table>
+      `;
+
+      expect(wwe.getHTML()).toBe(expected);
+    });
+
+    it('should add columns as selected column count to right of selection', () => {
+      setCellSelection([0, 1], [2, 2]);
+
+      cmd.exec('wysiwyg', 'addColumnToPrev');
+
+      const expected = oneLineTrim`
+        <table>
+          <thead>
+            <tr>
+              <th>foo</th>
+              <th><br></th>
+              <th><br></th>
+              <th class="te-cell-selected">bar</th>
+              <th class="te-cell-selected">baz</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
               <td>qux</td>
               <td><br></td>
               <td><br></td>
+              <td class="te-cell-selected">quux</td>
+              <td class="te-cell-selected">quuz</td>
             </tr>
             <tr>
-              <td>quux</td>
+              <td>corge</td>
               <td><br></td>
               <td><br></td>
-              <td><br></td>
-            </tr>
-          </tbody>
-        </table>
-      `;
-
-      expect(wwe.getHTML()).toBe(expected);
-    });
-
-    it('should add columns when cells of same row are selected in table head from right to left selection', () => {
-      setCellSelection(8, 3); // select from 'bar' to 'foo' cell
-
-      cmd.exec('wysiwyg', 'addColumn');
-
-      const expected = oneLineTrim`
-        <table>
-          <thead>
-            <tr>
-              <th class="te-cell-selected">foo</th>
-              <th class="te-cell-selected"><br></th>
-              <th class="te-cell-selected"><br></th>
-              <th class="te-cell-selected">bar</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>baz</td>
-              <td><br></td>
-              <td><br></td>
-              <td>qux</td>
-            </tr>
-            <tr>
-              <td>quux</td>
-              <td><br></td>
-              <td><br></td>
-              <td><br></td>
-            </tr>
-          </tbody>
-        </table>
-      `;
-
-      expect(wwe.getHTML()).toBe(expected);
-    });
-
-    it('should add columns by selected column count when cells of same row are selected in table body from left to right selection', () => {
-      setCellSelection(17, 22); // select from 'baz' to 'qux' cell
-
-      cmd.exec('wysiwyg', 'addColumn');
-
-      const expected = oneLineTrim`
-        <table>
-          <thead>
-            <tr>
-              <th>foo</th>
-              <th>bar</th>
-              <th><br></th>
-              <th><br></th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="te-cell-selected">baz</td>
-              <td class="te-cell-selected">qux</td>
-              <td><br></td>
-              <td><br></td>
-            </tr>
-            <tr>
-              <td>quux</td>
-              <td><br></td>
-              <td><br></td>
-              <td><br></td>
-            </tr>
-          </tbody>
-        </table>
-      `;
-
-      expect(wwe.getHTML()).toBe(expected);
-    });
-
-    it('should add columns by selected column count when cells of same row are selected in table body  from right to left selection', () => {
-      setCellSelection(22, 17); // select from 'qux' to 'baz' cell
-
-      cmd.exec('wysiwyg', 'addColumn');
-
-      const expected = oneLineTrim`
-        <table>
-          <thead>
-            <tr>
-              <th>foo</th>
-              <th><br></th>
-              <th><br></th>
-              <th>bar</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="te-cell-selected">baz</td>
+              <td class="te-cell-selected">grault</td>
               <td class="te-cell-selected"><br></td>
-              <td class="te-cell-selected"><br></td>
-              <td class="te-cell-selected">qux</td>
-            </tr>
-            <tr>
-              <td>quux</td>
-              <td><br></td>
-              <td><br></td>
-              <td><br></td>
-            </tr>
-          </tbody>
-        </table>
-      `;
-
-      expect(wwe.getHTML()).toBe(expected);
-    });
-
-    it('should add columns by all column count when cells of multiple rows are selected', () => {
-      setCellSelection(8, 22); // select from 'bar' to 'qux' cell
-
-      cmd.exec('wysiwyg', 'addColumn');
-
-      const expected = oneLineTrim`
-        <table>
-          <thead>
-            <tr>
-              <th>foo</th>
-              <th class="te-cell-selected">bar</th>
-              <th class="te-cell-selected"><br></th>
-              <th class="te-cell-selected"><br></th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="te-cell-selected">baz</td>
-              <td class="te-cell-selected">qux</td>
-              <td><br></td>
-              <td><br></td>
-            </tr>
-            <tr>
-              <td>quux</td>
-              <td><br></td>
-              <td><br></td>
-              <td><br></td>
             </tr>
           </tbody>
         </table>
@@ -853,8 +684,8 @@ describe('wysiwyg table commands', () => {
       });
     });
 
-    it('should remove column when cursor is in table hedaer', () => {
-      wwe.setSelection(10, 10); // select 'bar' cell
+    it('should remove a column where current cursor cell is located', () => {
+      setCellSelection([1, 1], [1, 1], false);
 
       cmd.exec('wysiwyg', 'removeColumn');
 
@@ -882,8 +713,8 @@ describe('wysiwyg table commands', () => {
       expect(wwe.getHTML()).toBe(expected);
     });
 
-    it('should remove column when cursor is in table body', () => {
-      wwe.setSelection(25, 25); // select 'qux' cell
+    xit('should remove columns as selected row count in selection', () => {
+      setCellSelection([1, 1], [2, 2]);
 
       cmd.exec('wysiwyg', 'removeColumn');
 
@@ -891,45 +722,15 @@ describe('wysiwyg table commands', () => {
         <table>
           <thead>
             <tr>
+              <th>foo</th>
               <th>bar</th>
-              <th>baz</th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <td>quux</td>
-              <td>quuz</td>
-            </tr>
-            <tr>
-              <td>grault</td>
-              <td><br></td>
-            </tr>
-          </tbody>
-        </table>
-      `;
-
-      expect(wwe.getHTML()).toBe(expected);
-    });
-
-    it('should remove columns when cells are selected in table head', () => {
-      setCellSelection(8, 13); // select from 'bar' to 'baz' cell
-
-      cmd.exec('wysiwyg', 'removeColumn');
-
-      const expected = oneLineTrim`
-        <table>
-          <thead>
-            <tr>
-              <th>foo</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
+              <td>baz</td>
               <td>qux</td>
             </tr>
-            <tr>
-              <td>corge</td>
-            </tr>
           </tbody>
         </table>
       `;
@@ -937,10 +738,10 @@ describe('wysiwyg table commands', () => {
       expect(wwe.getHTML()).toBe(expected);
     });
 
-    it('should not remove columns when all cells are selected in table head', () => {
-      setCellSelection(13, 3); // select from 'baz' to 'foo' cell
+    it('should not remove columns when all columns are selected', () => {
+      setCellSelection([0, 0], [1, 2]);
 
-      cmd.exec('wysiwyg', 'removeColumn');
+      cmd.exec('wysiwyg', 'removeRow');
 
       const expected = oneLineTrim`
         <table>
@@ -953,9 +754,9 @@ describe('wysiwyg table commands', () => {
           </thead>
           <tbody>
             <tr>
-              <td>qux</td>
-              <td>quux</td>
-              <td>quuz</td>
+              <td class="te-cell-selected">qux</td>
+              <td class="te-cell-selected">quux</td>
+              <td class="te-cell-selected">quuz</td>
             </tr>
             <tr>
               <td>corge</td>
@@ -966,67 +767,6 @@ describe('wysiwyg table commands', () => {
         </table>
       `;
 
-      expect(wwe.getHTML()).toBe(expected);
-    });
-
-    it('should remove columns when cells are selected in table body', () => {
-      setCellSelection(48, 41); // select from 'grault' to 'corge' cell
-
-      cmd.exec('wysiwyg', 'removeColumn');
-
-      const expected = oneLineTrim`
-        <table>
-          <thead>
-            <tr>
-              <th>baz</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>quuz</td>
-            </tr>
-            <tr>
-              <td><br></td>
-            </tr>
-          </tbody>
-        </table>
-      `;
-
-      expect(wwe.getHTML()).toBe(expected);
-    });
-
-    it('should not remove columns when all cells are selected in table', () => {
-      setCellSelection(13, 48); // select from 'baz' to 'grault' cell
-
-      cmd.exec('wysiwyg', 'removeColumn');
-
-      const expected = oneLineTrim`
-        <table>
-          <thead>
-            <tr>
-              <th>foo</th>
-              <th>bar</th>
-              <th class="te-cell-selected">baz</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="te-cell-selected">qux</td>
-              <td class="te-cell-selected">quux</td>
-              <td class="te-cell-selected">quuz</td>
-            </tr>
-            <tr>
-              <td class="te-cell-selected">corge</td>
-              <td class="te-cell-selected">grault</td>
-              <td><br></td>
-            </tr>
-          </tbody>
-        </table>
-      `;
-
-      expect(wwe.getHTML()).toBe(expected);
-
-      setCellSelection(48, 13); // select from 'grault' to 'baz' cell
       expect(wwe.getHTML()).toBe(expected);
     });
   });
@@ -1041,7 +781,7 @@ describe('wysiwyg table commands', () => {
     });
 
     it('should add center align attribute to columns by no option', () => {
-      wwe.setSelection(20, 20); // select 'baz' cell
+      setCellSelection([1, 0], [1, 0], false); // select 'baz' cell
 
       cmd.exec('wysiwyg', 'alignColumn');
 
@@ -1070,7 +810,7 @@ describe('wysiwyg table commands', () => {
     });
 
     it('should change align attribute to columns by option', () => {
-      wwe.setSelection(36, 36); // select last cell
+      setCellSelection([2, 1], [2, 1]); // select last cell
 
       cmd.exec('wysiwyg', 'alignColumn', { align: 'left' });
 
@@ -1124,7 +864,7 @@ describe('wysiwyg table commands', () => {
     });
 
     it('should add align attribute to columns with cursor in table hedaer', () => {
-      wwe.setSelection(4, 4); // select 'foo' cell
+      setCellSelection([0, 0], [0, 0]); // select 'foo' cell
 
       cmd.exec('wysiwyg', 'alignColumn', { align: 'left' });
 
@@ -1152,8 +892,8 @@ describe('wysiwyg table commands', () => {
       expect(wwe.getHTML()).toBe(expected);
     });
 
-    it('should add align attribute to selected cells', () => {
-      setCellSelection(17, 22); // select from 'baz' to 'qux' cell
+    it('should add align attribute to selected columns in selection', () => {
+      setCellSelection([1, 0], [1, 1]); // select from 'baz' to 'qux' cell
 
       cmd.exec('wysiwyg', 'alignColumn', { align: 'left' });
 
@@ -1180,7 +920,7 @@ describe('wysiwyg table commands', () => {
 
       expect(wwe.getHTML()).toBe(expected);
 
-      setCellSelection(8, 3); // select from 'bar' to 'foo' cell
+      setCellSelection([0, 1], [0, 0]); // select from 'bar' to 'foo' cell
 
       cmd.exec('wysiwyg', 'alignColumn', { align: 'right' });
 

--- a/apps/editor/src/__test__/wysiwyg/wwTableCommand.spec.ts
+++ b/apps/editor/src/__test__/wysiwyg/wwTableCommand.spec.ts
@@ -713,8 +713,8 @@ describe('wysiwyg table commands', () => {
       expect(wwe.getHTML()).toBe(expected);
     });
 
-    xit('should remove columns as selected row count in selection', () => {
-      setCellSelection([1, 1], [2, 2]);
+    it('should remove columns as selected column count in selection', () => {
+      setCellSelection([0, 0], [2, 1]);
 
       cmd.exec('wysiwyg', 'removeColumn');
 
@@ -722,14 +722,15 @@ describe('wysiwyg table commands', () => {
         <table>
           <thead>
             <tr>
-              <th>foo</th>
-              <th>bar</th>
+              <th class="te-cell-selected">baz</th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <td>baz</td>
-              <td>qux</td>
+              <td class="te-cell-selected">quuz</td>
+            </tr>
+            <tr>
+              <td class="te-cell-selected"><br></td>
             </tr>
           </tbody>
         </table>

--- a/apps/editor/src/__test__/wysiwyg/wwTableCommand.spec.ts
+++ b/apps/editor/src/__test__/wysiwyg/wwTableCommand.spec.ts
@@ -171,7 +171,7 @@ describe('wysiwyg table commands', () => {
     });
 
     it('should add a row to next row of current cursor cell', () => {
-      setCellSelection([1, 1], [1, 1], false);
+      setCellSelection([1, 1], [1, 1], false); // select 'baz' cell
 
       cmd.exec('wysiwyg', 'addRowToNext');
 
@@ -204,7 +204,7 @@ describe('wysiwyg table commands', () => {
     });
 
     it('should add rows as selected row count after selection', () => {
-      setCellSelection([0, 0], [1, 1]);
+      setCellSelection([0, 0], [1, 1]); // select from 'foo' to 'qux' cells
 
       cmd.exec('wysiwyg', 'addRowToNext');
 
@@ -241,7 +241,7 @@ describe('wysiwyg table commands', () => {
     });
 
     it('should not add a row when selection is only at table head', () => {
-      setCellSelection([0, 0], [0, 1]);
+      setCellSelection([0, 0], [0, 1]); // select from 'foo' to 'bar' cells
 
       cmd.exec('wysiwyg', 'addRowToNext');
 
@@ -280,7 +280,7 @@ describe('wysiwyg table commands', () => {
     });
 
     it('should add a row to previous row of current cursor cell', () => {
-      setCellSelection([1, 1], [1, 1], false);
+      setCellSelection([1, 1], [1, 1], false); // select 'baz' cell
 
       cmd.exec('wysiwyg', 'addRowToPrev');
 
@@ -313,7 +313,7 @@ describe('wysiwyg table commands', () => {
     });
 
     it('should add rows as selected row count before selection', () => {
-      setCellSelection([1, 1], [2, 1]);
+      setCellSelection([1, 1], [2, 1]); // select from 'qux' to 'quuz' cells
 
       cmd.exec('wysiwyg', 'addRowToPrev');
 
@@ -350,7 +350,7 @@ describe('wysiwyg table commands', () => {
     });
 
     it('should not add a row when selection include table head', () => {
-      setCellSelection([0, 0], [1, 0]);
+      setCellSelection([0, 0], [1, 0]); // select from 'foo' to 'baz' cells
 
       cmd.exec('wysiwyg', 'addRowToPrev');
 
@@ -389,7 +389,7 @@ describe('wysiwyg table commands', () => {
     });
 
     it('should remove a row where current cursor cell is located', () => {
-      setCellSelection([1, 1], [1, 1], false);
+      setCellSelection([1, 1], [1, 1], false); // select from 'qux' cell
 
       cmd.exec('wysiwyg', 'removeRow');
 
@@ -418,7 +418,7 @@ describe('wysiwyg table commands', () => {
     });
 
     it('should remove columns as selected column count in selection', () => {
-      setCellSelection([3, 1], [2, 1]);
+      setCellSelection([3, 1], [2, 1]); // select from last to 'quuz' cells
 
       cmd.exec('wysiwyg', 'removeRow');
 
@@ -443,7 +443,7 @@ describe('wysiwyg table commands', () => {
     });
 
     it('should not remove rows when selection include table head', () => {
-      setCellSelection([0, 1], [2, 1]);
+      setCellSelection([0, 1], [2, 1]); // select from 'bar' to 'qux' cells
 
       cmd.exec('wysiwyg', 'removeRow');
 
@@ -476,7 +476,7 @@ describe('wysiwyg table commands', () => {
     });
 
     it('should not remove rows when all rows of table body are selected', () => {
-      setCellSelection([1, 0], [3, 0]);
+      setCellSelection([1, 0], [3, 0]); // select from 'baz' to 'corge' cells
 
       cmd.exec('wysiwyg', 'removeRow');
 
@@ -519,7 +519,7 @@ describe('wysiwyg table commands', () => {
     });
 
     it('should add a column to next column of current cursor cell', () => {
-      setCellSelection([1, 1], [1, 1], false);
+      setCellSelection([1, 1], [1, 1], false); // select 'quux' cell
 
       cmd.exec('wysiwyg', 'addColumnToNext');
 
@@ -554,7 +554,7 @@ describe('wysiwyg table commands', () => {
     });
 
     it('should add columns as selected column count to right of selection', () => {
-      setCellSelection([0, 0], [1, 1]);
+      setCellSelection([0, 0], [1, 1]); // select from 'foo' to 'quux' cells
 
       cmd.exec('wysiwyg', 'addColumnToNext');
 
@@ -602,7 +602,7 @@ describe('wysiwyg table commands', () => {
     });
 
     it('should add a column to previous column of current cursor cell', () => {
-      setCellSelection([1, 1], [1, 1], false);
+      setCellSelection([1, 1], [1, 1], false); // select 'quux' cell
 
       cmd.exec('wysiwyg', 'addColumnToPrev');
 
@@ -637,7 +637,7 @@ describe('wysiwyg table commands', () => {
     });
 
     it('should add columns as selected column count to right of selection', () => {
-      setCellSelection([0, 1], [2, 2]);
+      setCellSelection([0, 1], [2, 2]); // select from 'bar' to last cells
 
       cmd.exec('wysiwyg', 'addColumnToPrev');
 
@@ -685,7 +685,7 @@ describe('wysiwyg table commands', () => {
     });
 
     it('should remove a column where current cursor cell is located', () => {
-      setCellSelection([1, 1], [1, 1], false);
+      setCellSelection([1, 1], [1, 1], false); // select 'quux' cell
 
       cmd.exec('wysiwyg', 'removeColumn');
 
@@ -714,7 +714,7 @@ describe('wysiwyg table commands', () => {
     });
 
     it('should remove columns as selected column count in selection', () => {
-      setCellSelection([0, 0], [2, 1]);
+      setCellSelection([0, 1], [2, 2]); // select from 'bar' to last cells
 
       cmd.exec('wysiwyg', 'removeColumn');
 
@@ -722,15 +722,15 @@ describe('wysiwyg table commands', () => {
         <table>
           <thead>
             <tr>
-              <th class="te-cell-selected">baz</th>
+              <th>foo</th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <td class="te-cell-selected">quuz</td>
+              <td>qux</td>
             </tr>
             <tr>
-              <td class="te-cell-selected"><br></td>
+              <td>corge</td>
             </tr>
           </tbody>
         </table>
@@ -740,7 +740,7 @@ describe('wysiwyg table commands', () => {
     });
 
     it('should not remove columns when all columns are selected', () => {
-      setCellSelection([0, 0], [1, 2]);
+      setCellSelection([0, 0], [1, 2]); // select from 'foo' to 'quuz' cells
 
       cmd.exec('wysiwyg', 'removeRow');
 
@@ -811,7 +811,7 @@ describe('wysiwyg table commands', () => {
     });
 
     it('should change align attribute to columns by option', () => {
-      setCellSelection([2, 1], [2, 1]); // select last cell
+      setCellSelection([2, 1], [2, 1], false); // select last cell
 
       cmd.exec('wysiwyg', 'alignColumn', { align: 'left' });
 
@@ -865,7 +865,7 @@ describe('wysiwyg table commands', () => {
     });
 
     it('should add align attribute to columns with cursor in table hedaer', () => {
-      setCellSelection([0, 0], [0, 0]); // select 'foo' cell
+      setCellSelection([0, 0], [0, 0], false); // select 'foo' cell
 
       cmd.exec('wysiwyg', 'alignColumn', { align: 'left' });
 

--- a/apps/editor/src/__test__/wysiwyg/wwTableCommand.spec.ts
+++ b/apps/editor/src/__test__/wysiwyg/wwTableCommand.spec.ts
@@ -5,7 +5,7 @@ import EventEmitter from '@/event/eventEmitter';
 import CommandManager from '@/commands/commandManager';
 import CellSelection from '@/wysiwyg/plugins/tableSelection/cellSelection';
 
-import { getCellsPosInfo } from '@/wysiwyg/helper/table';
+import { getTableCellsInfo } from '@/wysiwyg/helper/table';
 
 describe('wysiwyg table commands', () => {
   let container: HTMLElement, wwe: WysiwygEditor, em: EventEmitter, cmd: CommandManager;
@@ -27,10 +27,10 @@ describe('wysiwyg table commands', () => {
     cellSelection = true
   ) {
     const doc = wwe.getModel();
-    const cellsPosInfo = getCellsPosInfo(doc.resolve(1));
+    const cellsInfo = getTableCellsInfo(doc.resolve(1));
 
-    const startCellOffset = cellsPosInfo[startRowIndex][startColumnIndex].offset;
-    const endCellOffset = cellsPosInfo[endRowIndex][endColumnIndex].offset;
+    const startCellOffset = cellsInfo[startRowIndex][startColumnIndex].offset;
+    const endCellOffset = cellsInfo[endRowIndex][endColumnIndex].offset;
 
     if (startCellOffset === endCellOffset && !cellSelection) {
       const from = startCellOffset + 1;

--- a/apps/editor/src/__test__/wysiwyg/wwTableCommand.spec.ts
+++ b/apps/editor/src/__test__/wysiwyg/wwTableCommand.spec.ts
@@ -161,7 +161,7 @@ describe('wysiwyg table commands', () => {
     });
   });
 
-  describe('addRowToNext command', () => {
+  describe('addRowToBottom command', () => {
     beforeEach(() => {
       cmd.exec('wysiwyg', 'addTable', {
         columns: 2,
@@ -173,7 +173,7 @@ describe('wysiwyg table commands', () => {
     it('should add a row to next row of current cursor cell', () => {
       setCellSelection([1, 1], [1, 1], false); // select 'baz' cell
 
-      cmd.exec('wysiwyg', 'addRowToNext');
+      cmd.exec('wysiwyg', 'addRowToBottom');
 
       const expected = oneLineTrim`
         <table>
@@ -206,7 +206,7 @@ describe('wysiwyg table commands', () => {
     it('should add rows as selected row count after selection', () => {
       setCellSelection([0, 0], [1, 1]); // select from 'foo' to 'qux' cells
 
-      cmd.exec('wysiwyg', 'addRowToNext');
+      cmd.exec('wysiwyg', 'addRowToBottom');
 
       const expected = oneLineTrim`
         <table>
@@ -243,7 +243,7 @@ describe('wysiwyg table commands', () => {
     it('should not add a row when selection is only at table head', () => {
       setCellSelection([0, 0], [0, 1]); // select from 'foo' to 'bar' cells
 
-      cmd.exec('wysiwyg', 'addRowToNext');
+      cmd.exec('wysiwyg', 'addRowToBottom');
 
       const expected = oneLineTrim`
         <table>
@@ -270,7 +270,7 @@ describe('wysiwyg table commands', () => {
     });
   });
 
-  describe('addRowToPrev command', () => {
+  describe('addRowToUp command', () => {
     beforeEach(() => {
       cmd.exec('wysiwyg', 'addTable', {
         columns: 2,
@@ -282,7 +282,7 @@ describe('wysiwyg table commands', () => {
     it('should add a row to previous row of current cursor cell', () => {
       setCellSelection([1, 1], [1, 1], false); // select 'baz' cell
 
-      cmd.exec('wysiwyg', 'addRowToPrev');
+      cmd.exec('wysiwyg', 'addRowToUp');
 
       const expected = oneLineTrim`
         <table>
@@ -315,7 +315,7 @@ describe('wysiwyg table commands', () => {
     it('should add rows as selected row count before selection', () => {
       setCellSelection([1, 1], [2, 1]); // select from 'qux' to 'quuz' cells
 
-      cmd.exec('wysiwyg', 'addRowToPrev');
+      cmd.exec('wysiwyg', 'addRowToUp');
 
       const expected = oneLineTrim`
         <table>
@@ -352,7 +352,7 @@ describe('wysiwyg table commands', () => {
     it('should not add a row when selection include table head', () => {
       setCellSelection([0, 0], [1, 0]); // select from 'foo' to 'baz' cells
 
-      cmd.exec('wysiwyg', 'addRowToPrev');
+      cmd.exec('wysiwyg', 'addRowToUp');
 
       const expected = oneLineTrim`
         <table>
@@ -509,7 +509,7 @@ describe('wysiwyg table commands', () => {
     });
   });
 
-  describe('addColumnToNext command', () => {
+  describe('addColumnToRight command', () => {
     beforeEach(() => {
       cmd.exec('wysiwyg', 'addTable', {
         columns: 3,
@@ -521,7 +521,7 @@ describe('wysiwyg table commands', () => {
     it('should add a column to next column of current cursor cell', () => {
       setCellSelection([1, 1], [1, 1], false); // select 'quux' cell
 
-      cmd.exec('wysiwyg', 'addColumnToNext');
+      cmd.exec('wysiwyg', 'addColumnToRight');
 
       const expected = oneLineTrim`
         <table>
@@ -556,7 +556,7 @@ describe('wysiwyg table commands', () => {
     it('should add columns as selected column count to right of selection', () => {
       setCellSelection([0, 0], [1, 1]); // select from 'foo' to 'quux' cells
 
-      cmd.exec('wysiwyg', 'addColumnToNext');
+      cmd.exec('wysiwyg', 'addColumnToRight');
 
       const expected = oneLineTrim`
         <table>
@@ -592,7 +592,7 @@ describe('wysiwyg table commands', () => {
     });
   });
 
-  describe('addColumnToPrev command', () => {
+  describe('addColumnToLeft command', () => {
     beforeEach(() => {
       cmd.exec('wysiwyg', 'addTable', {
         columns: 3,
@@ -604,7 +604,7 @@ describe('wysiwyg table commands', () => {
     it('should add a column to previous column of current cursor cell', () => {
       setCellSelection([1, 1], [1, 1], false); // select 'quux' cell
 
-      cmd.exec('wysiwyg', 'addColumnToPrev');
+      cmd.exec('wysiwyg', 'addColumnToLeft');
 
       const expected = oneLineTrim`
         <table>
@@ -639,7 +639,7 @@ describe('wysiwyg table commands', () => {
     it('should add columns as selected column count to right of selection', () => {
       setCellSelection([0, 1], [2, 2]); // select from 'bar' to last cells
 
-      cmd.exec('wysiwyg', 'addColumnToPrev');
+      cmd.exec('wysiwyg', 'addColumnToLeft');
 
       const expected = oneLineTrim`
         <table>

--- a/apps/editor/src/wysiwyg/helper/table.ts
+++ b/apps/editor/src/wysiwyg/helper/table.ts
@@ -3,9 +3,16 @@ import { Selection, TextSelection } from 'prosemirror-state';
 
 import { findNodeBy } from '@/wysiwyg/helper/node';
 
-export interface CellInfo {
+export interface CellPosInfo {
   offset: number;
   nodeSize: number;
+}
+
+export interface SelectionInfo {
+  rowIndex: number;
+  rowCount: number;
+  columnIndex: number;
+  columnCount: number;
 }
 
 export function createTableRows(
@@ -40,19 +47,14 @@ export function createTableRows(
   return tableRows;
 }
 
-export function createCellsToAdd(
-  [startRowIndex, startColumnIndex]: number[],
-  [endRowIndex, endColumnIndex]: number[],
-  columnCount: number,
-  cell: Node
-) {
-  const cellCount =
-    startRowIndex !== endRowIndex ? columnCount : getCountByRange(startColumnIndex, endColumnIndex);
-
+export function createCellsToAdd(count: number, offset: number, doc: Node) {
+  const { type } = doc
+    .resolve(offset + 1)
+    .node()
+    .copy();
   const cells = [];
-  const { type } = cell;
 
-  for (let i = 0, len = cellCount; i < len; i += 1) {
+  for (let index = 0; index < count; index += 1) {
     cells.push(type.create());
   }
 
@@ -66,6 +68,47 @@ export function findCell(pos: ResolvedPos) {
   );
 }
 
+export function findPrevCell([rowIndex, columnIndex]: number[], cellsPosInfo: CellPosInfo[][]) {
+  const allColumnCount = cellsPosInfo[0].length;
+
+  const firstCellInRow = columnIndex === 0;
+  const firstCellInTable = rowIndex === 0 && firstCellInRow;
+
+  if (!firstCellInTable) {
+    columnIndex -= 1;
+
+    if (firstCellInRow) {
+      rowIndex -= 1;
+      columnIndex = allColumnCount - 1;
+    }
+
+    return cellsPosInfo[rowIndex][columnIndex];
+  }
+
+  return null;
+}
+
+export function findNextCell([rowIndex, columnIndex]: number[], cellsPosInfo: CellPosInfo[][]) {
+  const allRowCount = cellsPosInfo.length;
+  const allColumnCount = cellsPosInfo[0].length;
+
+  const lastCellInRow = columnIndex === allColumnCount - 1;
+  const lastCellInTable = rowIndex === allRowCount - 1 && lastCellInRow;
+
+  if (!lastCellInTable) {
+    columnIndex += 1;
+
+    if (lastCellInRow) {
+      rowIndex += 1;
+      columnIndex = 0;
+    }
+
+    return cellsPosInfo[rowIndex][columnIndex];
+  }
+
+  return null;
+}
+
 export function isInCellElement(node: HTMLElement, root: Element) {
   while (node && node !== root) {
     if (node.nodeName === 'TD' || node.nodeName === 'TH') {
@@ -76,18 +119,6 @@ export function isInCellElement(node: HTMLElement, root: Element) {
   }
 
   return false;
-}
-
-export function judgeToRemoveCells(
-  [startRowIndex, startColumnIndex]: number[],
-  [endRowIndex, endColumnIndex]: number[],
-  columnCount: number
-) {
-  const selectedColumnCount = getCountByRange(startColumnIndex, endColumnIndex);
-  const selectedRows = startRowIndex !== endRowIndex;
-  const selectedAllColumns = startRowIndex === endRowIndex && selectedColumnCount === columnCount;
-
-  return !selectedRows && !selectedAllColumns;
 }
 
 export function getResolvedSelection(selection: Selection) {
@@ -107,23 +138,27 @@ export function getResolvedSelection(selection: Selection) {
   return { anchor, head };
 }
 
-function getCellPosInfoList(headOrBody: Node, startOffset: number) {
-  const cellInfos: CellInfo[] = [];
+function getCellsPosInfo(headOrBody: Node, startOffset: number) {
+  const infoList: CellPosInfo[][] = [];
 
   headOrBody.forEach((row: Node, rowOffset: number) => {
+    const cellInfoList: CellPosInfo[] = [];
+
     row.forEach(({ nodeSize }: Node, cellOffset: number) => {
-      cellInfos.push({
+      cellInfoList.push({
         // 2 is the sum of the front and back positions of the closing tag
         offset: startOffset + rowOffset + cellOffset + 2,
         nodeSize
       });
     });
+
+    infoList.push(cellInfoList);
   });
 
-  return cellInfos;
+  return infoList;
 }
 
-export function getAllCellPosInfoList(cellPos: ResolvedPos) {
+export function getTableCellsInfo(cellPos: ResolvedPos) {
   const foundTable = findNodeBy(cellPos, ({ type }: Node) => type.name === 'table');
 
   if (foundTable) {
@@ -133,8 +168,8 @@ export function getAllCellPosInfoList(cellPos: ResolvedPos) {
     const thead = node.child(0);
     const tbody = node.child(1);
 
-    const theadCellsPos = getCellPosInfoList(thead, tablePos);
-    const tbodyCellsPos = getCellPosInfoList(tbody, tablePos + thead.nodeSize);
+    const theadCellsPos = getCellsPosInfo(thead, tablePos);
+    const tbodyCellsPos = getCellsPosInfo(tbody, tablePos + thead.nodeSize);
 
     return theadCellsPos.concat(tbodyCellsPos);
   }
@@ -142,43 +177,12 @@ export function getAllCellPosInfoList(cellPos: ResolvedPos) {
   return [];
 }
 
-export function getTableByCellPos(cellPos: ResolvedPos) {
-  return cellPos.node(cellPos.depth - 2);
+function getIndexByRange(startIndex: number, endIndex: number) {
+  return Math.min(startIndex, endIndex);
 }
 
-export function getRowCount(table: Node) {
-  return table.child(1).childCount;
-}
-
-export function getColumnCount(table: Node) {
-  return table.child(0).child(0).childCount;
-}
-
-export function getCountByRange(startIndex: number, endIndex: number) {
+function getCountByRange(startIndex: number, endIndex: number) {
   return Math.abs(startIndex - endIndex) + 1;
-}
-
-export function getCellIndexesByRange(
-  table: Node,
-  [startRowIndex, startColumnIndex]: number[],
-  [endRowIndex, endColumnIndex]: number[]
-) {
-  const columnCount = getColumnCount(table);
-  const rowCount = getRowCount(table) + 1;
-
-  const columnStart =
-    startRowIndex !== endRowIndex ? 0 : Math.min(startColumnIndex, endColumnIndex);
-  const columnEnd = Math.max(startColumnIndex, endColumnIndex);
-
-  const indexes = [];
-
-  for (let rowIndex = 0; rowIndex < rowCount; rowIndex += 1) {
-    for (let columnIndex = columnStart, len = columnEnd; columnIndex <= len; columnIndex += 1) {
-      indexes.push(rowIndex * columnCount + columnIndex);
-    }
-  }
-
-  return indexes;
 }
 
 export function getCellIndexInfo(cellPos: ResolvedPos) {
@@ -198,63 +202,15 @@ export function getCellIndexInfo(cellPos: ResolvedPos) {
   return [rowIndex, columnIndex];
 }
 
-export function getSelectedCellRange(startCellPos: ResolvedPos, endCellPos: ResolvedPos) {
+export function getSelectionInfo(startCellPos: ResolvedPos, endCellPos = startCellPos) {
   const [startRowIndex, startColumnIndex] = getCellIndexInfo(startCellPos);
   const [endRowIndex, endColumnIndex] = getCellIndexInfo(endCellPos);
-  const columnCount = startCellPos.parent.childCount;
 
-  const [startIndex, endIndex] = [
-    startRowIndex * columnCount + startColumnIndex,
-    endRowIndex * columnCount + endColumnIndex
-  ];
+  const rowIndex = getIndexByRange(startRowIndex, endRowIndex);
+  const rowCount = getCountByRange(startRowIndex, endRowIndex);
 
-  return [Math.min(startIndex, endIndex), Math.max(startIndex, endIndex)];
-}
+  const columnIndex = getIndexByRange(startColumnIndex, endColumnIndex);
+  const columnCount = getCountByRange(startColumnIndex, endColumnIndex);
 
-export function getPositionsToAddRow(
-  cellPos: ResolvedPos,
-  startRowIndex: number,
-  endRowIndex: number
-) {
-  const onlyTheadSelected = startRowIndex === endRowIndex && startRowIndex === 0;
-  const endCellInThead = startRowIndex !== endRowIndex && endRowIndex === 0;
-
-  let start = cellPos.after(cellPos.depth);
-
-  if (onlyTheadSelected || endCellInThead) {
-    start += 2;
-  }
-
-  return [start, start];
-}
-
-export function getPositionsToRemoveRow(
-  startCellPos: ResolvedPos,
-  endCellPos: ResolvedPos,
-  rowCount: number
-) {
-  const [startRowIndex] = getCellIndexInfo(startCellPos);
-  const [endRowIndex] = getCellIndexInfo(endCellPos);
-
-  const onlyTheadSelected = startRowIndex === endRowIndex && startRowIndex === 0;
-  const endCellInThead = startRowIndex !== endRowIndex && endRowIndex === 0;
-
-  if (onlyTheadSelected || endCellInThead) {
-    return [];
-  }
-
-  let start = startCellPos.before(startCellPos.depth);
-  let selectedRowCount = getCountByRange(startRowIndex, endRowIndex);
-
-  if (startRowIndex === 0) {
-    start = startCellPos.after(startCellPos.depth) + 2;
-    selectedRowCount -= 1;
-  }
-
-  const end =
-    selectedRowCount === rowCount
-      ? endCellPos.before(endCellPos.depth)
-      : endCellPos.after(endCellPos.depth);
-
-  return [start, end];
+  return { rowIndex, rowCount, columnIndex, columnCount };
 }

--- a/apps/editor/src/wysiwyg/helper/table.ts
+++ b/apps/editor/src/wysiwyg/helper/table.ts
@@ -149,8 +149,8 @@ export function getNextRowOffset(
 
   if (!selectedOnlyThead) {
     const rowIdx = rowIndex + rowCount - 1;
-    const columnIdx = allColumnCount - 1;
-    const { offset, nodeSize } = cellsPosInfo[rowIdx][columnIdx];
+    const colIdx = allColumnCount - 1;
+    const { offset, nodeSize } = cellsPosInfo[rowIdx][colIdx];
 
     return offset + nodeSize + 1;
   }
@@ -168,6 +168,28 @@ export function getPrevRowOffset({ rowIndex }: SelectionInfo, cellsPosInfo: Cell
   }
 
   return -1;
+}
+
+export function getNextColumnOffsets(
+  rowIndex: number,
+  { columnIndex, columnCount }: SelectionInfo,
+  cellsPosInfo: CellPosInfo[][]
+) {
+  const { offset, nodeSize } = cellsPosInfo[rowIndex][columnIndex + columnCount - 1];
+  const mapOffset = offset + nodeSize;
+
+  return { offset, mapOffset };
+}
+
+export function getPrevColumnOffsets(
+  rowIndex: number,
+  { columnIndex, columnCount }: SelectionInfo,
+  cellsPosInfo: CellPosInfo[][]
+) {
+  const { offset } = cellsPosInfo[rowIndex][columnIndex];
+  const mapOffset = offset;
+
+  return { offset, mapOffset };
 }
 
 export function getResolvedSelection(selection: Selection) {

--- a/apps/editor/src/wysiwyg/helper/table.ts
+++ b/apps/editor/src/wysiwyg/helper/table.ts
@@ -37,17 +37,11 @@ export function createTableBodyRows(
   const { tableRow, tableBodyCell } = schema.nodes;
   const tableRows = [];
 
-  let dataIndex = 0;
-
-  for (let i = 0; i < rowCount; i += 1) {
+  for (let rowIndex = 0; rowIndex < rowCount; rowIndex += 1) {
     const cells = [];
 
-    for (let j = 0; j < columnCount; j += 1) {
-      const text = data && data[dataIndex];
-
-      if (text) {
-        dataIndex += 1;
-      }
+    for (let columnIndex = 0; columnIndex < columnCount; columnIndex += 1) {
+      const text = data && data[rowIndex * columnCount + columnIndex];
 
       cells.push(tableBodyCell.create(null, text ? schema.text(text) : []));
     }

--- a/apps/editor/src/wysiwyg/helper/table.ts
+++ b/apps/editor/src/wysiwyg/helper/table.ts
@@ -3,7 +3,7 @@ import { Selection, TextSelection } from 'prosemirror-state';
 
 import { findNodeBy } from '@/wysiwyg/helper/node';
 
-export interface CellPosInfo {
+export interface CellInfo {
   offset: number;
   nodeSize: number;
 }
@@ -91,7 +91,7 @@ export function findCell(pos: ResolvedPos) {
   );
 }
 
-export function findNextCell([rowIndex, columnIndex]: number[], cellsInfo: CellPosInfo[][]) {
+export function findNextCell([rowIndex, columnIndex]: number[], cellsInfo: CellInfo[][]) {
   const allRowCount = cellsInfo.length;
   const allColumnCount = cellsInfo[0].length;
 
@@ -112,7 +112,7 @@ export function findNextCell([rowIndex, columnIndex]: number[], cellsInfo: CellP
   return null;
 }
 
-export function findPrevCell([rowIndex, columnIndex]: number[], cellsInfo: CellPosInfo[][]) {
+export function findPrevCell([rowIndex, columnIndex]: number[], cellsInfo: CellInfo[][]) {
   const allColumnCount = cellsInfo[0].length;
 
   const firstCellInRow = columnIndex === 0;
@@ -140,10 +140,7 @@ function getCountByRange(startIndex: number, endIndex: number) {
   return Math.abs(startIndex - endIndex) + 1;
 }
 
-export function getNextRowOffset(
-  { rowIndex, rowCount }: SelectionInfo,
-  cellsInfo: CellPosInfo[][]
-) {
+export function getNextRowOffset({ rowIndex, rowCount }: SelectionInfo, cellsInfo: CellInfo[][]) {
   const allColumnCount = cellsInfo[0].length;
   const selectedOnlyThead = rowIndex === 0 && rowCount === 1;
 
@@ -158,7 +155,7 @@ export function getNextRowOffset(
   return -1;
 }
 
-export function getPrevRowOffset({ rowIndex }: SelectionInfo, cellsInfo: CellPosInfo[][]) {
+export function getPrevRowOffset({ rowIndex }: SelectionInfo, cellsInfo: CellInfo[][]) {
   const selectedThead = rowIndex === 0;
 
   if (!selectedThead) {
@@ -173,7 +170,7 @@ export function getPrevRowOffset({ rowIndex }: SelectionInfo, cellsInfo: CellPos
 export function getNextColumnOffsets(
   rowIndex: number,
   { columnIndex, columnCount }: SelectionInfo,
-  cellsInfo: CellPosInfo[][]
+  cellsInfo: CellInfo[][]
 ) {
   const { offset, nodeSize } = cellsInfo[rowIndex][columnIndex + columnCount - 1];
   const mapOffset = offset + nodeSize;
@@ -184,7 +181,7 @@ export function getNextColumnOffsets(
 export function getPrevColumnOffsets(
   rowIndex: number,
   { columnIndex }: SelectionInfo,
-  cellsInfo: CellPosInfo[][]
+  cellsInfo: CellInfo[][]
 ) {
   const { offset } = cellsInfo[rowIndex][columnIndex];
   const mapOffset = offset;
@@ -210,10 +207,10 @@ export function getResolvedSelection(selection: Selection) {
 }
 
 function getCellInfoMatrix(headOrBody: Node, startOffset: number) {
-  const cellInfoMatrix: CellPosInfo[][] = [];
+  const cellInfoMatrix: CellInfo[][] = [];
 
   headOrBody.forEach((row: Node, rowOffset: number) => {
-    const cellInfoList: CellPosInfo[] = [];
+    const cellInfoList: CellInfo[] = [];
 
     row.forEach(({ nodeSize }: Node, cellOffset: number) => {
       cellInfoList.push({

--- a/apps/editor/src/wysiwyg/nodes/table.ts
+++ b/apps/editor/src/wysiwyg/nodes/table.ts
@@ -103,7 +103,7 @@ export class Table extends Node {
           const columnIdx = direction === 1 ? columnIndex + columnCount - 1 : columnIndex;
           const { offset, nodeSize } = cellsPosInfo[i][columnIdx];
 
-          const mapOffset = direction === 1 ? offset + nodeSize : offset - 1;
+          const mapOffset = direction === 1 ? offset + nodeSize : offset;
           const from = tr.mapping.map(mapOffset);
           const cells = createCellsToAdd(columnCount, offset, doc);
 

--- a/apps/editor/src/wysiwyg/nodes/table.ts
+++ b/apps/editor/src/wysiwyg/nodes/table.ts
@@ -13,6 +13,8 @@ import {
   getCellIndexInfo,
   getNextRowOffset,
   getPrevRowOffset,
+  getNextColumnOffsets,
+  getPrevColumnOffsets,
   findNextCell,
   findPrevCell
 } from '@/wysiwyg/helper/table';
@@ -96,14 +98,15 @@ export class Table extends Node {
       if (anchor && head) {
         const selectionInfo = getSelectionInfo(anchor, head);
         const cellsPosInfo = getCellsPosInfo(anchor);
-        const { columnIndex, columnCount } = selectionInfo;
+        const { columnCount } = selectionInfo;
         const allRowCount = cellsPosInfo.length;
 
-        for (let i = 0; i < allRowCount; i += 1) {
-          const columnIdx = direction === 1 ? columnIndex + columnCount - 1 : columnIndex;
-          const { offset, nodeSize } = cellsPosInfo[i][columnIdx];
+        for (let rowIndex = 0; rowIndex < allRowCount; rowIndex += 1) {
+          const { offset, mapOffset } =
+            direction === 1
+              ? getNextColumnOffsets(rowIndex, selectionInfo, cellsPosInfo)
+              : getPrevColumnOffsets(rowIndex, selectionInfo, cellsPosInfo);
 
-          const mapOffset = direction === 1 ? offset + nodeSize : offset;
           const from = tr.mapping.map(mapOffset);
           const cells = createCellsToAdd(columnCount, offset, doc);
 
@@ -208,8 +211,8 @@ export class Table extends Node {
         const from = cellsPosInfo[rowIndex][0].offset - 1;
 
         const rowIdx = rowIndex + rowCount - 1;
-        const columnIdx = cellsPosInfo[0].length - 1;
-        const { offset, nodeSize } = cellsPosInfo[rowIdx][columnIdx];
+        const colIdx = cellsPosInfo[0].length - 1;
+        const { offset, nodeSize } = cellsPosInfo[rowIdx][colIdx];
         const to = offset + nodeSize + 1;
 
         dispatch!(tr.step(new ReplaceStep(from, to, Slice.empty)));

--- a/apps/editor/src/wysiwyg/nodes/table.ts
+++ b/apps/editor/src/wysiwyg/nodes/table.ts
@@ -9,7 +9,7 @@ import {
   createCellsToAdd,
   getResolvedSelection,
   getSelectionInfo,
-  getCellsPosInfo,
+  getTableCellsInfo,
   getCellIndexInfo,
   getNextRowOffset,
   getPrevRowOffset,
@@ -97,15 +97,15 @@ export class Table extends Node {
 
       if (anchor && head) {
         const selectionInfo = getSelectionInfo(anchor, head);
-        const cellsPosInfo = getCellsPosInfo(anchor);
+        const cellsInfo = getTableCellsInfo(anchor);
         const { columnCount } = selectionInfo;
-        const allRowCount = cellsPosInfo.length;
+        const allRowCount = cellsInfo.length;
 
         for (let rowIndex = 0; rowIndex < allRowCount; rowIndex += 1) {
           const { offset, mapOffset } =
             direction === 1
-              ? getNextColumnOffsets(rowIndex, selectionInfo, cellsPosInfo)
-              : getPrevColumnOffsets(rowIndex, selectionInfo, cellsPosInfo);
+              ? getNextColumnOffsets(rowIndex, selectionInfo, cellsInfo)
+              : getPrevColumnOffsets(rowIndex, selectionInfo, cellsInfo);
 
           const from = tr.mapping.map(mapOffset);
           const cells = createCellsToAdd(columnCount, offset, doc);
@@ -129,9 +129,9 @@ export class Table extends Node {
 
       if (anchor && head) {
         const selectionInfo = getSelectionInfo(anchor, head);
-        const cellsPosInfo = getCellsPosInfo(anchor);
+        const cellsInfo = getTableCellsInfo(anchor);
         const { columnIndex, columnCount } = selectionInfo;
-        const allColumnCount = cellsPosInfo[0].length;
+        const allColumnCount = cellsInfo[0].length;
 
         const selectedAllColumn = columnCount === allColumnCount;
 
@@ -139,12 +139,12 @@ export class Table extends Node {
           return false;
         }
 
-        const allRowCount = cellsPosInfo.length;
+        const allRowCount = cellsInfo.length;
         const mapOffset = tr.mapping.maps.length;
 
         for (let i = 0; i < allRowCount; i += 1) {
           for (let j = 0; j < columnCount; j += 1) {
-            const { offset, nodeSize } = cellsPosInfo[i][j + columnIndex];
+            const { offset, nodeSize } = cellsInfo[i][j + columnIndex];
 
             const from = tr.mapping.slice(mapOffset).map(offset);
             const to = from + nodeSize;
@@ -169,13 +169,13 @@ export class Table extends Node {
 
       if (anchor && head) {
         const selectionInfo = getSelectionInfo(anchor, head);
-        const cellsPosInfo = getCellsPosInfo(anchor);
+        const cellsInfo = getTableCellsInfo(anchor);
         const { rowCount } = selectionInfo;
-        const allColumnCount = cellsPosInfo[0].length;
+        const allColumnCount = cellsInfo[0].length;
         const from =
           direction === 1
-            ? getNextRowOffset(selectionInfo, cellsPosInfo)
-            : getPrevRowOffset(selectionInfo, cellsPosInfo);
+            ? getNextRowOffset(selectionInfo, cellsInfo)
+            : getPrevRowOffset(selectionInfo, cellsInfo);
 
         if (from > -1) {
           const rows = createTableBodyRows(rowCount, allColumnCount, schema);
@@ -197,9 +197,9 @@ export class Table extends Node {
 
       if (anchor && head) {
         const selectionInfo = getSelectionInfo(anchor, head);
-        const cellsPosInfo = getCellsPosInfo(anchor);
+        const cellsInfo = getTableCellsInfo(anchor);
         const { rowIndex, rowCount } = selectionInfo;
-        const allRowCount = cellsPosInfo.length;
+        const allRowCount = cellsInfo.length;
 
         const selectedThead = rowIndex === 0;
         const selectedAllTbodyRow = rowCount === allRowCount - 1;
@@ -208,11 +208,11 @@ export class Table extends Node {
           return false;
         }
 
-        const from = cellsPosInfo[rowIndex][0].offset - 1;
+        const from = cellsInfo[rowIndex][0].offset - 1;
 
         const rowIdx = rowIndex + rowCount - 1;
-        const colIdx = cellsPosInfo[0].length - 1;
-        const { offset, nodeSize } = cellsPosInfo[rowIdx][colIdx];
+        const colIdx = cellsInfo[0].length - 1;
+        const { offset, nodeSize } = cellsInfo[rowIdx][colIdx];
         const to = offset + nodeSize + 1;
 
         dispatch!(tr.step(new ReplaceStep(from, to, Slice.empty)));
@@ -232,13 +232,13 @@ export class Table extends Node {
 
       if (anchor && head) {
         const selectionInfo = getSelectionInfo(anchor, head);
-        const cellsPosInfo = getCellsPosInfo(anchor);
+        const cellsInfo = getTableCellsInfo(anchor);
         const { columnIndex, columnCount } = selectionInfo;
-        const allRowCount = cellsPosInfo.length;
+        const allRowCount = cellsInfo.length;
 
         for (let i = 0; i < allRowCount; i += 1) {
           for (let j = 0; j < columnCount; j += 1) {
-            const { offset } = cellsPosInfo[i][j + columnIndex];
+            const { offset } = cellsInfo[i][j + columnIndex];
 
             tr.setNodeMarkup(offset, null, { align });
           }
@@ -259,12 +259,10 @@ export class Table extends Node {
       const { anchor, head } = getResolvedSelection(selection);
 
       if (anchor && head) {
-        const cellsPosInfo = getCellsPosInfo(anchor);
+        const cellsInfo = getTableCellsInfo(anchor);
         const cellIndex = getCellIndexInfo(anchor);
         const foundCell =
-          direction === 1
-            ? findNextCell(cellIndex, cellsPosInfo)
-            : findPrevCell(cellIndex, cellsPosInfo);
+          direction === 1 ? findNextCell(cellIndex, cellsInfo) : findPrevCell(cellIndex, cellsInfo);
 
         if (foundCell) {
           const { offset, nodeSize } = foundCell;

--- a/apps/editor/src/wysiwyg/plugins/tableSelection/cellSelection.ts
+++ b/apps/editor/src/wysiwyg/plugins/tableSelection/cellSelection.ts
@@ -44,7 +44,7 @@ export default class CellSelection extends Selection {
   map(doc: Node, mapping: Mappable) {
     const startCell = doc.resolve(mapping.map(this.$anchor.pos));
     const endCell = doc.resolve(mapping.map(this.$head.pos));
-    const removed = startCell === endCell;
+    const removed = startCell.parent.childCount < this.$anchor.parent.childCount;
 
     if (removed) {
       const from = doc.resolve(startCell.pos + 1);

--- a/apps/editor/src/wysiwyg/plugins/tableSelection/cellSelection.ts
+++ b/apps/editor/src/wysiwyg/plugins/tableSelection/cellSelection.ts
@@ -4,7 +4,7 @@ import { Mappable } from 'prosemirror-transform';
 
 import {
   getSelectionInfo,
-  getCellsPosInfo,
+  getTableCellsInfo,
   CellPosInfo,
   SelectionInfo
 } from '@/wysiwyg/helper/table';
@@ -31,7 +31,7 @@ export default class CellSelection extends Selection {
   constructor(startCellPos: ResolvedPos, endCellPos = startCellPos) {
     const doc = startCellPos.node(0);
 
-    const cellsPos = getCellsPosInfo(startCellPos);
+    const cellsPos = getTableCellsInfo(startCellPos);
     const selectionInfo = getSelectionInfo(startCellPos, endCellPos);
     const ranges = getSelectionRanges(doc, cellsPos, selectionInfo);
 

--- a/apps/editor/src/wysiwyg/plugins/tableSelection/cellSelection.ts
+++ b/apps/editor/src/wysiwyg/plugins/tableSelection/cellSelection.ts
@@ -12,13 +12,13 @@ import {
 function getSelectionRanges(
   doc: Node,
   cellsPos: CellInfo[][],
-  { rowIndex, rowCount, columnIndex, columnCount }: SelectionInfo
+  { startRowIndex, rowCount, startColumnIndex, columnCount }: SelectionInfo
 ) {
   const ranges = [];
 
   for (let i = 0; i < rowCount; i += 1) {
     for (let j = 0; j < columnCount; j += 1) {
-      const { offset, nodeSize } = cellsPos[i + rowIndex][j + columnIndex];
+      const { offset, nodeSize } = cellsPos[i + startRowIndex][j + startColumnIndex];
 
       ranges.push(new SelectionRange(doc.resolve(offset), doc.resolve(offset + nodeSize)));
     }

--- a/apps/editor/src/wysiwyg/plugins/tableSelection/cellSelection.ts
+++ b/apps/editor/src/wysiwyg/plugins/tableSelection/cellSelection.ts
@@ -2,19 +2,38 @@ import { Node, ResolvedPos } from 'prosemirror-model';
 import { Selection, SelectionRange, TextSelection } from 'prosemirror-state';
 import { Mappable } from 'prosemirror-transform';
 
-import { CellInfo, getAllCellPosInfoList, getSelectedCellRange } from '@/wysiwyg/helper/table';
+import {
+  getSelectionInfo,
+  getTableCellsInfo,
+  CellPosInfo,
+  SelectionInfo
+} from '@/wysiwyg/helper/table';
+
+function getSelectionRanges(
+  doc: Node,
+  cellsPos: CellPosInfo[][],
+  { rowIndex, rowCount, columnIndex, columnCount }: SelectionInfo
+) {
+  const ranges = [];
+
+  for (let i = 0; i < rowCount; i += 1) {
+    for (let j = 0; j < columnCount; j += 1) {
+      const { offset, nodeSize } = cellsPos[i + rowIndex][j + columnIndex];
+
+      ranges.push(new SelectionRange(doc.resolve(offset), doc.resolve(offset + nodeSize)));
+    }
+  }
+
+  return ranges;
+}
 
 export default class CellSelection extends Selection {
   constructor(startCellPos: ResolvedPos, endCellPos = startCellPos) {
     const doc = startCellPos.node(0);
 
-    const [startIndex, endIndex] = getSelectedCellRange(startCellPos, endCellPos);
-    const positions = getAllCellPosInfoList(startCellPos).slice(startIndex, endIndex + 1);
-
-    const ranges = positions.map(
-      ({ offset, nodeSize }: CellInfo) =>
-        new SelectionRange(doc.resolve(offset), doc.resolve(offset + nodeSize))
-    );
+    const cellsPos = getTableCellsInfo(startCellPos);
+    const selectionInfo = getSelectionInfo(startCellPos, endCellPos);
+    const ranges = getSelectionRanges(doc, cellsPos, selectionInfo);
 
     super(ranges[0].$from, ranges[0].$to, ranges);
 

--- a/apps/editor/src/wysiwyg/plugins/tableSelection/cellSelection.ts
+++ b/apps/editor/src/wysiwyg/plugins/tableSelection/cellSelection.ts
@@ -4,7 +4,7 @@ import { Mappable } from 'prosemirror-transform';
 
 import {
   getSelectionInfo,
-  getTableCellsInfo,
+  getCellsPosInfo,
   CellPosInfo,
   SelectionInfo
 } from '@/wysiwyg/helper/table';
@@ -31,7 +31,7 @@ export default class CellSelection extends Selection {
   constructor(startCellPos: ResolvedPos, endCellPos = startCellPos) {
     const doc = startCellPos.node(0);
 
-    const cellsPos = getTableCellsInfo(startCellPos);
+    const cellsPos = getCellsPosInfo(startCellPos);
     const selectionInfo = getSelectionInfo(startCellPos, endCellPos);
     const ranges = getSelectionRanges(doc, cellsPos, selectionInfo);
 

--- a/apps/editor/src/wysiwyg/plugins/tableSelection/cellSelection.ts
+++ b/apps/editor/src/wysiwyg/plugins/tableSelection/cellSelection.ts
@@ -5,13 +5,13 @@ import { Mappable } from 'prosemirror-transform';
 import {
   getSelectionInfo,
   getTableCellsInfo,
-  CellPosInfo,
+  CellInfo,
   SelectionInfo
 } from '@/wysiwyg/helper/table';
 
 function getSelectionRanges(
   doc: Node,
-  cellsPos: CellPosInfo[][],
+  cellsPos: CellInfo[][],
   { rowIndex, rowCount, columnIndex, columnCount }: SelectionInfo
 ) {
   const ranges = [];

--- a/apps/editor/src/wysiwyg/plugins/tableSelection/tableSelectionView.ts
+++ b/apps/editor/src/wysiwyg/plugins/tableSelection/tableSelectionView.ts
@@ -33,7 +33,7 @@ export default class TableSelection {
   }
 
   init() {
-    this.view.root.addEventListener('mousedown', this.handlers.mousedown);
+    this.view.dom.addEventListener('mousedown', this.handlers.mousedown);
   }
 
   handleMousedown(ev: Event) {
@@ -72,17 +72,17 @@ export default class TableSelection {
   }
 
   bindEvent() {
-    const { root } = this.view;
+    const { dom } = this.view;
 
-    root.addEventListener('mousemove', this.handlers.mousemove);
-    root.addEventListener('mouseup', this.handlers.mouseup);
+    dom.addEventListener('mousemove', this.handlers.mousemove);
+    dom.addEventListener('mouseup', this.handlers.mouseup);
   }
 
   unbindEvent() {
-    const { root } = this.view;
+    const { dom } = this.view;
 
-    root.removeEventListener('mousemove', this.handlers.mousemove);
-    root.removeEventListener('mouseup', this.handlers.mouseup);
+    dom.removeEventListener('mousemove', this.handlers.mousemove);
+    dom.removeEventListener('mouseup', this.handlers.mouseup);
   }
 
   getCellIndexInfo({ clientX, clientY }: MouseEvent) {
@@ -113,6 +113,6 @@ export default class TableSelection {
   }
 
   destroy() {
-    this.view.root.removeEventListener('mousedown', this.handlers.mousedown);
+    this.view.dom.removeEventListener('mousedown', this.handlers.mousedown);
   }
 }


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

## Feature

### Change selection unit

The selection unit has been changed to select within a **rectangular range** instead of selecting all cells between anchor and head cells.

**Before**

![selection-before](https://user-images.githubusercontent.com/18183560/101311548-02038600-3895-11eb-84db-819c2065fe35.gif)

**After**

![selection-after](https://user-images.githubusercontent.com/18183560/101311512-f021e300-3894-11eb-8054-d0e8a35cb2dc.gif)

### Change selection unit

Previously, columns or rows were added after the head cell. After the selection unit is changed, columns or rows are added before the selection when executing `ToPrev` commands and after the selection when executing `ToNext` commands.

**Before**
* `addColumn`
* `addRow `

![command-before](https://user-images.githubusercontent.com/18183560/101321164-464c5180-38a8-11eb-94cc-eeef64fcffbd.gif)

**After**
* `addColumnToNext` -> `addColumnToDown`
* `addColumnToPrev` -> `addColumnToUp`
* `addRowToNext` -> `addColumnToRight`
* `addRowToPrev` -> `addColumnToLeft`

![command-after](https://user-images.githubusercontent.com/18183560/101321151-43516100-38a8-11eb-920c-9c4f70a93887.gif)

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
