### PR TITLE
fix: react-editor 'onEvent' props missing

### DIFF
--- a/apps/editor/index.d.ts
+++ b/apps/editor/index.d.ts
@@ -229,7 +229,7 @@ declare namespace toastui {
   }
 
   export interface ConvertorClass {
-    new (em: EventManager, options: ConvertorOptions): Convertor;
+    new(em: EventManager, options: ConvertorOptions): Convertor;
   }
 
   export interface ConvertorOptions {
@@ -853,6 +853,9 @@ declare namespace toastui {
 }
 
 declare module '@toast-ui/editor' {
+  export type SourceType = toastui.SourceType;
+  export type MarkdownToolbarState = toastui.MarkdownToolbarState;
+  export type WysiwygToolbarState = toastui.WysiwygToolbarState;
   export type EditorOptions = toastui.EditorOptions;
   export type CustomConvertor = toastui.ConvertorClass;
   export type EventMap = toastui.EventMap;

--- a/apps/react-editor/index.d.ts
+++ b/apps/react-editor/index.d.ts
@@ -2,7 +2,13 @@ import { Component } from 'react';
 import ToastuiEditor, { EditorOptions } from '@toast-ui/editor';
 import ToastuiEditorViewer, { ViewerOptions } from '@toast-ui/editor/dist/toastui-editor-viewer';
 
-type EditorProps = Omit<EditorOptions, 'el'>;
+type EditorProps = Omit<EditorOptions& {
+  onLoad?: (param: Editor) => void;
+  onChange?: (param: { source: SourceType | 'viewer'; data: MouseEvent }) => void;
+  onStateChange?: (param: MarkdownToolbarState | WysiwygToolbarState) => void;
+  onFocus?: (param: { source: SourceType }) => void;
+  onBlur?: (param: { source: SourceType }) => void;
+}, 'el'>;
 type ViewerProps = Omit<ViewerOptions, 'el'>;
 
 export class Editor extends Component<EditorProps> {

--- a/apps/react-editor/index.d.ts
+++ b/apps/react-editor/index.d.ts
@@ -1,8 +1,9 @@
 import { Component } from 'react';
-import ToastuiEditor, { EditorOptions } from '@toast-ui/editor';
+import ToastuiEditor, { EditorOptions, SourceType, MarkdownToolbarState, WysiwygToolbarState } from '@toast-ui/editor';
 import ToastuiEditorViewer, { ViewerOptions } from '@toast-ui/editor/dist/toastui-editor-viewer';
 
-type EditorProps = Omit<EditorOptions& {
+
+type EditorProps = Omit<EditorOptions & {
   onLoad?: (param: Editor) => void;
   onChange?: (param: { source: SourceType | 'viewer'; data: MouseEvent }) => void;
   onStateChange?: (param: MarkdownToolbarState | WysiwygToolbarState) => void;


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description
Fix React-editor 'onEvent' props missing, or it will cause a fatal error when using TypeScript.


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
