### PR TITLE
feat: add wysiwyg task plugin

### DIFF
--- a/apps/editor/src/__test__/dom.spec.ts
+++ b/apps/editor/src/__test__/dom.spec.ts
@@ -1,0 +1,29 @@
+import { isInBox } from '@/wysiwyg/helper/dom';
+
+describe('dom utils', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.parentNode!.removeChild(container);
+  });
+
+  it('isInBox() returns state whether position is contained within box size', () => {
+    container.innerHTML = '<div class="test">foo</div>';
+
+    const div = document.querySelector('.test') as HTMLElement;
+    const { style } = div;
+
+    style.left = '0';
+    style.top = '0';
+    style.width = '10px';
+    style.height = '10px';
+
+    expect(isInBox(style, 5, 5)).toBe(true);
+    expect(isInBox(style, 15, 15)).toBe(false);
+  });
+});

--- a/apps/editor/src/__test__/dom.spec.ts
+++ b/apps/editor/src/__test__/dom.spec.ts
@@ -1,4 +1,4 @@
-import { isInBox } from '@/wysiwyg/helper/dom';
+import { isPositionInBox } from '@/wysiwyg/helper/dom';
 
 describe('dom utils', () => {
   let container: HTMLElement;
@@ -12,7 +12,7 @@ describe('dom utils', () => {
     container.parentNode!.removeChild(container);
   });
 
-  it('isInBox() returns state whether position is contained within box size', () => {
+  it('isPositionInBox() returns state whether position is contained within box size', () => {
     container.innerHTML = '<div class="test">foo</div>';
 
     const div = document.querySelector('.test') as HTMLElement;
@@ -23,7 +23,7 @@ describe('dom utils', () => {
     style.width = '10px';
     style.height = '10px';
 
-    expect(isInBox(style, 5, 5)).toBe(true);
-    expect(isInBox(style, 15, 15)).toBe(false);
+    expect(isPositionInBox(style, 5, 5)).toBe(true);
+    expect(isPositionInBox(style, 15, 15)).toBe(false);
   });
 });

--- a/apps/editor/src/__test__/dom.spec.ts
+++ b/apps/editor/src/__test__/dom.spec.ts
@@ -1,3 +1,4 @@
+// @TODO move to utils/dom.ts
 import { isPositionInBox } from '@/wysiwyg/helper/dom';
 
 describe('dom utils', () => {

--- a/apps/editor/src/wysiwyg/helper/dom.ts
+++ b/apps/editor/src/wysiwyg/helper/dom.ts
@@ -1,4 +1,5 @@
-export function isInBox(style: CSSStyleDeclaration, offsetX: number, offsetY: number) {
+// @TODO move to utils/dom.ts
+export function isPositionInBox(style: CSSStyleDeclaration, offsetX: number, offsetY: number) {
   const rect = {
     left: parseInt(style.left, 10),
     top: parseInt(style.top, 10),

--- a/apps/editor/src/wysiwyg/helper/dom.ts
+++ b/apps/editor/src/wysiwyg/helper/dom.ts
@@ -1,0 +1,15 @@
+export function isInBox(style: CSSStyleDeclaration, offsetX: number, offsetY: number) {
+  const rect = {
+    left: parseInt(style.left, 10),
+    top: parseInt(style.top, 10),
+    width: parseInt(style.width, 10),
+    height: parseInt(style.height, 10)
+  };
+
+  return (
+    offsetX >= rect.left &&
+    offsetX <= rect.left + rect.width &&
+    offsetY >= rect.top &&
+    offsetY <= rect.top + rect.height
+  );
+}

--- a/apps/editor/src/wysiwyg/helper/node.ts
+++ b/apps/editor/src/wysiwyg/helper/node.ts
@@ -30,3 +30,7 @@ export function isInTableNode(pos: ResolvedPos) {
     ({ type }: Node) => type.name === 'tableHeadCell' || type.name === 'tableBodyCell'
   );
 }
+
+export function findListItem(pos: ResolvedPos) {
+  return findNodeBy(pos, ({ type }: Node) => type.name === 'listItem');
+}

--- a/apps/editor/src/wysiwyg/plugins/tableContextMenu.ts
+++ b/apps/editor/src/wysiwyg/plugins/tableContextMenu.ts
@@ -15,9 +15,11 @@ export function tableContextMenuPlugin(eventEmitter: Emitter) {
 
           if (inTable) {
             eventEmitter.emit('closeAllPopup', ev);
+
+            return true;
           }
 
-          return true;
+          return false;
         },
         contextmenu: (view: EditorView, ev: Event) => {
           const inTable = isInCellElement(ev.target as HTMLElement, view.dom);
@@ -25,9 +27,11 @@ export function tableContextMenuPlugin(eventEmitter: Emitter) {
           if (inTable) {
             ev.preventDefault();
             eventEmitter.emit('openPopupTableUtils', ev);
+
+            return true;
           }
 
-          return true;
+          return false;
         }
       }
     }

--- a/apps/editor/src/wysiwyg/plugins/taskPlugin.ts
+++ b/apps/editor/src/wysiwyg/plugins/taskPlugin.ts
@@ -1,0 +1,43 @@
+import { Plugin } from 'prosemirror-state';
+import { EditorView } from 'prosemirror-view';
+
+import { isInBox } from '@/wysiwyg/helper/dom';
+import { findListItem } from '@/wysiwyg/helper/node';
+
+export function taskPlugin() {
+  return new Plugin({
+    props: {
+      handleDOMEvents: {
+        mousedown: (view: EditorView, ev: Event) => {
+          const { clientX, clientY } = ev as MouseEvent;
+          const mousePos = view.posAtCoords({ left: clientX, top: clientY });
+
+          if (mousePos) {
+            const { doc, tr } = view.state;
+            const currentPos = doc.resolve(mousePos.pos);
+            const listItem = findListItem(currentPos);
+
+            const target = ev.target as HTMLElement;
+            const style = getComputedStyle(target, ':before');
+            const { offsetX, offsetY } = ev as MouseEvent;
+
+            if (!listItem || !isInBox(style, offsetX, offsetY)) {
+              return true;
+            }
+
+            ev.preventDefault();
+
+            const offset = currentPos.before(listItem.depth);
+            const { attrs } = listItem.node;
+            const { checked } = attrs;
+
+            tr.setNodeMarkup(offset, null, { ...attrs, ...{ checked: !checked } });
+            view.dispatch!(tr);
+          }
+
+          return true;
+        }
+      }
+    }
+  });
+}

--- a/apps/editor/src/wysiwyg/plugins/taskPlugin.ts
+++ b/apps/editor/src/wysiwyg/plugins/taskPlugin.ts
@@ -33,9 +33,11 @@ export function taskPlugin() {
 
             tr.setNodeMarkup(offset, null, { ...attrs, ...{ checked: !checked } });
             view.dispatch!(tr);
+
+            return true;
           }
 
-          return true;
+          return false;
         }
       }
     }

--- a/apps/editor/src/wysiwyg/plugins/taskPlugin.ts
+++ b/apps/editor/src/wysiwyg/plugins/taskPlugin.ts
@@ -1,7 +1,7 @@
 import { Plugin } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 
-import { isInBox } from '@/wysiwyg/helper/dom';
+import { isPositionInBox } from '@/wysiwyg/helper/dom';
 import { findListItem } from '@/wysiwyg/helper/node';
 
 export function taskPlugin() {
@@ -21,7 +21,7 @@ export function taskPlugin() {
             const style = getComputedStyle(target, ':before');
             const { offsetX, offsetY } = ev as MouseEvent;
 
-            if (!listItem || !isInBox(style, offsetX, offsetY)) {
+            if (!listItem || !isPositionInBox(style, offsetX, offsetY)) {
               return true;
             }
 

--- a/apps/editor/src/wysiwyg/plugins/taskPlugin.ts
+++ b/apps/editor/src/wysiwyg/plugins/taskPlugin.ts
@@ -29,9 +29,8 @@ export function taskPlugin() {
 
             const offset = currentPos.before(listItem.depth);
             const { attrs } = listItem.node;
-            const { checked } = attrs;
 
-            tr.setNodeMarkup(offset, null, { ...attrs, ...{ checked: !checked } });
+            tr.setNodeMarkup(offset, null, { ...attrs, ...{ checked: !attrs.checked } });
             view.dispatch!(tr);
 
             return true;

--- a/apps/editor/src/wysiwyg/wwEditor.ts
+++ b/apps/editor/src/wysiwyg/wwEditor.ts
@@ -11,6 +11,7 @@ import { getWwCommands } from '@/commands/wwCommands';
 
 import { tableSelectionPlugin } from '@/wysiwyg/plugins/tableSelection';
 import { tableContextMenuPlugin } from '@/wysiwyg/plugins/tableContextMenu';
+import { taskPlugin } from '@/wysiwyg/plugins/taskPlugin';
 
 // @TODO move to common file and change path on markdown
 import { createTextSelection } from '@/markdown/helper/manipulation';
@@ -70,7 +71,8 @@ export default class WysiwygEditor extends EditorBase {
         }),
         history(),
         tableSelectionPlugin(),
-        tableContextMenuPlugin(this.eventEmitter)
+        tableContextMenuPlugin(this.eventEmitter),
+        taskPlugin()
       ],
       ...addedStates
     });


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

## Feature

### Add WYSIWYG task marker plugin

Add a plugin so that the state changes when the marker of the WYSIWYG task is clicked.

![wysiwyg-task](https://user-images.githubusercontent.com/18183560/101632169-da651700-3a68-11eb-93a4-5535fc0e405d.gif)

## TODO

* [ ] Move to `dom.ts` and change file name to `dom.js` -> `dom-old.js`

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
