### PR TITLE
fix: markdown highlighting(blockquote, codeblock)

### DIFF
--- a/apps/editor/src/__test__/markdown/syntaxHighlight.spec.ts
+++ b/apps/editor/src/__test__/markdown/syntaxHighlight.spec.ts
@@ -174,4 +174,12 @@ describe('markdown editor syntax highlight', () => {
 
     expect(html).toMatchSnapshot();
   });
+
+  it('code block within list', () => {
+    mde.setMarkdown('* list\n  ```js\n  console.log("editor")\n  ```');
+
+    const html = getEditorHTML(mde);
+
+    expect(html).toMatchSnapshot();
+  });
 });

--- a/apps/editor/src/markdown/helper/pos.ts
+++ b/apps/editor/src/markdown/helper/pos.ts
@@ -48,12 +48,12 @@ export function getEditorToMdPos(doc: ProsemirrorNode, from: number, to = from):
   const startResolvedPos = doc.resolve(from);
   const lineRange = getEditorToMdLine(from, to, doc);
 
-  const startOffset = startResolvedPos.start();
+  const startOffset = startResolvedPos.start(1);
   let endOffset = startOffset;
 
   if (!collapsed) {
     // To resolve the end offset for blank line
-    // to = getEndOffsetWithBlankLine(doc, to, lineRange);
+    to = getEndOffsetWithBlankLine(doc, to, lineRange);
 
     const endResolvedPos = doc.resolve(to);
 
@@ -66,8 +66,8 @@ export function getEditorToMdPos(doc: ProsemirrorNode, from: number, to = from):
   }
 
   return [
-    [lineRange[0], from - startOffset + 1],
-    [lineRange[1], to - endOffset + 1]
+    [lineRange[0], Math.max(from - startOffset + 1, 1)],
+    [lineRange[1], Math.max(to - endOffset + 1, 1)]
   ];
 }
 

--- a/apps/editor/src/markdown/plugins/helper/markInfo.ts
+++ b/apps/editor/src/markdown/plugins/helper/markInfo.ts
@@ -224,12 +224,7 @@ function blockQuote(node: MdNode, start: MdPos, end: MdPos) {
     let childMarks: MarkInfo[] = [];
 
     if (node.firstChild.type === 'paragraph') {
-      let childNode = node.firstChild;
-
-      while (childNode) {
-        childMarks = childMarks.concat(markParagraphInBlockQuote(childNode.firstChild!));
-        childNode = childNode.next!;
-      }
+      childMarks = markParagraphInBlockQuote(node.firstChild.firstChild!);
     } else if (node.firstChild.type === 'list') {
       childMarks = markListItemChildren(node.firstChild, TEXT);
     }

--- a/apps/editor/src/markdown/plugins/helper/markInfo.ts
+++ b/apps/editor/src/markdown/plugins/helper/markInfo.ts
@@ -55,12 +55,7 @@ interface MarkInfo {
   spec: { type?: MarkType; attrs?: Record<string, any> };
 }
 
-function markInfo(
-  start: MdPos,
-  end: MdPos,
-  type?: MarkType,
-  attrs?: Record<string, any>
-): MarkInfo {
+function markInfo(start: MdPos, end: MdPos, type: MarkType, attrs?: Record<string, any>): MarkInfo {
   return { start, end, spec: { type, attrs } };
 }
 
@@ -154,14 +149,14 @@ function codeBlock(node: MdNode, start: MdPos, end: MdPos, endLine: string) {
   if (info) {
     marks.push(
       markInfo(
-        setOffsetPos(start, fenceEnd + 1),
-        setOffsetPos(start, fenceEnd + infoPadding + info.length + 1),
+        addOffsetPos(start, fenceLength),
+        addOffsetPos(start, fenceLength + infoPadding + info.length),
         META
       )
     );
   }
 
-  const codeBlockEnd = `^(\\s{0,3})(${fenceChar}{${fenceLength},})`;
+  const codeBlockEnd = `^(\\s{0,4})(${fenceChar}{${fenceLength},})`;
   const reCodeBlockEnd = new RegExp(codeBlockEnd);
 
   if (reCodeBlockEnd.test(endLine)) {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
* fixed broken highlighting(`blockquote`, `codeblock`)
![스크린샷 2020-12-21 오전 9 43 18](https://user-images.githubusercontent.com/37766175/102728779-0473de80-4371-11eb-8948-fdba9a53b061.png)

* fixed wrong calculation for markdown position


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
