### PR TITLE
feat: convert column align syntax

### DIFF
--- a/apps/editor/src/__test__/unit/convertor.spec.ts
+++ b/apps/editor/src/__test__/unit/convertor.spec.ts
@@ -242,6 +242,29 @@ describe('Convertor', () => {
       assertConverting(markdown, `${expected}\n`);
     });
 
+    it('table with column align syntax', () => {
+      const markdown = source`
+        | default | left | right | center |
+        | --- | :--- | ---: | :---: |
+        | tbody | tbody | tbody | tbody |
+
+        |  |  |  |  |
+        | --- | :--- | ---: | :---: |
+        | default | left | right | center |
+      `;
+      const expected = source`
+        | default | left | right | center |
+        | ------- | ---- | ----: | :----: |
+        | tbody | tbody | tbody | tbody |
+
+        |  |  |  |  |
+        | --- | --- | ---: | :---: |
+        | default | left | right | center |
+      `;
+
+      assertConverting(markdown, `${expected}\n`);
+    });
+
     it('table with inline syntax', () => {
       const markdown = source`
         | ![altText](imgUrl) | foo ![altText](imgUrl) baz |

--- a/apps/editor/src/convertors/toWysiwyg/toWwConvertors.ts
+++ b/apps/editor/src/convertors/toWysiwyg/toWwConvertors.ts
@@ -13,6 +13,7 @@ import {
   ListItemMdNode,
   ImageMdNode,
   LinkMdNode,
+  TableCellMdNode,
   CustomBlockMdNode
 } from '@t/markdown';
 
@@ -220,12 +221,17 @@ export const toWwConvertors: ToWwConvertorMap = {
   },
 
   tableCell(state, node, { entering }) {
-    const { tableHeadCell, tableBodyCell, paragraph } = state.schema.nodes;
-    const tablePart = node.parent!.parent!;
-    const cell = tablePart.type === 'tableHead' ? tableHeadCell : tableBodyCell;
-
     if (entering) {
-      state.openNode(cell);
+      const { tableHeadCell, tableBodyCell, paragraph } = state.schema.nodes;
+      const tablePart = (node as TableCellMdNode).parent!.parent!;
+      const cell = tablePart.type === 'tableHead' ? tableHeadCell : tableBodyCell;
+
+      const table = tablePart.parent!;
+      const columnInfo = table.columns[(node as TableCellMdNode).startIdx];
+      const align = columnInfo?.align !== 'left' ? columnInfo.align : null;
+      const attrs = align ? { align } : null;
+
+      state.openNode(cell, attrs);
 
       if (node.firstChild && isInlineNode(node.firstChild)) {
         state.openNode(paragraph);

--- a/apps/editor/src/editorCore.ts
+++ b/apps/editor/src/editorCore.ts
@@ -128,6 +128,7 @@ class ToastUIEditor {
         extendedAutolinks: false,
         customConvertor: null,
         customHTMLRenderer: null,
+        customMarkdownRenderer: null,
         referenceDefinition: false,
         customHTMLSanitizer: null,
         frontMatter: false,
@@ -147,6 +148,7 @@ class ToastUIEditor {
       extendedAutolinks,
       referenceDefinition,
       frontMatter,
+      customMarkdownRenderer,
     } = this.options;
     const rendererOptions = {
       linkAttribute,
@@ -188,7 +190,11 @@ class ToastUIEditor {
 
     this.wwEditor = new WysiwygEditor(this.eventEmitter, wwToDOMAdaptor);
 
-    this.convertor = new Convertor(this.wwEditor.getSchema());
+    this.convertor = new Convertor(
+      this.wwEditor.getSchema(),
+      customMarkdownRenderer,
+      linkAttribute!
+    );
 
     if (plugins) {
       invokePlugins(plugins, this);

--- a/apps/editor/src/wysiwyg/nodes/table.ts
+++ b/apps/editor/src/wysiwyg/nodes/table.ts
@@ -26,6 +26,7 @@ import {
 import { createTextSelection } from '@/helper/manipulation';
 
 import { EditorCommand } from '@t/spec';
+import { ColumnAlign } from '@t/wysiwyg';
 
 interface AddTablePayload {
   columns: number;
@@ -34,7 +35,7 @@ interface AddTablePayload {
 }
 
 interface AlignColumnPayload {
-  align: 'left' | 'center' | 'right';
+  align: ColumnAlign;
 }
 
 type CellOffsetFn = ([rowIndex, columnIndex]: number[], cellsInfo: CellInfo[][]) => number | null;

--- a/apps/editor/types/wysiwyg.d.ts
+++ b/apps/editor/types/wysiwyg.d.ts
@@ -28,3 +28,5 @@ export interface CellSelection extends Selection {
   startCell: ResolvedPos;
   endCell: ResolvedPos;
 }
+
+export type ColumnAlign = 'left' | 'right' | 'center';


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description

Convert column align markdown syntax.

```md
| default | left | right | center |
| --- | :--- | ---: | :---: |
| tbody | tbody | tbody | tbody |

|  |  |  |  |
| --- | :--- | ---: | :---: |
| default | left | right | center |
```

## TODO

* [ ] Add `align: 'left'` property to ToastMark

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
