### PR TITLE
fix: edit broken table when press key

### DIFF
--- a/apps/editor/src/wysiwyg/nodes/tableBodyCell.ts
+++ b/apps/editor/src/wysiwyg/nodes/tableBodyCell.ts
@@ -16,6 +16,7 @@ export class TableBodyCell extends NodeSchema {
         className: { default: null },
         rawHTML: { default: null }
       },
+      isolating: true,
       parseDOM: [createDOMInfoParsedRawHTML('td')],
       toDOM({ attrs }: ProsemirrorNode): DOMOutputSpecArray {
         const { align, className } = attrs;

--- a/apps/editor/src/wysiwyg/nodes/tableHeadCell.ts
+++ b/apps/editor/src/wysiwyg/nodes/tableHeadCell.ts
@@ -16,6 +16,7 @@ export class TableHeadCell extends NodeSchema {
         className: { default: null },
         rawHTML: { default: null }
       },
+      isolating: true,
       parseDOM: [createDOMInfoParsedRawHTML('th')],
       toDOM({ attrs }: ProsemirrorNode): DOMOutputSpecArray {
         const { align, className } = attrs;

--- a/apps/editor/src/wysiwyg/plugins/tableSelection/cellSelection.ts
+++ b/apps/editor/src/wysiwyg/plugins/tableSelection/cellSelection.ts
@@ -22,7 +22,7 @@ function getSelectionRanges(
       const columnIdx = columnIndex + startColumnIndex;
       const { offset, nodeSize } = cellsPos[rowIdx][columnIdx];
 
-      ranges.push(new SelectionRange(doc.resolve(offset), doc.resolve(offset + nodeSize)));
+      ranges.push(new SelectionRange(doc.resolve(offset + 1), doc.resolve(offset + nodeSize - 1)));
     }
   }
 
@@ -46,8 +46,8 @@ export default class CellSelection extends Selection {
     this.startCell = startCellPos;
     this.endCell = endCellPos;
 
-    // this property is the api of the 'Selection' in prosemirror,
-    // and is used to disable the text selection
+    // This property is the api of the 'Selection' in prosemirror,
+    // and is used to disable the text selection.
     this.visible = false;
   }
 

--- a/apps/editor/src/wysiwyg/plugins/tableSelection/index.ts
+++ b/apps/editor/src/wysiwyg/plugins/tableSelection/index.ts
@@ -14,7 +14,7 @@ function drawCellSelection({ selection, doc }: EditorState) {
     const { ranges } = selection;
 
     ranges.forEach(({ $from, $to }: SelectionRange) => {
-      cells.push(Decoration.node($from.pos, $to.pos, { class: SELECTED_CELL_CLASS_NAME }));
+      cells.push(Decoration.node($from.pos - 1, $to.pos + 1, { class: SELECTED_CELL_CLASS_NAME }));
     });
 
     return DecorationSet.create(doc, cells);


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description

Fixes the problem that the cell is broken when pressing the `backspace` key or pressing the key while cells are selected.

#### AS-IS

![wrong](https://user-images.githubusercontent.com/18183560/105655088-c08d6f80-5f02-11eb-810a-3eea5e0d137a.gif)

#### TO-BE

![correct](https://user-images.githubusercontent.com/18183560/105655108-c7b47d80-5f02-11eb-805b-7379f20ac29e.gif)

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
