### PR TITLE
fix: change default column align value

### DIFF
--- a/apps/editor/src/__test__/unit/convertor.spec.ts
+++ b/apps/editor/src/__test__/unit/convertor.spec.ts
@@ -254,11 +254,11 @@ describe('Convertor', () => {
       `;
       const expected = source`
         | default | left | right | center |
-        | ------- | ---- | ----: | :----: |
+        | ------- | :--- | ----: | :----: |
         | tbody | tbody | tbody | tbody |
 
         |  |  |  |  |
-        | --- | --- | ---: | :---: |
+        | --- | :--- | ---: | :---: |
         | default | left | right | center |
       `;
 

--- a/apps/editor/src/convertors/toWysiwyg/toWwConvertors.ts
+++ b/apps/editor/src/convertors/toWysiwyg/toWwConvertors.ts
@@ -228,8 +228,7 @@ export const toWwConvertors: ToWwConvertorMap = {
 
       const table = tablePart.parent!;
       const columnInfo = table.columns[(node as TableCellMdNode).startIdx];
-      const align = columnInfo?.align !== 'left' ? columnInfo.align : null;
-      const attrs = align ? { align } : null;
+      const attrs = columnInfo.align ? { align: columnInfo.align } : null;
 
       state.openNode(cell, attrs);
 

--- a/libs/toastmark/src/commonmark/gfm/tableBlockStart.ts
+++ b/libs/toastmark/src/commonmark/gfm/tableBlockStart.ts
@@ -72,13 +72,15 @@ function generateTableCells(
 }
 
 function getColumnFromDelimCell(cellNode: TableCellNode) {
-  let align = 'left';
+  let align = null;
   const content = cellNode.stringContent!;
   const firstCh = content[0];
   const lastCh = content[content.length - 1];
 
   if (lastCh === ':') {
     align = firstCh === ':' ? 'center' : 'right';
+  } else if (firstCh === ':') {
+    align = 'left';
   }
 
   return { align } as TableColumn;
@@ -114,7 +116,7 @@ export const tableHead: BlockStart = (parser, container) => {
       [firstLineNum, firstLineStart],
       [parser.lineNumber, parser.offset]
     ]);
-    table.columns = delimCells.map(() => ({ align: 'left' }));
+    table.columns = delimCells.map(() => ({ align: null }));
 
     container.insertAfter(table);
     if (lineOffsets.length === 1) {

--- a/libs/toastmark/src/commonmark/node.ts
+++ b/libs/toastmark/src/commonmark/node.ts
@@ -251,7 +251,7 @@ export class CodeNode extends Node {
 }
 
 export interface TableColumn {
-  align: 'left' | 'center' | 'right';
+  align: 'left' | 'center' | 'right' | null;
 }
 
 export class TableNode extends BlockNode {

--- a/libs/toastmark/src/html/gfmConvertors.ts
+++ b/libs/toastmark/src/html/gfmConvertors.ts
@@ -122,8 +122,7 @@ export const gfmConvertors: HTMLConvertorMap = {
     const tagName = tablePart.type === 'tableHead' ? 'th' : 'td';
     const table = tablePart.parent as TableNode;
     const columnInfo = table.columns[(node as TableCellNode).startIdx];
-    const align = columnInfo && columnInfo.align !== 'left' ? columnInfo.align : null;
-    const attributes = align ? { align } : null;
+    const attributes = columnInfo?.align ? { align: columnInfo.align } : null;
 
     if (entering) {
       return {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description

Change the default align value to `null` in the table. The `align` value becomes `left` only when `:---` is entered in the table align syntax.

#### AS-IS

![wrong](https://user-images.githubusercontent.com/18183560/106402607-9c371300-646d-11eb-936f-89671a82e63f.png)

#### TO-BE

![correct](https://user-images.githubusercontent.com/18183560/106402611-a0fbc700-646d-11eb-90c8-88c40654fccb.png)


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
