### PR TITLE
feat: wysiwyg table move cursor

### DIFF
--- a/apps/editor/src/__test__/unit/wysiwyg/keymap.spec.ts
+++ b/apps/editor/src/__test__/unit/wysiwyg/keymap.spec.ts
@@ -1,0 +1,304 @@
+import { oneLineTrim } from 'common-tags';
+
+import { DOMParser } from 'prosemirror-model';
+
+import WysiwygEditor from '@/wysiwyg/wwEditor';
+import EventEmitter from '@/event/eventEmitter';
+import { WwToDOMAdaptor } from '@/wysiwyg/adaptor/wwToDOMAdaptor';
+import CellSelection from '@/wysiwyg/plugins/tableSelection/cellSelection';
+
+describe('keymap', () => {
+  let wwe: WysiwygEditor, em: EventEmitter;
+
+  function setContent(content: string) {
+    const wrapper = document.createElement('div');
+
+    wrapper.innerHTML = content;
+
+    const nodes = DOMParser.fromSchema(wwe.schema).parse(wrapper);
+
+    wwe.setModel(nodes);
+  }
+
+  function forceKeymapFn(type: string, methodName: string, args: any[] = []) {
+    const { specs, view } = wwe;
+    // @ts-ignore
+    const [keymapFn] = specs.specs.filter((spec) => spec.name === type);
+
+    // @ts-ignore
+    keymapFn[methodName](...args)(view.state, view.dispatch);
+  }
+
+  beforeEach(() => {
+    const adaptor = new WwToDOMAdaptor({}, {});
+
+    em = new EventEmitter();
+    wwe = new WysiwygEditor(em, adaptor);
+  });
+
+  afterEach(() => {
+    wwe.destroy();
+  });
+
+  describe('table', () => {
+    let html;
+
+    function selectCells(from: number, to: number) {
+      const { state, dispatch } = wwe.view;
+      const { doc, tr } = state;
+
+      const startCellPos = doc.resolve(from);
+      const endCellPos = doc.resolve(to);
+      const selection = new CellSelection(startCellPos, endCellPos);
+
+      dispatch!(tr.setSelection(selection));
+    }
+
+    beforeEach(() => {
+      html = oneLineTrim`
+        <table>
+          <thead>
+            <tr>
+              <th><p>foo</p></th>
+              <th><p>bar</p></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><p>baz</p></td>
+              <td><p>qux</p></td>
+            </tr>
+          </tbody>
+        </table>
+      `;
+
+      setContent(html);
+    });
+
+    describe('moveInCell keymap with right', () => {
+      it('should move to end of right cell', () => {
+        wwe.setSelection(7, 7); // in 'foo' cell
+
+        forceKeymapFn('table', 'moveToCell', ['right']);
+
+        expect(wwe.getRange()).toEqual([15, 15]);
+      });
+
+      it('should move to first cell of next line', () => {
+        wwe.setSelection(13, 13); // in 'bar' cell
+
+        forceKeymapFn('table', 'moveToCell', ['right']);
+
+        expect(wwe.getRange()).toEqual([26, 26]);
+      });
+    });
+
+    describe('moveInCell keymap with left', () => {
+      it('should move to end of left cell', () => {
+        wwe.setSelection(13, 13); // in 'bar' cell
+
+        forceKeymapFn('table', 'moveToCell', ['left']);
+
+        expect(wwe.getRange()).toEqual([8, 8]);
+      });
+
+      it('should move to last cell of previous line', () => {
+        wwe.setSelection(24, 24); // in 'baz' cell
+
+        forceKeymapFn('table', 'moveToCell', ['left']);
+
+        expect(wwe.getRange()).toEqual([15, 15]);
+      });
+    });
+
+    describe('moveInCell keymap with up', () => {
+      it('should move to end of up cell', () => {
+        wwe.setSelection(26, 26); // in 'baz' cell
+
+        forceKeymapFn('table', 'moveToCell', ['up']);
+
+        expect(wwe.getRange()).toEqual([8, 8]);
+      });
+
+      it('should add paragraph when there is no content before table and cursor is in first row', () => {
+        wwe.setSelection(13, 13); // in 'bar' cell
+
+        forceKeymapFn('table', 'moveToCell', ['up']);
+
+        const expected = oneLineTrim`
+          <p><br></p>
+          <table>
+            <thead>
+              <tr>
+                <th><p>foo</p></th>
+                <th><p>bar</p></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><p>baz</p></td>
+                <td><p>qux</p></td>
+              </tr>
+            </tbody>
+          </table>
+        `;
+
+        expect(wwe.getHTML()).toBe(expected);
+      });
+
+      it('should move to before table content when cursor is in first row', () => {
+        html = oneLineTrim`
+          <p>before</p>
+          <table>
+            <thead>
+              <tr>
+                <th><p>foo</p></th>
+                <th><p>bar</p></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><p>baz</p></td>
+                <td><p>qux</p></td>
+              </tr>
+            </tbody>
+          </table>
+        `;
+
+        setContent(html);
+
+        wwe.setSelection(15, 15); // in 'foo' cell
+        forceKeymapFn('table', 'moveToCell', ['up']);
+
+        expect(wwe.getRange()).toEqual([7, 7]); // 'before' paragraph
+      });
+    });
+
+    describe('moveInCell keymap with down', () => {
+      it('should move to start of down cell', () => {
+        wwe.setSelection(7, 7); // in 'foo' cell
+
+        forceKeymapFn('table', 'moveToCell', ['down']);
+
+        expect(wwe.getRange()).toEqual([23, 23]);
+      });
+
+      it('should add paragraph when there is no content after table and cursor is in last row', () => {
+        wwe.setSelection(26, 26); // in 'baz' cell
+
+        forceKeymapFn('table', 'moveToCell', ['down']);
+
+        const expected = oneLineTrim`
+          <table>
+            <thead>
+              <tr>
+                <th><p>foo</p></th>
+                <th><p>bar</p></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><p>baz</p></td>
+                <td><p>qux</p></td>
+              </tr>
+            </tbody>
+          </table>
+          <p><br></p>
+        `;
+
+        expect(wwe.getHTML()).toBe(expected);
+      });
+
+      it('should move to after table content when cursor is in last row', () => {
+        html = oneLineTrim`
+          <table>
+            <thead>
+              <tr>
+                <th><p>foo</p></th>
+                <th><p>bar</p></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><p>baz</p></td>
+                <td><p>qux</p></td>
+              </tr>
+            </tbody>
+          </table>
+          <p>after</p>
+        `;
+
+        setContent(html);
+
+        wwe.setSelection(32, 32); // in 'qux' cell
+        forceKeymapFn('table', 'moveToCell', ['down']);
+
+        expect(wwe.getRange()).toEqual([39, 39]); // 'after' paragraph
+      });
+    });
+
+    describe('moveInCell keymap', () => {
+      let expected: string;
+
+      beforeEach(() => {
+        expected = oneLineTrim`
+          <table class="ProseMirror-selectednode" draggable="true">
+            <thead>
+              <tr>
+                <th><p>foo</p></th>
+                <th><p>bar</p></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><p>baz</p></td>
+                <td><p>qux</p></td>
+              </tr>
+            </tbody>
+          </table>
+        `;
+      });
+
+      it('should select table when cursor is in start of first cell', () => {
+        wwe.setSelection(5, 5); // in 'foo' cell
+
+        forceKeymapFn('table', 'moveInCell', ['left']);
+
+        expect(wwe.getHTML()).toBe(expected);
+      });
+
+      it('should select table when cursor is in end of last cell', () => {
+        wwe.setSelection(33, 33); // in 'qux' cell
+
+        forceKeymapFn('table', 'moveInCell', ['right']);
+
+        expect(wwe.getHTML()).toBe(expected);
+      });
+    });
+
+    it('deleteCells keymap should delete cells in selection', () => {
+      selectCells(3, 28);
+
+      forceKeymapFn('table', 'deleteCells');
+
+      const expected = oneLineTrim`
+        <table>
+          <thead>
+            <tr>
+              <th class="te-cell-selected"><p><br></p></th>
+              <th class="te-cell-selected"><p><br></p></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="te-cell-selected"><p><br></p></td>
+              <td class="te-cell-selected"><p><br></p></td>
+            </tr>
+          </tbody>
+        </table>
+      `;
+
+      expect(wwe.getHTML()).toBe(expected);
+    });
+  });
+});

--- a/apps/editor/src/__test__/unit/wysiwyg/wwTableCommand.spec.ts
+++ b/apps/editor/src/__test__/unit/wysiwyg/wwTableCommand.spec.ts
@@ -949,46 +949,4 @@ describe('wysiwyg table commands', () => {
       expect(wwe.getHTML()).toBe(expected);
     });
   });
-
-  describe('deleteCells command', () => {
-    beforeEach(() => {
-      cmd.exec('wysiwyg', 'addTable', {
-        columns: 3,
-        rows: 2,
-        data: ['foo', 'bar', 'baz', 'qux', 'quux', 'quuz', 'corge', 'grault', ''],
-      });
-    });
-
-    it('should delete cells in selection', () => {
-      setCellSelection([0, 1], [2, 2]); // select from 'bar' to last cell
-
-      cmd.exec('wysiwyg', 'deleteCells');
-
-      const expected = oneLineTrim`
-        <table>
-          <thead>
-            <tr>
-              <th><p>foo</p></th>
-              <th class="te-cell-selected"><p><br></p></th>
-              <th class="te-cell-selected"><p><br></p></th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td><p>qux</p></td>
-              <td class="te-cell-selected"><p><br></p></td>
-              <td class="te-cell-selected"><p><br></p></td>
-            </tr>
-            <tr>
-              <td><p>corge</p></td>
-              <td class="te-cell-selected"><p><br></p></td>
-              <td class="te-cell-selected"><p><br></p></td>
-            </tr>
-          </tbody>
-        </table>
-      `;
-
-      expect(wwe.getHTML()).toBe(expected);
-    });
-  });
 });

--- a/apps/editor/src/css/contents.css
+++ b/apps/editor/src/css/contents.css
@@ -12,6 +12,11 @@
   outline: none;
 }
 
+/* @TODO change color */
+table.ProseMirror-selectednode {
+  outline: 1px solid lime;
+}
+
 .tui-editor-contents {
   margin: 0;
   padding: 0;
@@ -352,7 +357,8 @@
   margin-left: 8px;
   padding: 3px;
   border: solid 1px #cccccc;
-  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 10 10'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23555'%3E%3Cg%3E%3Cg%3E%3Cg%3E%3Cpath d='M5.5 2.5l2 2L2 10H0V8l5.5-5.5zM8 0l2 2-1.5 1.5-2-2L8 0z' transform='translate(-940 -712) translate(60 647) translate(875 60) translate(5 5)'/%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E") no-repeat;
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 10 10'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23555'%3E%3Cg%3E%3Cg%3E%3Cg%3E%3Cpath d='M5.5 2.5l2 2L2 10H0V8l5.5-5.5zM8 0l2 2-1.5 1.5-2-2L8 0z' transform='translate(-940 -712) translate(60 647) translate(875 60) translate(5 5)'/%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E")
+    no-repeat;
   background-position: 5px 5px;
 }
 

--- a/apps/editor/src/wysiwyg/command/table.ts
+++ b/apps/editor/src/wysiwyg/command/table.ts
@@ -1,0 +1,65 @@
+import { Schema } from 'prosemirror-model';
+import { Selection, Transaction } from 'prosemirror-state';
+
+import { createParagraph, createTextSelection } from '@/helper/manipulation';
+import { CellInfo } from '@/wysiwyg/helper/table';
+
+export type CursorDirection = 'left' | 'right';
+
+export type CellDirection = CursorDirection | 'up' | 'down';
+
+export function isCursorInTableStart(direction: CellDirection, [rowIndex, columnIndex]: number[]) {
+  const cursorInFirstRow = direction === 'up' && rowIndex === 0;
+  const cursorInFirstCell = direction === 'left' && rowIndex === 0 && columnIndex === 0;
+
+  return cursorInFirstRow || cursorInFirstCell;
+}
+
+export function isCursorInTableEnd(
+  direction: CellDirection,
+  cellsInfo: CellInfo[][],
+  [rowIndex, columnIndex]: number[]
+) {
+  const rowCount = cellsInfo.length;
+  const columnCount = cellsInfo[0].length;
+
+  const cursorInLastRow = direction === 'down' && rowIndex === cellsInfo.length - 1;
+  const cursorInLastCell =
+    direction === 'right' && rowIndex === rowCount - 1 && columnIndex === columnCount - 1;
+
+  return cursorInLastRow || cursorInLastCell;
+}
+
+export function addParagraphBeforeTable(tr: Transaction, cellsInfo: CellInfo[][], schema: Schema) {
+  // 3 is position value of <table><thead><tr>
+  const tableStartPos = tr.doc.resolve(cellsInfo[0][0].offset - 3);
+
+  if (!tableStartPos.nodeBefore) {
+    const tableStartOffset = tableStartPos.pos;
+
+    tr.replaceWith(tableStartOffset, tableStartOffset, createParagraph(schema));
+
+    return tr.setSelection(createTextSelection(tr, tableStartOffset + 1));
+  }
+
+  return tr.setSelection(Selection.near(tableStartPos, -1));
+}
+
+export function addParagraphAfterTable(tr: Transaction, cellsInfo: CellInfo[][], schema: Schema) {
+  const rowCount = cellsInfo.length;
+  const columnCount = cellsInfo[0].length;
+  const lastCell = cellsInfo[rowCount - 1][columnCount - 1];
+
+  // 3 is position value of </tr></tbody></table>
+  const tableEndPos = tr.doc.resolve(lastCell.offset + lastCell.nodeSize + 3);
+
+  if (!tableEndPos.nodeAfter) {
+    const tableEndOffset = tableEndPos.pos;
+
+    tr.replaceWith(tableEndOffset, tableEndOffset, createParagraph(schema));
+
+    return tr.setSelection(createTextSelection(tr, tableEndOffset + 1));
+  }
+
+  return tr.setSelection(Selection.near(tableEndPos, 1));
+}

--- a/apps/editor/src/wysiwyg/helper/table.ts
+++ b/apps/editor/src/wysiwyg/helper/table.ts
@@ -104,7 +104,7 @@ export function getRightCellOffset([rowIndex, columnIndex]: number[], cellsInfo:
 
     const { offset, nodeSize } = cellsInfo[rowIndex][columnIndex];
 
-    return offset + nodeSize - 1;
+    return offset + nodeSize - 2;
   }
 
   return null;
@@ -126,7 +126,7 @@ export function getLeftCellOffset([rowIndex, columnIndex]: number[], cellsInfo: 
 
     const { offset, nodeSize } = cellsInfo[rowIndex][columnIndex];
 
-    return offset + nodeSize - 1;
+    return offset + nodeSize - 2;
   }
 
   return null;
@@ -136,7 +136,7 @@ export function getUpCellOffset([rowIndex, columnIndex]: number[], cellsInfo: Ce
   if (rowIndex > 0) {
     const { offset, nodeSize } = cellsInfo[rowIndex - 1][columnIndex];
 
-    return offset + nodeSize - 1;
+    return offset + nodeSize - 2;
   }
 
   return null;
@@ -148,7 +148,7 @@ export function getDownCellOffset([rowIndex, columnIndex]: number[], cellsInfo: 
   if (rowIndex < allRowCount - 1) {
     const { offset } = cellsInfo[rowIndex + 1][columnIndex];
 
-    return offset + 1;
+    return offset + 2;
   }
 
   return null;

--- a/apps/editor/src/wysiwyg/nodes/table.ts
+++ b/apps/editor/src/wysiwyg/nodes/table.ts
@@ -27,8 +27,8 @@ import {
 import {
   CursorDirection,
   CellDirection,
-  isCursorInTableStart,
-  isCursorInTableEnd,
+  canBeOutOfTableStart,
+  canBeOutOfTableEnd,
   addParagraphBeforeTable,
   addParagraphAfterTable,
 } from '@/wysiwyg/command/table';
@@ -302,11 +302,13 @@ export class Table extends NodeSchema {
         const cellsInfo = getTableCellsInfo(anchor);
         const cellIndex = getCellIndexInfo(anchor);
 
-        const cursorInTableStart = isCursorInTableStart(direction, cellIndex);
-        const cursorInTableEnd = isCursorInTableEnd(direction, cellsInfo, cellIndex);
+        const cursorInTableStart = canBeOutOfTableStart(direction, cellIndex);
+        const cursorInTableEnd = canBeOutOfTableEnd(direction, cellsInfo, cellIndex);
 
         let newTr;
 
+        // When there is no content before or after the table,
+        // an empty line('paragraph') is created by pressing the arrow keys.
         if (cursorInTableStart) {
           newTr = addParagraphBeforeTable(tr, cellsInfo, schema);
         } else if (cursorInTableEnd) {
@@ -337,7 +339,7 @@ export class Table extends NodeSchema {
     return () => (state, dispatch, view) => {
       const { selection, tr } = state;
 
-      if (view?.endOfTextblock(direction)) {
+      if (view!.endOfTextblock(direction)) {
         const { head } = getResolvedSelection(selection);
 
         if (!head) {
@@ -426,13 +428,9 @@ export class Table extends NodeSchema {
 
       ArrowLeft: moveLeftInCellCommand,
       ArrowRight: moveRightInCellCommand,
-      'Shift-ArrowLeft': moveLeftInCellCommand,
-      'Shift-ArrowRight': moveRightInCellCommand,
 
       ArrowUp: moveToUpCellCommand,
       ArrowDown: moveToDownCellCommand,
-      'Shift-ArrowUp': moveToUpCellCommand,
-      'Shift-ArrowDown': moveToDownCellCommand,
 
       Backspace: deleteCellsCommand,
       'Mod-Backspace': deleteCellsCommand,

--- a/apps/editor/src/wysiwyg/wwEditor.ts
+++ b/apps/editor/src/wysiwyg/wwEditor.ts
@@ -41,6 +41,7 @@ export default class WysiwygEditor extends EditorBase {
     this.keymaps = this.createKeymaps();
     this.view = this.createView();
     this.commands = this.createCommands();
+    this.specs.setContext({ ...this.context, view: this.view });
   }
 
   createSpecs() {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

## Feature

In version 2, if there is no content before or after the table, a blank line is added or the table is deleted through the **cursor**. In version 3, the previous method cannot be used because of the **default behavior of ProseMirror that the cursor (`TextSelection`) cannot be added behind the table**, so the cursor operation method is improved. Depending on the key type and direction, it operates as follows.

### Up and down arrow key operation

* When there is no content before/after the table: Add an empty line (`paragraph`)

![up-down-empty](https://user-images.githubusercontent.com/18183560/106589276-30e56200-658f-11eb-88e2-4610f26c369e.gif)

* When there is content before/after the table: Move the cursor

![up-down](https://user-images.githubusercontent.com/18183560/106589302-36db4300-658f-11eb-8c23-6b8c38102890.gif)

### Tab key operation

* When there is no content before/after the table: Add an empty line (`paragraph`)

![tab-empty](https://user-images.githubusercontent.com/18183560/106589391-52464e00-658f-11eb-8fa1-91fe6eea41cf.gif)

* When there is content before/after the table: Move the cursor

![tab](https://user-images.githubusercontent.com/18183560/106589503-6e49ef80-658f-11eb-9370-f347b9727219.gif)

### Left and right arrow key operation

* When pressing the `left` arrow key on the first cell of the table and the first cursor: Select a table (`NodeSelection`)
* When pressing the `right` arrow key on the last cell of the table or the last cursor: Select a table (`NodeSelection`)

![left-right](https://user-images.githubusercontent.com/18183560/106590685-b9183700-6590-11eb-9744-49509decacf9.gif)

In the case of the table removal operation, the table is removed through the context menu by default. When the table is removed with the `delete` key, it is removed only when the table is selected through the arrow keys.

### Table remove

* Remove with context menu

![remove-table](https://user-images.githubusercontent.com/18183560/106591285-71de7600-6591-11eb-8d78-74c59e7be88a.gif)

* Select a table with the arrow keys and remove it by pressing the `delete` key.

![left-right-delete](https://user-images.githubusercontent.com/18183560/106591116-38a60600-6591-11eb-920d-e9b9b203a81c.gif)


## TODO

* [ ] Change border color when selecting table

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
