### PR TITLE
feat: remove 'Plugin' on wysiwyg plugin file name

### DIFF
--- a/apps/editor/src/wysiwyg/plugins/tableContextMenu.ts
+++ b/apps/editor/src/wysiwyg/plugins/tableContextMenu.ts
@@ -59,7 +59,7 @@ function getContextMenuGroups(eventEmitter: Emitter, inTableHead: boolean) {
     .concat();
 }
 
-export function tableContextMenuPlugin(eventEmitter: Emitter) {
+export function tableContextMenu(eventEmitter: Emitter) {
   return new Plugin({
     props: {
       handleDOMEvents: {

--- a/apps/editor/src/wysiwyg/plugins/tableSelection/index.ts
+++ b/apps/editor/src/wysiwyg/plugins/tableSelection/index.ts
@@ -23,7 +23,7 @@ function drawCellSelection({ selection, doc }: EditorState) {
   return null;
 }
 
-export function tableSelectionPlugin() {
+export function tableSelection() {
   return new Plugin({
     key: pluginKey,
     state: {

--- a/apps/editor/src/wysiwyg/plugins/task.ts
+++ b/apps/editor/src/wysiwyg/plugins/task.ts
@@ -4,7 +4,7 @@ import { EditorView } from 'prosemirror-view';
 import { isPositionInBox } from '@/utils/dom';
 import { findListItem } from '@/wysiwyg/helper/node';
 
-export function taskPlugin() {
+export function task() {
   return new Plugin({
     props: {
       handleDOMEvents: {

--- a/apps/editor/src/wysiwyg/wwEditor.ts
+++ b/apps/editor/src/wysiwyg/wwEditor.ts
@@ -15,9 +15,9 @@ import { emitImageBlobHook, pasteImageOnly } from '@/helper/image';
 import { placeholder } from '@/plugins/placeholder';
 import { dropImage } from '@/plugins/dropImage';
 
-import { tableSelectionPlugin } from './plugins/tableSelection';
-import { tableContextMenuPlugin } from './plugins/tableContextMenu';
-import { taskPlugin } from './plugins/taskPlugin';
+import { tableSelection } from './plugins/tableSelection';
+import { tableContextMenu } from './plugins/tableContextMenu';
+import { task } from './plugins/task';
 import { toolbarActivity } from './plugins/toolbarActivity';
 
 import { CustomBlockView } from './nodeview/customBlockView';
@@ -91,9 +91,9 @@ export default class WysiwygEditor extends EditorBase {
         }),
         history(),
         placeholder(this.placeholder),
-        tableSelectionPlugin(),
-        tableContextMenuPlugin(this.eventEmitter),
-        taskPlugin(),
+        tableSelection(),
+        tableContextMenu(this.eventEmitter),
+        task(),
         dropImage(this.context, 'wysiwyg'),
         toolbarActivity(this.eventEmitter),
       ],

--- a/apps/editor/src/wysiwyg/wwEditor.ts
+++ b/apps/editor/src/wysiwyg/wwEditor.ts
@@ -23,7 +23,6 @@ import { toolbarActivity } from './plugins/toolbarActivity';
 import { CustomBlockView } from './nodeview/customBlockView';
 import { changePastedHTML, changePastedSlice } from './clipboard/paste';
 import { pasteToTable } from './clipboard/pasteToTable';
-
 import { createSpecs } from './specCreator';
 
 import { Emitter } from '@t/event';


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description

* If there is `Plugin` in the file in the `plugins` folder of WYSIWYG, it was removed.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
