### PR TITLE
fix: context menu is not disabled when in head cell

### DIFF
--- a/apps/editor/src/wysiwyg/helper/table.ts
+++ b/apps/editor/src/wysiwyg/helper/table.ts
@@ -68,16 +68,16 @@ export function createDummyCells(columnCount: number, rowIndex: number, schema: 
   return cells;
 }
 
-export function isInCellElement(node: HTMLElement, root: Element) {
+export function findCellElement(node: HTMLElement, root: Element) {
   while (node && node !== root) {
     if (node.nodeName === 'TD' || node.nodeName === 'TH') {
-      return true;
+      return node;
     }
 
     node = node.parentNode as HTMLElement;
   }
 
-  return false;
+  return null;
 }
 
 export function findCell(pos: ResolvedPos) {

--- a/apps/editor/src/wysiwyg/plugins/tableContextMenu.ts
+++ b/apps/editor/src/wysiwyg/plugins/tableContextMenu.ts
@@ -1,7 +1,7 @@
 import { Plugin } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 
-import { isInCellElement } from '@/wysiwyg/helper/table';
+import { findCellElement } from '@/wysiwyg/helper/table';
 import i18n from '@/i18n/i18n';
 
 import { Emitter } from '@t/event';
@@ -64,15 +64,14 @@ export function tableContextMenuPlugin(eventEmitter: Emitter) {
     props: {
       handleDOMEvents: {
         contextmenu: (view: EditorView, ev: Event) => {
-          const inTable = isInCellElement(ev.target as HTMLElement, view.dom);
+          const foundCell = findCellElement(ev.target as HTMLElement, view.dom);
 
-          if (inTable) {
+          if (foundCell) {
             ev.preventDefault();
 
             const { clientX, clientY } = ev as MouseEvent;
             const { left, top } = (view.dom.parentNode as HTMLElement).getBoundingClientRect();
-
-            const inTableHead = (ev.target as HTMLElement).nodeName === 'TH';
+            const inTableHead = foundCell.nodeName === 'TH';
 
             eventEmitter.emit('contextmenu', {
               pos: { left: `${clientX - left + 10}px`, top: `${clientY - top + 30}px` },

--- a/apps/editor/src/wysiwyg/plugins/tableSelection/tableSelectionView.ts
+++ b/apps/editor/src/wysiwyg/plugins/tableSelection/tableSelectionView.ts
@@ -2,7 +2,7 @@ import { ResolvedPos } from 'prosemirror-model';
 import { EditorView } from 'prosemirror-view';
 import { PluginKey } from 'prosemirror-state';
 
-import { findCell, isInCellElement } from '@/wysiwyg/helper/table';
+import { findCell, findCellElement } from '@/wysiwyg/helper/table';
 
 import CellSelection from './cellSelection';
 
@@ -42,14 +42,14 @@ export default class TableSelection {
   }
 
   handleMousedown(ev: Event) {
-    const inCell = isInCellElement(ev.target as HTMLElement, this.view.dom);
+    const foundCell = findCellElement(ev.target as HTMLElement, this.view.dom);
 
     if ((ev as MouseEvent).button === MOUSE_RIGHT_BUTTON) {
       ev.preventDefault();
       return;
     }
 
-    if (inCell) {
+    if (foundCell) {
       const startCellPos = this.getCellPos(ev as MouseEvent);
 
       if (startCellPos) {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description

In the head cell, the context menu corresponding to the row action should be disabled. Fixed an issue where if there is content in a cell, some context menu are not disabled.

#### AS-IS

![wrong](https://user-images.githubusercontent.com/18183560/107949105-1c19bd00-6fd8-11eb-88d4-9732357b9e77.gif)

#### TO-BE

![correct](https://user-images.githubusercontent.com/18183560/107949094-191ecc80-6fd8-11eb-809b-267c57290434.gif)


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
