### PR TITLE
feat: widget rules and addWidget, replaceWithWidget API

### DIFF
--- a/apps/editor/src/__test__/integration/widget/widgetNode.spec.ts
+++ b/apps/editor/src/__test__/integration/widget/widgetNode.spec.ts
@@ -1,0 +1,318 @@
+import { oneLineTrim } from 'common-tags';
+import Editor from '@/editorCore';
+
+describe('widgetNode', () => {
+  let container: HTMLElement,
+    mdEditor: HTMLElement,
+    mdPreview: HTMLElement,
+    wwEditor: HTMLElement,
+    editor: Editor;
+
+  function getEditorHTML() {
+    return mdEditor.querySelector('.ProseMirror')!.innerHTML.trim();
+  }
+
+  function getPreviewHTML() {
+    return mdPreview
+      .querySelector('.tui-editor-contents')!
+      .innerHTML.replace(/\sdata-nodeid="\d{1,}"/g, '')
+      .trim();
+  }
+
+  function getWwEditorHTML() {
+    return wwEditor.querySelector('.ProseMirror')!.innerHTML.trim();
+  }
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    editor = new Editor({
+      el: container,
+      widgetRules: [
+        {
+          rule: /@\S+/,
+          toDOM(text) {
+            const span = document.createElement('span');
+
+            span.innerHTML = `<a href="www.google.com">${text}</a>`;
+            return span;
+          },
+        },
+        {
+          rule: /\[(#\S+)\]\((\S+)\)/,
+          toDOM: (text) => {
+            const rule = /\[(#\S+)\]\((\S+)\)/;
+            const matched = text.match(rule)!;
+            const span = document.createElement('span');
+
+            span.innerHTML = `<a href="${matched[2]}">${matched[1]}</a>`;
+
+            return span;
+          },
+        },
+      ],
+      previewStyle: 'vertical',
+    });
+
+    const elements = editor.getEditorElements();
+
+    mdEditor = elements.mdEditor;
+    mdPreview = elements.mdPreview!;
+    wwEditor = elements.wwEditor!;
+
+    container.append(mdEditor);
+    container.append(mdPreview!);
+    container.append(wwEditor!);
+
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    editor.destroy();
+    document.body.removeChild(container);
+  });
+
+  describe('in markdown', () => {
+    it('should render widget node in the editor and preview using replaceWithWidget API', () => {
+      editor.setMarkdown('abc');
+      editor.replaceWithWidget([1, 1], [1, 3], '@test');
+
+      const expectedEditor = oneLineTrim`
+        <div>
+          <span class="tui-widget">
+            <span><a href="www.google.com">@test</a></span>
+          </span>
+          c
+        </div>
+      `;
+      const expectedPreview = oneLineTrim`
+        <p>
+          <span class="tui-widget">
+            <span><a href="www.google.com">@test</a></span>
+          </span>
+          c
+        </p>
+      `;
+
+      expect(getEditorHTML()).toBe(expectedEditor);
+      expect(getPreviewHTML()).toBe(expectedPreview);
+    });
+
+    it('should render widget node in the editor and preview using setMarkdown API', () => {
+      editor.setMarkdown('@test1 @test2');
+
+      const expectedEditor = oneLineTrim`
+        <div>
+          <span class="tui-widget">
+            <span><a href="www.google.com">@test1</a></span>
+          </span> 
+          <span class="tui-widget">
+            <span>
+              <a href="www.google.com">@test2</a>
+            </span>
+          </span>
+          <br>
+        </div>
+      `;
+      const expectedPreview = oneLineTrim`
+        <p>
+          <span class="tui-widget">
+            <span>
+              <a href="www.google.com">@test1</a>
+            </span>
+          </span> 
+          <span class="tui-widget">
+            <span><a href="www.google.com">@test2</a></span>
+          </span>
+        </p>
+      `;
+
+      expect(getEditorHTML()).toBe(expectedEditor);
+      expect(getPreviewHTML()).toBe(expectedPreview);
+    });
+
+    it('should render widget node in the editor and preview using insertText API', () => {
+      editor.insertText('@test1 @test2');
+
+      const expectedEditor = oneLineTrim`
+        <div>
+          <span class="tui-widget">
+            <span><a href="www.google.com">@test1</a></span>
+          </span> 
+          <span class="tui-widget">
+            <span>
+              <a href="www.google.com">@test2</a>
+            </span>
+          </span>
+          <br>
+        </div>
+      `;
+      const expectedPreview = oneLineTrim`
+        <p>
+          <span class="tui-widget">
+            <span>
+              <a href="www.google.com">@test1</a>
+            </span>
+          </span> 
+          <span class="tui-widget">
+            <span><a href="www.google.com">@test2</a></span>
+          </span>
+        </p>
+      `;
+
+      expect(getEditorHTML()).toBe(expectedEditor);
+      expect(getPreviewHTML()).toBe(expectedPreview);
+    });
+
+    it('should render widget node with markdown text', () => {
+      editor.replaceWithWidget([1, 1], [1, 1], '[#toast](ui.toast.com)');
+
+      const expectedEditor = oneLineTrim`
+        <div>
+          <span class="tui-widget">
+            <span><a href="ui.toast.com">#toast</a></span>
+          </span>
+          <br>
+        </div>
+      `;
+      const expectedPreview = oneLineTrim`
+        <p>
+          <span class="tui-widget">
+            <span><a href="ui.toast.com">#toast</a></span>
+          </span>
+        </p>
+      `;
+
+      expect(getEditorHTML()).toBe(expectedEditor);
+      expect(getPreviewHTML()).toBe(expectedPreview);
+    });
+
+    it('should render widget node using all widget rules', () => {
+      editor.insertText('@test1 [#toast](ui.toast.com) @test2');
+
+      const expectedEditor = oneLineTrim`
+        <div>
+          <span class="tui-widget">
+            <span><a href="www.google.com">@test1</a></span>
+          </span> 
+          <span class="tui-widget">
+            <span><a href="ui.toast.com">#toast</a></span>
+          </span> 
+          <span class="tui-widget">
+            <span>
+              <a href="www.google.com">@test2</a>
+            </span>
+          </span>
+          <br>
+        </div>
+      `;
+      const expectedPreview = oneLineTrim`
+        <p>
+          <span class="tui-widget">
+            <span>
+              <a href="www.google.com">@test1</a>
+            </span>
+          </span> 
+          <span class="tui-widget">
+            <span><a href="ui.toast.com">#toast</a></span>
+          </span> 
+          <span class="tui-widget">
+            <span><a href="www.google.com">@test2</a></span>
+          </span>
+        </p>
+      `;
+
+      expect(getEditorHTML()).toBe(expectedEditor);
+      expect(getPreviewHTML()).toBe(expectedPreview);
+    });
+
+    it('should convert to wysiwyg properly', () => {
+      editor.setMarkdown('@test1 @test2');
+      editor.changeMode('wysiwyg');
+
+      const expectedEditor = oneLineTrim`
+        <p>
+          <span class="tui-widget">
+            <span><a href="www.google.com">@test1</a></span>
+          </span> 
+          <span class="tui-widget">
+            <span>
+              <a href="www.google.com">@test2</a>
+            </span>
+          </span>
+          <br>
+        </p>
+      `;
+
+      expect(getWwEditorHTML()).toBe(expectedEditor);
+    });
+  });
+
+  describe('in wysiwyg', () => {
+    it('should render widget node in the editor using replaceWithWidget API', () => {
+      editor.changeMode('wysiwyg');
+      editor.replaceWithWidget(1, 1, '@test');
+
+      const expectedEditor = oneLineTrim`
+        <p>
+          <span class="tui-widget">
+            <span><a href="www.google.com">@test</a></span>
+          </span>
+          <br>
+        </p>
+      `;
+
+      expect(getWwEditorHTML()).toBe(expectedEditor);
+    });
+
+    it('should render widget node with markdown text', () => {
+      editor.changeMode('wysiwyg');
+      editor.replaceWithWidget(1, 1, '[#toast](ui.toast.com)');
+
+      const expectedEditor = oneLineTrim`
+        <p>
+          <span class="tui-widget">
+            <span><a href="ui.toast.com">#toast</a></span>
+          </span>
+          <br>
+        </p>
+      `;
+
+      expect(getWwEditorHTML()).toBe(expectedEditor);
+    });
+
+    it('should convert to markdown properly', () => {
+      editor.changeMode('wysiwyg');
+      editor.replaceWithWidget(1, 1, '@test1 @test2');
+      editor.changeMode('markdown');
+
+      const expectedEditor = oneLineTrim`
+        <div>
+          <span class="tui-widget">
+            <span><a href="www.google.com">@test1</a></span>
+          </span> 
+          <span class="tui-widget">
+            <span>
+              <a href="www.google.com">@test2</a>
+            </span>
+          </span>
+          <br>
+        </div>
+      `;
+      const expectedPreview = oneLineTrim`
+        <p>
+          <span class="tui-widget">
+            <span>
+              <a href="www.google.com">@test1</a>
+            </span>
+          </span> 
+          <span class="tui-widget">
+            <span><a href="www.google.com">@test2</a></span>
+          </span>
+        </p>
+      `;
+
+      expect(getEditorHTML()).toBe(expectedEditor);
+      expect(getPreviewHTML()).toBe(expectedPreview);
+    });
+  });
+});

--- a/apps/editor/src/__test__/integration/widget/widgetNode.spec.ts
+++ b/apps/editor/src/__test__/integration/widget/widgetNode.spec.ts
@@ -245,6 +245,41 @@ describe('widgetNode', () => {
 
       expect(getWwEditorHTML()).toBe(expectedEditor);
     });
+
+    it('should keep "$" character in case of plain text other than widget node', () => {
+      editor.setMarkdown('@test1 $$myText @test2');
+
+      const expectedEditor = oneLineTrim`
+        <div>
+          <span class="tui-widget">
+            <span><a href="www.google.com">@test1</a></span>
+          </span> 
+          $$myText 
+          <span class="tui-widget">
+            <span>
+              <a href="www.google.com">@test2</a>
+            </span>
+          </span>
+          <br>
+        </div>
+      `;
+      const expectedPreview = oneLineTrim`
+        <p>
+          <span class="tui-widget">
+            <span>
+              <a href="www.google.com">@test1</a>
+            </span>
+          </span> 
+          $$myText 
+          <span class="tui-widget">
+            <span><a href="www.google.com">@test2</a></span>
+          </span>
+        </p>
+      `;
+
+      expect(getEditorHTML()).toBe(expectedEditor);
+      expect(getPreviewHTML()).toBe(expectedPreview);
+    });
   });
 
   describe('in wysiwyg', () => {

--- a/apps/editor/src/__test__/integration/widget/widgetNode.spec.ts
+++ b/apps/editor/src/__test__/integration/widget/widgetNode.spec.ts
@@ -15,7 +15,7 @@ describe('widgetNode', () => {
   function getPreviewHTML() {
     return mdPreview
       .querySelector('.tui-editor-contents')!
-      .innerHTML.replace(/\sdata-nodeid="\d{1,}"/g, '')
+      .innerHTML.replace(/\sdata-nodeid="\d+"/g, '')
       .trim();
   }
 

--- a/apps/editor/src/__test__/unit/markdown/mdEditor.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/mdEditor.spec.ts
@@ -115,4 +115,17 @@ describe('MarkdownEditor', () => {
 
     expect(minHeight).toBe('100px');
   });
+
+  it('addWidget API', () => {
+    const ul = document.createElement('ul');
+
+    ul.innerHTML = `
+      <li>Ryu</li>
+      <li>Lee</li>
+    `;
+
+    mde.addWidget(ul, 'top');
+
+    expect(document.body).toContainElement(ul);
+  });
 });

--- a/apps/editor/src/__test__/unit/wysiwyg/wwEditor.spec.ts
+++ b/apps/editor/src/__test__/unit/wysiwyg/wwEditor.spec.ts
@@ -122,6 +122,19 @@ describe('WysiwygEditor', () => {
         <p>new barar</p>
       `);
     });
+
+    it('addWidget API', () => {
+      const ul = document.createElement('ul');
+
+      ul.innerHTML = `
+        <li>Ryu</li>
+        <li>Lee</li>
+      `;
+
+      wwe.addWidget(ul, 'top');
+
+      expect(document.body).toContainElement(ul);
+    });
   });
 
   it(`should emit 'cursorActivity' event when changing cursor`, () => {

--- a/apps/editor/src/base.ts
+++ b/apps/editor/src/base.ts
@@ -31,10 +31,6 @@ export default abstract class EditorBase {
 
   placeholder: { text: string };
 
-  private widgetSeq = 0;
-
-  protected widgetMap: Record<string, HTMLElement> = {};
-
   constructor(eventEmitter: Emitter) {
     this.el = document.createElement('div');
     this.el.className = 'te-editor';
@@ -129,14 +125,12 @@ export default abstract class EditorBase {
     dispatch(state.tr.setMeta('widget', { pos: state.selection.to, node, style, offset }));
   }
 
-  insertWidgetNode(node: HTMLElement) {
+  replaceWithWidget(markdownText: string, node: HTMLElement) {
     const { schema, tr } = this.view.state;
-    const id = `tui-widget${this.widgetSeq}`;
 
-    this.widgetSeq += 1;
-    this.widgetMap[id] = node;
-
-    this.view.dispatch(tr.replaceSelectionWith(schema.nodes.widget.create({ id, node })));
+    this.view.dispatch(
+      tr.replaceSelectionWith(schema.nodes.widget.create({ node }, schema.text(markdownText)))
+    );
   }
 
   abstract getRange(): any;

--- a/apps/editor/src/base.ts
+++ b/apps/editor/src/base.ts
@@ -4,6 +4,7 @@ import { EditorView } from 'prosemirror-view';
 import css from 'tui-code-snippet/domUtil/css';
 import { WidgetStyle } from '@t/editor';
 import { Emitter } from '@t/event';
+import { MdPos } from '@t/markdown';
 import { Context, EditorAllCommandMap } from '@t/spec';
 import SpecManager from './spec/specManager';
 import { createTextSelection } from './helper/manipulation';
@@ -119,21 +120,11 @@ export default abstract class EditorBase {
     return this.el;
   }
 
-  addWidget(node: Node, style: WidgetStyle, offset: number) {
-    const { dispatch, state } = this.view;
+  abstract replaceWithWidget(from: MdPos | number, to: MdPos | number, content: string): void;
 
-    dispatch(state.tr.setMeta('widget', { pos: state.selection.to, node, style, offset }));
-  }
-
-  replaceWithWidget(markdownText: string, node: HTMLElement) {
-    const { schema, tr } = this.view.state;
-
-    this.view.dispatch(
-      tr.replaceSelectionWith(schema.nodes.widget.create({ node }, schema.text(markdownText)))
-    );
-  }
-
-  abstract getRange(): any;
+  abstract addWidget(node: Node, style: WidgetStyle, pos?: MdPos | number): void;
 
   abstract replaceSelection(content: string, range: Range): void;
+
+  abstract getRange(): any;
 }

--- a/apps/editor/src/base.ts
+++ b/apps/editor/src/base.ts
@@ -2,6 +2,7 @@ import { Node as ProsemirrorNode, Schema } from 'prosemirror-model';
 import { Plugin } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 import css from 'tui-code-snippet/domUtil/css';
+import { WidgetStyle } from '@t/editor';
 import { Emitter } from '@t/event';
 import { Context, EditorAllCommandMap } from '@t/spec';
 import SpecManager from './spec/specManager';
@@ -122,7 +123,7 @@ export default abstract class EditorBase {
     return this.el;
   }
 
-  addWidget(node: Node, style: 'top' | 'bottom', offset: number) {
+  addWidget(node: Node, style: WidgetStyle, offset: number) {
     const { dispatch, state } = this.view;
 
     dispatch(state.tr.setMeta('widget', { pos: state.selection.to, node, style, offset }));

--- a/apps/editor/src/base.ts
+++ b/apps/editor/src/base.ts
@@ -4,7 +4,7 @@ import { EditorView } from 'prosemirror-view';
 import css from 'tui-code-snippet/domUtil/css';
 import { WidgetStyle } from '@t/editor';
 import { Emitter } from '@t/event';
-import { MdPos } from '@t/markdown';
+import { MdPos, MdSourcepos } from '@t/markdown';
 import { Context, EditorAllCommandMap } from '@t/spec';
 import SpecManager from './spec/specManager';
 import { createTextSelection } from './helper/manipulation';
@@ -126,5 +126,5 @@ export default abstract class EditorBase {
 
   abstract replaceSelection(content: string, range: Range): void;
 
-  abstract getRange(): any;
+  abstract getRange(): MdSourcepos | [number, number];
 }

--- a/apps/editor/src/convertors/toMarkdown/toMdConvertors.ts
+++ b/apps/editor/src/convertors/toMarkdown/toMdConvertors.ts
@@ -15,7 +15,6 @@ import {
   MarkInfo,
 } from '@t/convertor';
 import { WwNodeType, WwMarkType } from '@t/wysiwyg';
-import { getWidgetContent } from '@/widget/widgetNode';
 
 function addBackticks(node: ProsemirrorNode, side: number) {
   const { text } = node;

--- a/apps/editor/src/convertors/toMarkdown/toMdConvertors.ts
+++ b/apps/editor/src/convertors/toMarkdown/toMdConvertors.ts
@@ -188,7 +188,7 @@ export const toMdConvertors: ToMdConvertorMap = {
 
   widget({ node }) {
     return {
-      text: getWidgetContent((node as ProsemirrorNode).textContent),
+      text: (node as ProsemirrorNode).textContent,
     };
   },
 

--- a/apps/editor/src/convertors/toMarkdown/toMdConvertors.ts
+++ b/apps/editor/src/convertors/toMarkdown/toMdConvertors.ts
@@ -15,6 +15,7 @@ import {
   MarkInfo,
 } from '@t/convertor';
 import { WwNodeType, WwMarkType } from '@t/wysiwyg';
+import { getWidgetContent } from '@/widget/widgetNode';
 
 function addBackticks(node: ProsemirrorNode, side: number) {
   const { text } = node;
@@ -182,6 +183,12 @@ export const toMdConvertors: ToMdConvertorMap = {
   frontMatter({ node }) {
     return {
       text: (node as ProsemirrorNode).textContent,
+    };
+  },
+
+  widget({ node }) {
+    return {
+      text: getWidgetContent((node as ProsemirrorNode).textContent),
     };
   },
 

--- a/apps/editor/src/convertors/toMarkdown/toMdNodeTypeWriters.ts
+++ b/apps/editor/src/convertors/toMarkdown/toMdNodeTypeWriters.ts
@@ -220,6 +220,10 @@ export const nodeTypeWriters: ToMdNodeTypeWriterMap = {
     state.text(text!, false);
     state.closeBlock(node);
   },
+
+  widget(state, _, { text }) {
+    state.write(text);
+  },
 };
 
 export function write(

--- a/apps/editor/src/convertors/toWysiwyg/toWwConvertors.ts
+++ b/apps/editor/src/convertors/toWysiwyg/toWwConvertors.ts
@@ -17,7 +17,7 @@ import {
   CustomBlockMdNode,
   CustomInlineMdNode,
 } from '@t/markdown';
-import { getWidgetMdContent } from '@/widget/widgetNode';
+import { createWidgetContent, getWidgetContent } from '@/widget/rules';
 
 function isBRTag(node: MdNode) {
   return node.type === 'htmlInline' && /<br ?\/?>/.test(node.literal!);
@@ -318,10 +318,13 @@ export const toWwConvertors: ToWwConvertorMap = {
     const { schema } = state;
 
     if (info.indexOf('widget') !== -1 && entering) {
-      const content = getWidgetMdContent(node as CustomInlineMdNode);
+      const content = getWidgetContent(node as CustomInlineMdNode);
 
       skipChildren();
-      state.addNode(schema.nodes.widget, { info }, [schema.text(`$$${info} ${content}$$`)]);
+
+      state.addNode(schema.nodes.widget, { info }, [
+        schema.text(createWidgetContent(info, content)),
+      ]);
     }
   },
 };

--- a/apps/editor/src/convertors/toWysiwyg/toWwConvertors.ts
+++ b/apps/editor/src/convertors/toWysiwyg/toWwConvertors.ts
@@ -15,7 +15,9 @@ import {
   LinkMdNode,
   TableCellMdNode,
   CustomBlockMdNode,
+  CustomInlineMdNode,
 } from '@t/markdown';
+import { getWidgetMdContent } from '@/widget/widgetNode';
 
 function isBRTag(node: MdNode) {
   return node.type === 'htmlInline' && /<br ?\/?>/.test(node.literal!);
@@ -309,5 +311,17 @@ export const toWwConvertors: ToWwConvertorMap = {
     addRawHTMLAttributeToDOM(container);
 
     state.convertByDOMParser(container as HTMLElement);
+  },
+
+  customInline(state, node, { entering, skipChildren }) {
+    const { info } = node as CustomInlineMdNode;
+    const { schema } = state;
+
+    if (info.indexOf('widget') !== -1 && entering) {
+      const content = getWidgetMdContent(node as CustomInlineMdNode);
+
+      skipChildren();
+      state.addNode(schema.nodes.widget, { info }, [schema.text(`$$${info} ${content}$$`)]);
+    }
   },
 };

--- a/apps/editor/src/editorCore.ts
+++ b/apps/editor/src/editorCore.ts
@@ -414,8 +414,8 @@ class ToastUIEditor {
     this.getCurrentModeEditor().addWidget(node, style, offset);
   }
 
-  insertWidgetNode(node: HTMLElement) {
-    this.getCurrentModeEditor().insertWidgetNode(node);
+  replaceWithWidget(markdownText: string, node: HTMLElement) {
+    this.getCurrentModeEditor().replaceWithWidget(markdownText, node);
   }
 
   /**

--- a/apps/editor/src/editorCore.ts
+++ b/apps/editor/src/editorCore.ts
@@ -10,7 +10,7 @@ import removeClass from 'tui-code-snippet/domUtil/removeClass';
 import isString from 'tui-code-snippet/type/isString';
 
 import { Emitter, Handler } from '@t/event';
-import { EditorOptions, EditorType, PreviewStyle, ViewerOptions } from '@t/editor';
+import { EditorOptions, EditorType, PreviewStyle, ViewerOptions, WidgetStyle } from '@t/editor';
 import { EditorCommandFn } from '@t/spec';
 
 import { sendHostName, sanitizeLinkAttribute } from './utils/common';
@@ -406,12 +406,11 @@ class ToastUIEditor {
 
   /**
    * Add widget to selection
-   * @param {Range} selection Current selection
    * @param {Node} node widget node
-   * @param {string} style Adding style "over" or "bottom"
+   * @param {string} style Adding style "top" or "bottom"
    * @param {number} [offset] Offset for adjust position
    */
-  addWidget(node: Node, style: 'top' | 'bottom', offset: number) {
+  addWidget(node: Node, style: WidgetStyle, offset: number) {
     this.getCurrentModeEditor().addWidget(node, style, offset);
   }
 

--- a/apps/editor/src/editorCore.ts
+++ b/apps/editor/src/editorCore.ts
@@ -411,11 +411,13 @@ class ToastUIEditor {
    * @param {string} style Adding style "over" or "bottom"
    * @param {number} [offset] Offset for adjust position
    */
-  // @TODO: should reimplment the API
-  // @ts-ignore
-  // addWidget(selection, node, style, offset) {
-  //   this.getCurrentModeEditor().addWidget(selection, node, style, offset);
-  // }
+  addWidget(node: Node, style: 'top' | 'bottom', offset: number) {
+    this.getCurrentModeEditor().addWidget(node, style, offset);
+  }
+
+  insertWidgetNode(node: HTMLElement) {
+    this.getCurrentModeEditor().insertWidgetNode(node);
+  }
 
   /**
    * Set editor height

--- a/apps/editor/src/editorCore.ts
+++ b/apps/editor/src/editorCore.ts
@@ -12,6 +12,7 @@ import isString from 'tui-code-snippet/type/isString';
 import { Emitter, Handler } from '@t/event';
 import { EditorOptions, EditorType, PreviewStyle, ViewerOptions, WidgetStyle } from '@t/editor';
 import { EditorCommandFn } from '@t/spec';
+import { MdPos } from '@t/markdown';
 
 import { sendHostName, sanitizeLinkAttribute } from './utils/common';
 
@@ -32,6 +33,7 @@ import { ToastMark } from '@toast-ui/toastmark';
 import { WwToDOMAdaptor } from './wysiwyg/adaptor/wwToDOMAdaptor';
 import { ScrollSync } from './markdown/scroll/scrollSync';
 import { addDefaultImageBlobHook } from './helper/image';
+import { setWidgetRule } from './widget/widgetNode';
 
 /**
  * ToastUI Editor
@@ -133,6 +135,7 @@ class ToastUIEditor {
         referenceDefinition: false,
         customHTMLSanitizer: null,
         frontMatter: false,
+        widgetRules: [],
       },
       options
     );
@@ -141,6 +144,8 @@ class ToastUIEditor {
     this.mode = this.options.initialEditType || 'markdown';
 
     this.eventEmitter = new EventEmitter();
+
+    setWidgetRule(this.options.widgetRules);
 
     const linkAttributes = sanitizeLinkAttribute(this.options.linkAttributes);
     const { renderer, parser, plugins } = getPluginInfo(this.options.plugins);
@@ -408,14 +413,22 @@ class ToastUIEditor {
    * Add widget to selection
    * @param {Node} node widget node
    * @param {string} style Adding style "top" or "bottom"
-   * @param {number} [offset] Offset for adjust position
+   * @param {number|Array.<number>} [pos] position
    */
-  addWidget(node: Node, style: WidgetStyle, offset: number) {
-    this.getCurrentModeEditor().addWidget(node, style, offset);
+  addWidget(node: Node, style: WidgetStyle, pos?: MdPos | number) {
+    // @ts-ignore
+    this.getCurrentModeEditor().addWidget(node, style, pos);
   }
 
-  replaceWithWidget(markdownText: string, node: HTMLElement) {
-    this.getCurrentModeEditor().replaceWithWidget(markdownText, node);
+  /**
+   * replace node with widget to range
+   * @param {number|Array.<number>} from start position
+   * @param {number|Array.<number>} to end position
+   * @param {string} content widget text content
+   */
+  replaceWithWidget(from: MdPos | number, to: MdPos | number, content: string) {
+    // @ts-ignore
+    this.getCurrentModeEditor().replaceWithWidget(from, to, content);
   }
 
   /**

--- a/apps/editor/src/editorCore.ts
+++ b/apps/editor/src/editorCore.ts
@@ -33,7 +33,7 @@ import { ToastMark } from '@toast-ui/toastmark';
 import { WwToDOMAdaptor } from './wysiwyg/adaptor/wwToDOMAdaptor';
 import { ScrollSync } from './markdown/scroll/scrollSync';
 import { addDefaultImageBlobHook } from './helper/image';
-import { setWidgetRule } from './widget/widgetNode';
+import { setWidgetRules } from './widget/rules';
 
 /**
  * ToastUI Editor
@@ -145,7 +145,7 @@ class ToastUIEditor {
 
     this.eventEmitter = new EventEmitter();
 
-    setWidgetRule(this.options.widgetRules);
+    setWidgetRules(this.options.widgetRules);
 
     const linkAttributes = sanitizeLinkAttribute(this.options.linkAttributes);
     const { renderer, parser, plugins } = getPluginInfo(this.options.plugins);

--- a/apps/editor/src/markdown/helper/pos.ts
+++ b/apps/editor/src/markdown/helper/pos.ts
@@ -47,7 +47,7 @@ function getWidgetNodePos(node: ProsemirrorNode, chPos: number, direction: 1 | -
   let additionalPos = 0;
 
   node.forEach((child, pos) => {
-    // add or substract widget node tag
+    // add or subtract widget node tag
     if (child.type.name === 'widget' && pos + 2 < chPos) {
       additionalPos += 2 * direction;
     }

--- a/apps/editor/src/markdown/helper/pos.ts
+++ b/apps/editor/src/markdown/helper/pos.ts
@@ -107,14 +107,14 @@ export function getMdToEditorPos(
   for (let i = 0; i < endPos[0] - 1; i += 1) {
     const len = lineTexts[i].length;
     const child = doc.child(i);
-    const added = getWidgetNodePos(child, child.content.size);
+    const additionalPos = getWidgetNodePos(child, child.content.size);
 
     // should plus 2(end tag, start tag) to consider line breaking
     if (i < startPos[0] - 1) {
-      from += len + 2 + added;
+      from += len + 2 + additionalPos;
     }
 
-    to += len + 2 + added;
+    to += len + 2 + additionalPos;
   }
 
   const startNode = doc.child(startPos[0] - 1);

--- a/apps/editor/src/markdown/helper/pos.ts
+++ b/apps/editor/src/markdown/helper/pos.ts
@@ -43,6 +43,20 @@ function getEndOffsetWithBlankLine(doc: ProsemirrorNode, to: number, lineRange: 
   return Math.min(doc.content.size, to + blankLineTagOffset);
 }
 
+function addWidgetNodePos(node: ProsemirrorNode, chPos: number) {
+  let addedPos = 0;
+
+  node.descendants((child, pos) => {
+    if (child.type.name === 'widget') {
+      if (pos + 2 < chPos) {
+        addedPos += child.attrs.id.length - 2;
+      }
+    }
+  });
+
+  return addedPos;
+}
+
 export function getEditorToMdPos(doc: ProsemirrorNode, from: number, to = from): MdSourcepos {
   const collapsed = from === to;
   const startResolvedPos = doc.resolve(from);
@@ -72,9 +86,12 @@ export function getEditorToMdPos(doc: ProsemirrorNode, from: number, to = from):
     }
   }
 
+  const added1 = addWidgetNodePos(doc.child(lineRange[0] - 1), Math.max(from - startOffset + 1, 1));
+  const added2 = addWidgetNodePos(doc.child(lineRange[1] - 1), Math.max(to - startOffset + 1, 1));
+
   return [
-    [lineRange[0], Math.max(from - startOffset + 1, 1)],
-    [lineRange[1], Math.max(to - endOffset + 1, 1)],
+    [lineRange[0], Math.max(from - startOffset + 1, 1) + added1],
+    [lineRange[1], Math.max(to - endOffset + 1, 1) + added2],
   ];
 }
 

--- a/apps/editor/src/markdown/htmlRenderConvertors.ts
+++ b/apps/editor/src/markdown/htmlRenderConvertors.ts
@@ -7,8 +7,10 @@ import {
   CustomHTMLRendererMap,
   Context,
   OpenTagToken,
+  CustomInlineMdNode,
 } from '@t/markdown';
 import { LinkAttributes } from '@t/editor';
+import { getWidgetMdContent, widgetRuleMap } from '@/widget/widgetNode';
 
 type TokenAttrs = Record<string, any>;
 
@@ -96,6 +98,29 @@ const baseConvertors: CustomHTMLRendererMap = {
       { type: 'closeTag', tagName: 'code' },
       { type: 'closeTag', tagName: 'pre' },
     ];
+  },
+
+  customInline(node: MdNode, { origin, entering }: Context) {
+    const { info } = node as CustomInlineMdNode;
+
+    if (info.indexOf('widget') !== -1) {
+      if (entering) {
+        const content = getWidgetMdContent(node as CustomInlineMdNode);
+
+        return {
+          type: 'openTag',
+          tagName: 'span',
+          content: widgetRuleMap[info].toHTML(content).outerHTML,
+          classNames: ['tui-widget'],
+        };
+      }
+
+      return {
+        type: 'closeTag',
+        tagName: 'span',
+      };
+    }
+    return origin!();
   },
 };
 

--- a/apps/editor/src/markdown/mdEditor.ts
+++ b/apps/editor/src/markdown/mdEditor.ts
@@ -39,7 +39,7 @@ import { CustomBlock } from './marks/customBlock';
 import { getEditorToMdPos, getMdToEditorPos } from './helper/pos';
 import { smartTask } from './plugins/smartTask';
 import { widgetPlugin } from '@/plugins/widget';
-import { Widget } from './nodes/widget';
+import { Widget } from '../widget/widgetNode';
 
 interface WindowWithClipboard extends Window {
   clipboardData?: DataTransfer | null;
@@ -193,6 +193,16 @@ export default class MdEditor extends EditorBase {
           return true;
         },
       },
+      nodeViews: {
+        widget: (node) => {
+          const dom = document.createElement('span');
+
+          dom.className = 'tui-widget';
+          dom.appendChild(node.attrs.node);
+
+          return { dom };
+        },
+      },
     });
   }
 
@@ -210,7 +220,7 @@ export default class MdEditor extends EditorBase {
           const [startPos, endPos] = getEditorToMdPos(doc, from, to);
           const editResult = this.toastMark.editMarkdown(startPos, endPos, changed);
 
-          this.eventEmitter.emit('contentChangedFromMarkdown', editResult, this.widgetMap);
+          this.eventEmitter.emit('contentChangedFromMarkdown', editResult);
 
           tr.setMeta('editResult', editResult);
         }
@@ -234,8 +244,6 @@ export default class MdEditor extends EditorBase {
         changed += node.text!.slice(Math.max(from, pos) - pos, to - pos);
       } else if (node.isBlock && pos > 0) {
         changed += '\n';
-      } else if (node.type.name === 'widget') {
-        changed += node.attrs.id;
       }
     });
 

--- a/apps/editor/src/markdown/mdEditor.ts
+++ b/apps/editor/src/markdown/mdEditor.ts
@@ -40,7 +40,7 @@ import { CustomBlock } from './marks/customBlock';
 import { getEditorToMdPos, getMdToEditorPos } from './helper/pos';
 import { smartTask } from './plugins/smartTask';
 import { widgetPlugin } from '@/plugins/widget';
-import { extract, getWidgetContent, Widget, widgetRules, widgetView } from '@/widget/widgetNode';
+import { extract, Widget, widgetRules, widgetView } from '@/widget/widgetNode';
 
 interface WindowWithClipboard extends Window {
   clipboardData?: DataTransfer | null;
@@ -181,7 +181,7 @@ export default class MdEditor extends EditorBase {
 
         this.view.updateState(state);
       },
-      clipboardTextSerializer: (slice) => this.getChanged(slice, true),
+      clipboardTextSerializer: (slice) => this.getChanged(slice),
       handleKeyDown: (_, ev) => {
         if ((ev.metaKey || ev.ctrlKey) && ev.key.toUpperCase() === 'V') {
           this.clipboard.focus();
@@ -228,7 +228,7 @@ export default class MdEditor extends EditorBase {
     return resolvedPos || [step.from, step.to];
   }
 
-  private getChanged(slice: Slice, trailing = false) {
+  private getChanged(slice: Slice) {
     let changed = '';
     const from = 0;
     const to = slice.content.size;
@@ -240,10 +240,6 @@ export default class MdEditor extends EditorBase {
         changed += '\n';
       }
     });
-
-    if (trailing) {
-      changed = getWidgetContent(changed);
-    }
 
     return nbspToSpace(changed);
   }

--- a/apps/editor/src/markdown/mdEditor.ts
+++ b/apps/editor/src/markdown/mdEditor.ts
@@ -38,6 +38,8 @@ import { Html } from './marks/html';
 import { CustomBlock } from './marks/customBlock';
 import { getEditorToMdPos, getMdToEditorPos } from './helper/pos';
 import { smartTask } from './plugins/smartTask';
+import { widgetPlugin } from '@/plugins/widget';
+import { Widget } from './nodes/widget';
 
 interface WindowWithClipboard extends Window {
   clipboardData?: DataTransfer | null;
@@ -115,6 +117,7 @@ export default class MdEditor extends EditorBase {
     return new SpecManager([
       new Doc(),
       new Paragraph(),
+      new Widget(),
       new Text(),
       new Heading(),
       new BlockQuote(),
@@ -162,6 +165,7 @@ export default class MdEditor extends EditorBase {
         smartTask(this.context),
         dropImage(this.context, 'markdown'),
         placeholder(this.placeholder),
+        widgetPlugin(),
       ],
     });
   }
@@ -206,7 +210,7 @@ export default class MdEditor extends EditorBase {
           const [startPos, endPos] = getEditorToMdPos(doc, from, to);
           const editResult = this.toastMark.editMarkdown(startPos, endPos, changed);
 
-          this.eventEmitter.emit('contentChangedFromMarkdown', editResult);
+          this.eventEmitter.emit('contentChangedFromMarkdown', editResult, this.widgetMap);
 
           tr.setMeta('editResult', editResult);
         }
@@ -230,6 +234,8 @@ export default class MdEditor extends EditorBase {
         changed += node.text!.slice(Math.max(from, pos) - pos, to - pos);
       } else if (node.isBlock && pos > 0) {
         changed += '\n';
+      } else if (node.type.name === 'widget') {
+        changed += node.attrs.id;
       }
     });
 

--- a/apps/editor/src/markdown/mdPreview.ts
+++ b/apps/editor/src/markdown/mdPreview.ts
@@ -176,11 +176,9 @@ class MarkdownPreview extends Preview {
       nodes.map((node) => this.renderer.render(node)).join('')
     );
 
-    if (widgetMap) {
-      Object.keys(widgetMap).forEach((id) => {
-        newHtml = newHtml.replace(new RegExp(id, 'g'), widgetMap[id].outerHTML);
-      });
-    }
+    Object.keys(widgetMap).forEach((id) => {
+      newHtml = newHtml.replace(new RegExp(id, 'g'), widgetMap[id].outerHTML);
+    });
 
     newHtml = sanitizeHTML(newHtml, true);
 

--- a/apps/editor/src/markdown/mdPreview.ts
+++ b/apps/editor/src/markdown/mdPreview.ts
@@ -11,6 +11,7 @@ import on from 'tui-code-snippet/domEvent/on';
 import { Renderer } from '@toast-ui/toastmark';
 
 import { Emitter } from '@t/event';
+import { LinkAttributes } from '@t/editor';
 import { CustomHTMLRendererMap, EditResult, MdNode, MdPos } from '@t/markdown';
 import Preview from '@/preview';
 import { toggleClass } from '@/utils/dom';
@@ -20,7 +21,6 @@ import { sanitizeHTML } from '@/sanitizer/htmlSanitizer';
 import { isInlineNode, findClosestNode, getMdStartCh } from '@/utils/markdown';
 import { findAdjacentElementToScrollTop } from './scroll/dom';
 import { removeOffsetInfoByNode } from './scroll/offset';
-import { LinkAttributes } from '@t/editor';
 
 export const CLASS_HIGHLIGHT = 'te-preview-highlight';
 
@@ -163,22 +163,18 @@ class MarkdownPreview extends Preview {
       : null;
   }
 
-  update(changed: EditResult[], widgetMap: Record<string, HTMLElement>) {
-    changed.forEach((editResult) => this.replaceRangeNodes(editResult, widgetMap));
+  update(changed: EditResult[]) {
+    changed.forEach((editResult) => this.replaceRangeNodes(editResult));
     this.eventEmitter.emit('previewRenderAfter', this);
   }
 
-  replaceRangeNodes(editResult: EditResult, widgetMap: Record<string, HTMLElement>) {
+  replaceRangeNodes(editResult: EditResult) {
     const { nodes, removedNodeRange } = editResult;
     const contentEl = this.previewContent;
     let newHtml = this.eventEmitter.emitReduce(
       'convertorAfterMarkdownToHtmlConverted',
       nodes.map((node) => this.renderer.render(node)).join('')
     );
-
-    Object.keys(widgetMap).forEach((id) => {
-      newHtml = newHtml.replace(new RegExp(id, 'g'), widgetMap[id].outerHTML);
-    });
 
     newHtml = sanitizeHTML(newHtml, true);
 

--- a/apps/editor/src/markdown/nodes/paragraph.ts
+++ b/apps/editor/src/markdown/nodes/paragraph.ts
@@ -80,6 +80,7 @@ export class Paragraph extends Node {
         codeStart: { default: null },
         codeEnd: { default: null },
       },
+      selectable: false,
       group: 'block',
       parseDOM: [{ tag: 'div' }],
       toDOM({ attrs }: ProsemirrorNode): DOMOutputSpecArray {

--- a/apps/editor/src/markdown/nodes/widget.ts
+++ b/apps/editor/src/markdown/nodes/widget.ts
@@ -1,0 +1,26 @@
+import Node from '@/spec/Node';
+import { DOMOutputSpecArray, ProsemirrorNode } from 'prosemirror-model';
+
+export class Widget extends Node {
+  get name() {
+    return 'widget';
+  }
+
+  get defaultSchema() {
+    return {
+      attrs: {
+        id: {},
+        node: {},
+      },
+      group: 'inline',
+      inline: true,
+      content: 'text*',
+      selectable: false,
+      atom: true,
+      toDOM({ attrs }: ProsemirrorNode): DOMOutputSpecArray {
+        return ['span', { class: 'tui-widget' }, attrs.node];
+      },
+      parseDOM: [{ tag: 'span.tui-widget' }],
+    };
+  }
+}

--- a/apps/editor/src/markdown/plugins/syntaxHighlight.ts
+++ b/apps/editor/src/markdown/plugins/syntaxHighlight.ts
@@ -40,8 +40,7 @@ export function syntaxHighlight({ schema, toastMark }: Context) {
           }
         });
       }
-
-      return newTr;
+      return newTr.setMeta('widget', tr.getMeta('widget'));
     },
   });
 }

--- a/apps/editor/src/plugins/popupWidget.ts
+++ b/apps/editor/src/plugins/popupWidget.ts
@@ -10,15 +10,29 @@ interface Widget {
 
 const pluginKey = new PluginKey('widget');
 
-class WidgetView {
-  private widgetNode: HTMLElement | null = null;
+class PopupWidget {
+  private popup: HTMLElement | null = null;
+
+  private view: EditorView;
+
+  constructor(view: EditorView) {
+    view.dom.addEventListener('blur', this.removeWidget);
+    this.view = view;
+  }
+
+  private removeWidget = () => {
+    if (this.popup) {
+      document.body.removeChild(this.popup);
+      this.popup = null;
+    }
+  };
 
   update(view: EditorView) {
     const widget: Widget | null = pluginKey.getState(view.state);
 
-    if (this.widgetNode) {
-      document.body.removeChild(this.widgetNode);
-      this.widgetNode = null;
+    if (this.popup) {
+      document.body.removeChild(this.popup);
+      this.popup = null;
     }
 
     if (widget) {
@@ -34,13 +48,17 @@ class WidgetView {
 
       node.style.top = `${style === 'bottom' ? top + height : top - node.clientHeight - height}px`;
       node.style.opacity = '1';
-      this.widgetNode = node;
+      this.popup = node;
     }
     view.focus();
   }
+
+  destroy() {
+    this.view.dom.removeEventListener('blur', this.removeWidget);
+  }
 }
 
-export function widgetPlugin() {
+export function addWidget() {
   return new Plugin({
     key: pluginKey,
     state: {
@@ -51,8 +69,8 @@ export function widgetPlugin() {
         return tr.getMeta('widget');
       },
     },
-    view() {
-      return new WidgetView();
+    view(editorView: EditorView) {
+      return new PopupWidget(editorView);
     },
   });
 }

--- a/apps/editor/src/plugins/popupWidget.ts
+++ b/apps/editor/src/plugins/popupWidget.ts
@@ -1,6 +1,7 @@
 import { EditorView } from 'prosemirror-view';
 import { Plugin, PluginKey } from 'prosemirror-state';
 import { WidgetStyle } from '@t/editor';
+import css from 'tui-code-snippet/domUtil/css';
 
 interface Widget {
   node: HTMLElement;
@@ -30,24 +31,19 @@ class PopupWidget {
   update(view: EditorView) {
     const widget: Widget | null = pluginKey.getState(view.state);
 
-    if (this.popup) {
-      document.body.removeChild(this.popup);
-      this.popup = null;
-    }
+    this.removeWidget();
 
     if (widget) {
       const { node, style } = widget;
       const { top, left, bottom } = view.coordsAtPos(widget.pos);
       const height = bottom - top;
 
-      node.style.position = 'absolute';
-      node.style.left = `${left}px`;
-      node.style.opacity = '0';
-
+      css(node, { position: 'absolute', left: `${left}px`, opacity: '0' });
       document.body.appendChild(node);
-
-      node.style.top = `${style === 'bottom' ? top + height : top - node.clientHeight - height}px`;
-      node.style.opacity = '1';
+      css(node, {
+        top: `${style === 'bottom' ? top + height : top - node.clientHeight - height}px`,
+        opacity: '1',
+      });
       this.popup = node;
     }
     view.focus();

--- a/apps/editor/src/plugins/widget.ts
+++ b/apps/editor/src/plugins/widget.ts
@@ -1,0 +1,64 @@
+import { EditorView } from 'prosemirror-view';
+import { Plugin, PluginKey } from 'prosemirror-state';
+
+interface Widget {
+  node: HTMLElement;
+  pos: number;
+}
+
+const pluginKey = new PluginKey('suggestions');
+
+class WidgetView {
+  private widgetNode: HTMLElement | null = null;
+
+  update(view: EditorView) {
+    const { state } = view;
+    const widget: Widget | null = pluginKey.getState(state);
+
+    if (this.widgetNode) {
+      document.body.removeChild(this.widgetNode);
+      this.widgetNode = null;
+    }
+
+    if (widget) {
+      const { node, style } = widget;
+      const rect = view.coordsAtPos(widget.pos);
+      const a = view.domAtPos(widget.pos);
+
+      const { clientHeight } = a.node;
+
+      this.widgetNode = node;
+      node.style.position = 'absolute';
+      node.style.left = `${rect.left}px`;
+
+      if (style === 'bottom') {
+        node.style.top = `${rect.top + clientHeight / 2}px`;
+      }
+
+      document.body.appendChild(node);
+      if (style === 'top') {
+        node.style.top = `${rect.top - node.clientHeight - clientHeight}px`;
+      }
+    }
+    view.focus();
+  }
+}
+
+export function widgetPlugin() {
+  return new Plugin({
+    key: pluginKey,
+    state: {
+      init() {
+        return null;
+      },
+      apply(tr) {
+        const widget = tr.getMeta('widget');
+
+        return widget ? widget : null;
+      },
+    },
+    view() {
+      return new WidgetView();
+    },
+  });
+}

--- a/apps/editor/src/utils/markdown.ts
+++ b/apps/editor/src/utils/markdown.ts
@@ -92,6 +92,7 @@ export function isInlineNode(mdNode: MdNode) {
     case 'htmlInline':
     case 'linebreak':
     case 'softbreak':
+    case 'customInline':
       return true;
     default:
       return false;

--- a/apps/editor/src/widget/rules.ts
+++ b/apps/editor/src/widget/rules.ts
@@ -1,0 +1,91 @@
+import { Schema, ProsemirrorNode } from 'prosemirror-model';
+import { WidgetRule, WidgetRuleMap } from '@t/editor';
+import { CustomInlineMdNode } from '@t/markdown';
+
+let widgetRules: WidgetRule[];
+
+const widgetRuleMap: WidgetRuleMap = {};
+
+function trailingWidgetSyntax(text: string) {
+  return text.replace(/\$\$widget\d{1,}\s|\$\$/g, '');
+}
+
+export function createWidgetContent(info: string, content: string) {
+  return `$$${info} ${content}$$`;
+}
+
+export function widgetToDOM(info: string, content: string) {
+  const { rule, toDOM } = widgetRuleMap[info];
+
+  content = content.match(rule)![0];
+  return toDOM(content);
+}
+
+export function setWidgetRules(rules: WidgetRule[]) {
+  widgetRules = rules;
+  widgetRules.forEach((rule, index) => {
+    widgetRuleMap[`widget${index}`] = rule;
+  });
+}
+
+export function createNodesWithWidget(content: string, schema: Schema, ruleIndex = 0) {
+  let nodes: ProsemirrorNode[] = [];
+  const { rule } = widgetRules[ruleIndex] || {};
+
+  content = trailingWidgetSyntax(content);
+
+  if (rule && rule.test(content)) {
+    let index;
+    const nextRuleIndex = ruleIndex + 1;
+
+    while ((index = content.search(rule)) !== -1) {
+      const prev = content.substring(0, index);
+
+      // get widget node on first splitted node using next widget rule
+      if (prev) {
+        nodes = nodes.concat(createNodesWithWidget(prev, schema, nextRuleIndex));
+      }
+
+      // build widget node using current widget rule
+      content = content.substring(index);
+
+      const [literal] = content.match(rule)!;
+      const info = `widget${ruleIndex}`;
+
+      nodes.push(
+        schema.nodes.widget.create({ info }, schema.text(createWidgetContent(info, literal)))
+      );
+      content = content.substring(literal.length);
+    }
+    // get widget node on last splitted node using next widget rule
+    if (content) {
+      nodes = nodes.concat(createNodesWithWidget(content, schema, nextRuleIndex));
+    }
+  } else if (content) {
+    nodes = [schema.text(content)];
+  }
+
+  return nodes;
+}
+
+export function getWidgetContent(widgetNode: CustomInlineMdNode) {
+  let event;
+  let text = '';
+  const walker = widgetNode.walker();
+
+  while ((event = walker.next())) {
+    const { node, entering } = event;
+
+    if (entering) {
+      if (node !== widgetNode && node.type !== 'text') {
+        text += node.inlineToMark();
+        walker.resumeAt(widgetNode, false);
+        walker.next();
+      } else if (node.type === 'text') {
+        text += node.literal;
+      }
+    }
+  }
+
+  return text;
+}

--- a/apps/editor/src/widget/rules.ts
+++ b/apps/editor/src/widget/rules.ts
@@ -6,8 +6,19 @@ let widgetRules: WidgetRule[] = [];
 
 const widgetRuleMap: WidgetRuleMap = {};
 
+const reWidgetPrefix = /\$\$widget\d{1,}\s/;
+
 function trailingWidgetSyntax(text: string) {
-  return text.replace(/\$\$widget\d{1,}\s|\$\$/g, '');
+  const index = text.search(reWidgetPrefix);
+
+  if (index !== -1) {
+    const rest = text.substring(index);
+    const replaced = rest.replace(reWidgetPrefix, '').replace('$$', '');
+
+    text = text.substring(0, index);
+    text += trailingWidgetSyntax(replaced);
+  }
+  return text;
 }
 
 export function createWidgetContent(info: string, content: string) {

--- a/apps/editor/src/widget/widgetNode.ts
+++ b/apps/editor/src/widget/widgetNode.ts
@@ -41,6 +41,8 @@ export function getWidgetContent(text: string) {
 export function extract(content: string, schema: Schema, rules: WidgetRule[]) {
   let nodes: ProsemirrorNode[] = [];
 
+  content = getWidgetContent(content);
+
   if (rules.length) {
     rules.forEach((ruleInfo, ruleIndex) => {
       const { rule } = ruleInfo;

--- a/apps/editor/src/widget/widgetNode.ts
+++ b/apps/editor/src/widget/widgetNode.ts
@@ -1,5 +1,5 @@
 import Node from '@/spec/Node';
-import { DOMOutputSpecArray, ProsemirrorNode } from 'prosemirror-model';
+import { DOMOutputSpecArray } from 'prosemirror-model';
 
 export class Widget extends Node {
   get name() {
@@ -9,7 +9,6 @@ export class Widget extends Node {
   get defaultSchema() {
     return {
       attrs: {
-        id: {},
         node: {},
       },
       group: 'inline',
@@ -17,8 +16,8 @@ export class Widget extends Node {
       content: 'text*',
       selectable: false,
       atom: true,
-      toDOM({ attrs }: ProsemirrorNode): DOMOutputSpecArray {
-        return ['span', { class: 'tui-widget' }, attrs.node];
+      toDOM(): DOMOutputSpecArray {
+        return ['span', { class: 'tui-widget' }, 0];
       },
       parseDOM: [{ tag: 'span.tui-widget' }],
     };

--- a/apps/editor/src/widget/widgetNode.ts
+++ b/apps/editor/src/widget/widgetNode.ts
@@ -1,7 +1,95 @@
-import Node from '@/spec/Node';
-import { DOMOutputSpecArray } from 'prosemirror-model';
+import { DOMOutputSpecArray, Schema, Node as ProsemirrorNode } from 'prosemirror-model';
+import { WidgetRule, WidgetRuleMap } from '@t/editor';
+import { CustomInlineMdNode } from '@t/markdown';
+import SpecNode from '@/spec/Node';
 
-export class Widget extends Node {
+export const widgetRuleMap: WidgetRuleMap = {};
+
+export let widgetRules: WidgetRule[];
+
+export function setWidgetRule(rules: WidgetRule[]) {
+  widgetRules = rules;
+  widgetRules.forEach((rule, index) => {
+    widgetRuleMap[`widget${index}`] = rule;
+  });
+}
+
+export function getWidgetMdContent(node: CustomInlineMdNode) {
+  let event;
+  let text = '';
+  const walker = node.walker();
+
+  while ((event = walker.next())) {
+    if (event.entering) {
+      if (event.node !== node && event.node.type !== 'text') {
+        text += event.node.inlineToMark();
+        walker.resumeAt(node, false);
+        walker.next();
+      } else if (event.node.type === 'text') {
+        text += event.node.literal;
+      }
+    }
+  }
+
+  return text;
+}
+
+export function getWidgetContent(text: string) {
+  return text.replace(/\$\$widget\d{1,}\s|\$\$/g, '');
+}
+
+export function extract(content: string, schema: Schema, rules: WidgetRule[]) {
+  let nodes: ProsemirrorNode[] = [];
+
+  if (rules.length) {
+    rules.forEach((ruleInfo, ruleIndex) => {
+      const { rule } = ruleInfo;
+      const nextRules = rules.slice(ruleIndex + 1);
+
+      if (rule.test(content)) {
+        let index;
+
+        while ((index = content.search(rule)) !== -1) {
+          const prev = content.substring(0, index);
+
+          if (prev) {
+            nodes = nodes.concat(extract(prev, schema, nextRules));
+          }
+
+          content = content.substring(index);
+          const [literal] = content.match(rule)!;
+          const info = `widget${ruleIndex}`;
+
+          nodes.push(schema.nodes.widget.create({ info }, schema.text(`$$${info} ${literal}$$`)));
+          content = content.substring(literal.length);
+        }
+        if (content) {
+          nodes = nodes.concat(extract(content, schema, nextRules));
+        }
+      } else if (content) {
+        nodes = [schema.text(content)];
+      }
+    });
+  } else if (content) {
+    return [schema.text(content)];
+  }
+
+  return nodes;
+}
+
+export const widgetView = (pmNode: ProsemirrorNode) => {
+  const dom = document.createElement('span');
+  const content = pmNode.textContent;
+  const { rule, toHTML } = widgetRuleMap[pmNode.attrs.info];
+  const node = toHTML(content.match(rule)![0]);
+
+  dom.className = 'tui-widget';
+  dom.appendChild(node);
+
+  return { dom };
+};
+
+export class Widget extends SpecNode {
   get name() {
     return 'widget';
   }
@@ -9,7 +97,7 @@ export class Widget extends Node {
   get defaultSchema() {
     return {
       attrs: {
-        node: {},
+        info: { default: null },
       },
       group: 'inline',
       inline: true,
@@ -19,7 +107,17 @@ export class Widget extends Node {
       toDOM(): DOMOutputSpecArray {
         return ['span', { class: 'tui-widget' }, 0];
       },
-      parseDOM: [{ tag: 'span.tui-widget' }],
+      parseDOM: [
+        {
+          tag: 'span.tui-widget',
+          getAttrs(dom: Node | string) {
+            const text = (dom as HTMLElement).textContent!;
+            const [, info] = text.match(/\$\$(widget\d{1,})/)!;
+
+            return { info };
+          },
+        },
+      ],
     };
   }
 }

--- a/apps/editor/src/widget/widgetNode.ts
+++ b/apps/editor/src/widget/widgetNode.ts
@@ -1,95 +1,16 @@
-import { DOMOutputSpecArray, Schema, Node as ProsemirrorNode } from 'prosemirror-model';
-import { WidgetRule, WidgetRuleMap } from '@t/editor';
-import { CustomInlineMdNode } from '@t/markdown';
+import { DOMOutputSpecArray, ProsemirrorNode } from 'prosemirror-model';
 import SpecNode from '@/spec/Node';
+import { widgetToDOM } from './rules';
 
-export const widgetRuleMap: WidgetRuleMap = {};
-
-export let widgetRules: WidgetRule[];
-
-export function setWidgetRule(rules: WidgetRule[]) {
-  widgetRules = rules;
-  widgetRules.forEach((rule, index) => {
-    widgetRuleMap[`widget${index}`] = rule;
-  });
-}
-
-export function getWidgetMdContent(node: CustomInlineMdNode) {
-  let event;
-  let text = '';
-  const walker = node.walker();
-
-  while ((event = walker.next())) {
-    if (event.entering) {
-      if (event.node !== node && event.node.type !== 'text') {
-        text += event.node.inlineToMark();
-        walker.resumeAt(node, false);
-        walker.next();
-      } else if (event.node.type === 'text') {
-        text += event.node.literal;
-      }
-    }
-  }
-
-  return text;
-}
-
-export function getWidgetContent(text: string) {
-  return text.replace(/\$\$widget\d{1,}\s|\$\$/g, '');
-}
-
-export function extract(content: string, schema: Schema, rules: WidgetRule[]) {
-  let nodes: ProsemirrorNode[] = [];
-
-  content = getWidgetContent(content);
-
-  if (rules.length) {
-    rules.forEach((ruleInfo, ruleIndex) => {
-      const { rule } = ruleInfo;
-      const nextRules = rules.slice(ruleIndex + 1);
-
-      if (rule.test(content)) {
-        let index;
-
-        while ((index = content.search(rule)) !== -1) {
-          const prev = content.substring(0, index);
-
-          if (prev) {
-            nodes = nodes.concat(extract(prev, schema, nextRules));
-          }
-
-          content = content.substring(index);
-          const [literal] = content.match(rule)!;
-          const info = `widget${ruleIndex}`;
-
-          nodes.push(schema.nodes.widget.create({ info }, schema.text(`$$${info} ${literal}$$`)));
-          content = content.substring(literal.length);
-        }
-        if (content) {
-          nodes = nodes.concat(extract(content, schema, nextRules));
-        }
-      } else if (content) {
-        nodes = [schema.text(content)];
-      }
-    });
-  } else if (content) {
-    return [schema.text(content)];
-  }
-
-  return nodes;
-}
-
-export const widgetView = (pmNode: ProsemirrorNode) => {
+export function widgetNodeView(pmNode: ProsemirrorNode) {
   const dom = document.createElement('span');
-  const content = pmNode.textContent;
-  const { rule, toHTML } = widgetRuleMap[pmNode.attrs.info];
-  const node = toHTML(content.match(rule)![0]);
+  const node = widgetToDOM(pmNode.attrs.info, pmNode.textContent);
 
   dom.className = 'tui-widget';
   dom.appendChild(node);
 
   return { dom };
-};
+}
 
 export class Widget extends SpecNode {
   get name() {

--- a/apps/editor/src/widget/widgetNode.ts
+++ b/apps/editor/src/widget/widgetNode.ts
@@ -35,7 +35,7 @@ export class Widget extends SpecNode {
           tag: 'span.tui-widget',
           getAttrs(dom: Node | string) {
             const text = (dom as HTMLElement).textContent!;
-            const [, info] = text.match(/\$\$(widget\d{1,})/)!;
+            const [, info] = text.match(/\$\$(widget\d+)/)!;
 
             return { info };
           },

--- a/apps/editor/src/wysiwyg/specCreator.ts
+++ b/apps/editor/src/wysiwyg/specCreator.ts
@@ -27,7 +27,7 @@ import { CustomBlock } from './nodes/customBlock';
 import { FrontMatter } from './nodes/frontMatter';
 import { ToDOMAdaptor } from '@t/convertor';
 import { LinkAttributes } from '@t/editor';
-import { Widget } from '@/markdown/nodes/widget';
+import { Widget } from '@/widget/widgetNode';
 
 export function createSpecs(toDOMAdaptor: ToDOMAdaptor, linkAttributes: LinkAttributes) {
   return new SpecManager([

--- a/apps/editor/src/wysiwyg/specCreator.ts
+++ b/apps/editor/src/wysiwyg/specCreator.ts
@@ -27,6 +27,7 @@ import { CustomBlock } from './nodes/customBlock';
 import { FrontMatter } from './nodes/frontMatter';
 import { ToDOMAdaptor } from '@t/convertor';
 import { LinkAttributes } from '@t/editor';
+import { Widget } from '@/markdown/nodes/widget';
 
 export function createSpecs(toDOMAdaptor: ToDOMAdaptor, linkAttributes: LinkAttributes) {
   return new SpecManager([
@@ -54,5 +55,6 @@ export function createSpecs(toDOMAdaptor: ToDOMAdaptor, linkAttributes: LinkAttr
     new Code(toDOMAdaptor),
     new CustomBlock(),
     new FrontMatter(),
+    new Widget(),
   ]);
 }

--- a/apps/editor/src/wysiwyg/wwEditor.ts
+++ b/apps/editor/src/wysiwyg/wwEditor.ts
@@ -1,6 +1,6 @@
 import { EditorState } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
-import { Schema, Node, Slice, Fragment } from 'prosemirror-model';
+import { Schema, Node as ProsemirrorNode, Slice, Fragment } from 'prosemirror-model';
 import { keymap } from 'prosemirror-keymap';
 import { baseKeymap } from 'prosemirror-commands';
 import { history } from 'prosemirror-history';
@@ -14,6 +14,7 @@ import { emitImageBlobHook, pasteImageOnly } from '@/helper/image';
 
 import { placeholder } from '@/plugins/placeholder';
 import { dropImage } from '@/plugins/dropImage';
+import { extract, widgetRules, widgetView } from '@/widget/widgetNode';
 
 import { tableSelection } from './plugins/tableSelection';
 import { tableContextMenu } from './plugins/tableContextMenu';
@@ -28,7 +29,7 @@ import { createSpecs } from './specCreator';
 
 import { Emitter } from '@t/event';
 import { ToDOMAdaptor } from '@t/convertor';
-import { LinkAttributes } from '@t/editor';
+import { LinkAttributes, WidgetStyle } from '@t/editor';
 
 interface WindowWithClipboard extends Window {
   clipboardData?: DataTransfer | null;
@@ -116,6 +117,7 @@ export default class WysiwygEditor extends EditorBase {
         image(node, view, getPos) {
           return new ImageView(node, view, getPos, toDOMAdaptor, eventEmitter);
         },
+        widget: widgetView,
       },
       transformPastedHTML: changePastedHTML,
       transformPasted: (slice: Slice) => changePastedSlice(slice, this.schema),
@@ -173,7 +175,7 @@ export default class WysiwygEditor extends EditorBase {
     this.focus();
   }
 
-  setModel(newDoc: Node, cursorToEnd = false) {
+  setModel(newDoc: ProsemirrorNode, cursorToEnd = false) {
     const { tr, doc } = this.view.state;
 
     this.view.dispatch(tr.replaceWith(0, doc.content.size, newDoc));
@@ -188,5 +190,18 @@ export default class WysiwygEditor extends EditorBase {
     const selection = createTextSelection(tr, start, end);
 
     this.view.dispatch(tr.setSelection(selection));
+  }
+
+  addWidget(node: Node, style: WidgetStyle, pos?: number) {
+    const { dispatch, state } = this.view;
+
+    dispatch(state.tr.setMeta('widget', { pos: pos ?? state.selection.to, node, style }));
+  }
+
+  replaceWithWidget(from: number, to: number, content: string) {
+    const { tr, schema } = this.view.state;
+    const nodes = extract(content, schema, widgetRules);
+
+    this.view.dispatch(tr.replaceWith(from, to, nodes));
   }
 }

--- a/apps/editor/src/wysiwyg/wwEditor.ts
+++ b/apps/editor/src/wysiwyg/wwEditor.ts
@@ -14,7 +14,6 @@ import { emitImageBlobHook, pasteImageOnly } from '@/helper/image';
 
 import { placeholder } from '@/plugins/placeholder';
 import { dropImage } from '@/plugins/dropImage';
-import { extract, widgetRules, widgetView } from '@/widget/widgetNode';
 
 import { tableSelection } from './plugins/tableSelection';
 import { tableContextMenu } from './plugins/tableContextMenu';
@@ -30,6 +29,9 @@ import { createSpecs } from './specCreator';
 import { Emitter } from '@t/event';
 import { ToDOMAdaptor } from '@t/convertor';
 import { LinkAttributes, WidgetStyle } from '@t/editor';
+import { addWidget } from '@/plugins/popupWidget';
+import { createNodesWithWidget } from '@/widget/rules';
+import { widgetNodeView } from '@/widget/widgetNode';
 
 interface WindowWithClipboard extends Window {
   clipboardData?: DataTransfer | null;
@@ -97,6 +99,7 @@ export default class WysiwygEditor extends EditorBase {
         task(),
         dropImage(this.context, 'wysiwyg'),
         toolbarActivity(this.eventEmitter),
+        addWidget(),
       ],
       ...addedStates,
     });
@@ -117,7 +120,7 @@ export default class WysiwygEditor extends EditorBase {
         image(node, view, getPos) {
           return new ImageView(node, view, getPos, toDOMAdaptor, eventEmitter);
         },
-        widget: widgetView,
+        widget: widgetNodeView,
       },
       transformPastedHTML: changePastedHTML,
       transformPasted: (slice: Slice) => changePastedSlice(slice, this.schema),
@@ -200,7 +203,7 @@ export default class WysiwygEditor extends EditorBase {
 
   replaceWithWidget(from: number, to: number, content: string) {
     const { tr, schema } = this.view.state;
-    const nodes = extract(content, schema, widgetRules);
+    const nodes = createNodesWithWidget(content, schema);
 
     this.view.dispatch(tr.replaceWith(from, to, nodes));
   }

--- a/apps/editor/src/wysiwyg/wwEditor.ts
+++ b/apps/editor/src/wysiwyg/wwEditor.ts
@@ -158,7 +158,7 @@ export default class WysiwygEditor extends EditorBase {
     return this.view.state.doc;
   }
 
-  getRange() {
+  getRange(): [number, number] {
     const { from, to } = this.view.state.selection;
 
     return [from, to];

--- a/apps/editor/types/editor.d.ts
+++ b/apps/editor/types/editor.d.ts
@@ -7,6 +7,12 @@ import { DefaultUI, ToolbarItemOptions } from './ui';
 export type PreviewStyle = 'tab' | 'vertical';
 export type EditorType = 'markdown' | 'wysiwyg';
 export type WidgetStyle = 'top' | 'bottom';
+export interface WidgetRule {
+  rule: RegExp;
+  toHTML: (text: string) => HTMLElement;
+}
+
+export type WidgetRuleMap = Record<string, WidgetRule>;
 
 export interface EventMap {
   load?: (param: Editor) => void;
@@ -119,8 +125,7 @@ export interface EditorOptions {
   customHTMLSanitizer?: CustomHTMLSanitizer;
   previewHighlight?: boolean;
   frontMatter?: boolean;
-  // @TODO: should remove UI option
-  UI: any;
+  widgetRules?: WidgetRule[];
 }
 
 interface Slots {

--- a/apps/editor/types/editor.d.ts
+++ b/apps/editor/types/editor.d.ts
@@ -6,6 +6,7 @@ import { DefaultUI, ToolbarItemOptions } from './ui';
 
 export type PreviewStyle = 'tab' | 'vertical';
 export type EditorType = 'markdown' | 'wysiwyg';
+export type WidgetStyle = 'top' | 'bottom';
 
 export interface EventMap {
   load?: (param: Editor) => void;

--- a/apps/editor/types/editor.d.ts
+++ b/apps/editor/types/editor.d.ts
@@ -9,7 +9,7 @@ export type EditorType = 'markdown' | 'wysiwyg';
 export type WidgetStyle = 'top' | 'bottom';
 export interface WidgetRule {
   rule: RegExp;
-  toHTML: (text: string) => HTMLElement;
+  toDOM: (text: string) => HTMLElement;
 }
 
 export type WidgetRuleMap = Record<string, WidgetRule>;

--- a/apps/editor/types/markdown.d.ts
+++ b/apps/editor/types/markdown.d.ts
@@ -31,7 +31,8 @@ type InlineNodeType =
   | 'image'
   | 'htmlInline'
   | 'linebreak'
-  | 'softbreak';
+  | 'softbreak'
+  | 'customInline';
 
 interface NodeWalker {
   current: MdNode | null;
@@ -66,6 +67,7 @@ export interface MdNode {
   appendChild(child: MdNode): void;
   prependChild(child: MdNode): void;
   walker(): NodeWalker;
+  inlineToMark(): string | null;
 }
 
 export interface CodeBlockMdNode extends MdNode {
@@ -167,6 +169,11 @@ export interface CustomBlockMdNode extends MdNode {
   info: string;
   offset: number;
   syntaxLength: number;
+}
+
+export interface CustomInlineMdNode extends MdNode {
+  parent: NonNullable<MdNode>;
+  info: string;
 }
 
 /* ToastMark Parser type */

--- a/apps/editor/types/markdown.d.ts
+++ b/apps/editor/types/markdown.d.ts
@@ -67,7 +67,7 @@ export interface MdNode {
   appendChild(child: MdNode): void;
   prependChild(child: MdNode): void;
   walker(): NodeWalker;
-  inlineToMark(): string | null;
+  getInlineMarkdownText(): string | null;
 }
 
 export interface CodeBlockMdNode extends MdNode {

--- a/apps/editor/types/wysiwyg.d.ts
+++ b/apps/editor/types/wysiwyg.d.ts
@@ -21,7 +21,8 @@ export type WwNodeType =
   | 'hardBreak'
   | 'lineBreak'
   | 'customBlock'
-  | 'frontMatter';
+  | 'frontMatter'
+  | 'widget';
 
 export type WwMarkType = 'strong' | 'emph' | 'strike' | 'link' | 'code';
 

--- a/libs/toastmark/src/commonmark/custom/__test__/customInline.spec.ts
+++ b/libs/toastmark/src/commonmark/custom/__test__/customInline.spec.ts
@@ -1,0 +1,55 @@
+import { Parser } from '../../blocks';
+import { Renderer } from '../../../html/render';
+import { CustomInlineNode } from '../../../commonmark/node';
+
+const reader = new Parser();
+const renderer = new Renderer();
+
+describe('customInline', () => {
+  it('basic example', () => {
+    const root = reader.parse('Hello $$myInline World$$');
+    const para = root.firstChild!;
+    const text = para.firstChild!;
+    const customInline = text.next as CustomInlineNode;
+    const inlineText = customInline.firstChild!;
+
+    expect(text.literal).toBe('Hello ');
+    expect(inlineText.literal).toBe('World');
+    expect(customInline.info).toBe('myInline');
+    expect(customInline.sourcepos).toEqual([
+      [1, 7],
+      [1, 24]
+    ]);
+    expect(inlineText.sourcepos).toEqual([
+      [1, 17],
+      [1, 22]
+    ]);
+
+    const html = renderer.render(root);
+
+    expect(html).toBe('<p>Hello <span>World</span></p>\n');
+  });
+
+  it('nested markdown text example', () => {
+    const root = reader.parse('Hello $$myInline *World*$$');
+    const para = root.firstChild!;
+    const text = para.firstChild!;
+    const customInline = text.next as CustomInlineNode;
+    const emph = customInline.firstChild!;
+
+    expect(text.literal).toBe('Hello ');
+    expect(customInline.info).toBe('myInline');
+    expect(customInline.sourcepos).toEqual([
+      [1, 7],
+      [1, 26]
+    ]);
+    expect(emph.sourcepos).toEqual([
+      [1, 18],
+      [1, 24]
+    ]);
+
+    const html = renderer.render(root);
+
+    expect(html).toBe('<p>Hello <span><em>World</em></span></p>\n');
+  });
+});

--- a/libs/toastmark/src/commonmark/custom/__test__/customInline.spec.ts
+++ b/libs/toastmark/src/commonmark/custom/__test__/customInline.spec.ts
@@ -1,6 +1,6 @@
 import { Parser } from '../../blocks';
 import { Renderer } from '../../../html/render';
-import { CustomInlineNode } from '../../../commonmark/node';
+import { CustomInlineNode } from '../../node';
 
 const reader = new Parser();
 const renderer = new Renderer();

--- a/libs/toastmark/src/commonmark/inlines.ts
+++ b/libs/toastmark/src/commonmark/inlines.ts
@@ -6,7 +6,7 @@ import {
   LinkNode,
   createNode,
   text,
-  CustomInilneNode,
+  CustomInlineNode,
   InlineNodeType
 } from './node';
 import { repeat, normalizeURI, unescapeString, ESCAPABLE, ENTITY } from './common';
@@ -504,10 +504,10 @@ export class InlineParser {
             // build custom inline node
             if (closercc === C_DOLLAR) {
               const textNode = newNode.firstChild!;
-              const literal = textNode.literal!;
+              const literal = textNode.literal || '';
               const [info] = literal.split(/\s/)!;
 
-              (newNode as CustomInilneNode).info = info;
+              (newNode as CustomInlineNode).info = info;
               if (literal.length === info.length + 1) {
                 textNode.unlink();
               } else {

--- a/libs/toastmark/src/commonmark/node.ts
+++ b/libs/toastmark/src/commonmark/node.ts
@@ -304,7 +304,7 @@ export class CustomBlockNode extends BlockNode {
   public info = '';
 }
 
-export class CustomInilneNode extends Node {
+export class CustomInlineNode extends Node {
   public info = '';
 }
 
@@ -354,7 +354,7 @@ export function createNode(type: NodeType, sourcepos?: SourcePos) {
     case 'customBlock':
       return new CustomBlockNode(type, sourcepos);
     case 'customInline':
-      return new CustomInilneNode(type, sourcepos);
+      return new CustomInlineNode(type, sourcepos);
     default:
       return new Node(type, sourcepos) as Node;
   }

--- a/libs/toastmark/src/commonmark/node.ts
+++ b/libs/toastmark/src/commonmark/node.ts
@@ -191,7 +191,7 @@ export class Node {
     return new NodeWalker(this);
   }
 
-  inlineToMark() {
+  getInlineMarkdownText() {
     const text = this.firstChild!.literal;
     switch (this.type) {
       case 'emph':
@@ -250,7 +250,7 @@ export class LinkNode extends Node {
   public title: string | null = null;
   public extendedAutolink = false;
 
-  inlineToMark() {
+  getInlineMarkdownText() {
     const text = this.firstChild!.literal;
     const { destination, title } = this as LinkNode;
     const delim = this.type === 'link' ? '' : '!';

--- a/libs/toastmark/src/html/baseConvertors.ts
+++ b/libs/toastmark/src/html/baseConvertors.ts
@@ -220,5 +220,19 @@ export const baseConvertors: HTMLConvertorMap = {
       { type: 'text', content: node.literal! },
       { type: 'closeTag', tagName: 'div', outerNewLine: true }
     ];
+  },
+
+  customInline(node, context, convertors) {
+    const info = (node as CustomBlockNode).info!;
+    const customConvertor = convertors![info];
+
+    if (customConvertor) {
+      return customConvertor!(node, context);
+    }
+
+    return {
+      type: context.entering ? 'openTag' : 'closeTag',
+      tagName: 'span'
+    };
   }
 };

--- a/libs/toastmark/src/html/render.ts
+++ b/libs/toastmark/src/html/render.ts
@@ -1,4 +1,4 @@
-import { Node, NodeType, isContainer, isCustomBlock } from '../commonmark/node';
+import { Node, NodeType, isContainer, isCustomBlock, isCustomInline } from '../commonmark/node';
 import { escapeXml } from '../commonmark/common';
 import { last } from '../helper';
 import { baseConvertors } from './baseConvertors';
@@ -152,9 +152,10 @@ export class Renderer {
         }
       };
 
-      const converted = isCustomBlock(node)
-        ? convertor(node, context, this.convertors)
-        : convertor(node, context);
+      const converted =
+        isCustomBlock(node) || isCustomInline(node)
+          ? convertor(node, context, this.convertors)
+          : convertor(node, context);
       if (converted) {
         const htmlNodes = Array.isArray(converted) ? converted : [converted];
         htmlNodes.forEach((htmlNode, index) => {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
#### added API
* `addWidget(node: Node, style: WidgetStyle, pos?: MdPos | number)`
Add the widget(DOM) to editor. The added widget cannot affect editing the document, and exists only temporarily. It's useful to show DOM like suggestion popup.

* `replaceWithWidget(from: MdPos | number, to: MdPos | number, content: string)`
Add the inline widget node to editor. The added widget should affect editing the document, and exists only permanent in document unless removing the widget node explicitly. It's useful when you want to create your own nodes that serve as special widget in the document.

#### added option
* `widgetRules`
This option allows you to configure the **rules** that replaces the string matching to a specific `RegExp` with the widget node.
It has two options(`rule`, `toDOM`).  The first is the `rule`. Users configure the `RegExp` as the `rule` to be able to replace the string with widget node. The `toDOM` option defines the DOM structure of the widget node you want. It is used to convert the matched string to DOM in the editor and markdown preview.

For example, If the `rule` is configured as `/@\S+/,` like below code, the corresponding string will be replaced with widget node using `toDOM` option. And widget node can be added through `replaceWithWidget` API.

```js
const editor = new Editor({
  widgetRules: [
    {
      rule: /@\S+/,
      toDOM(text) {
        const span = document.createElement('span');

        span.innerHTML = `<a href="https://github.com/nhn/tui.editor">${text}</a>`;
        return span;
      },
    },
  ]
});

editor.replaceWithWidget([1, 1], [1, 1], '@test');
```





---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
