### PR TITLE
fix: copying cell from table is not pasted

### DIFF
--- a/apps/editor/src/wysiwyg/wwEditor.ts
+++ b/apps/editor/src/wysiwyg/wwEditor.ts
@@ -129,11 +129,9 @@ export default class WysiwygEditor extends EditorBase {
               ev.preventDefault();
 
               emitImageBlobHook(this.eventEmitter, 'wysiwyg', imageBlob, ev.type);
-
-              return false;
             }
           }
-          return true;
+          return false;
         },
       },
     });


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description

As a side effect of the issue below, when pasting a cell copied from a table into a table, the problem of pasting as text has been fixed.

> https://github.com/nhn/tui.editor/pull/1383

#### AS-IS

![wrong](https://user-images.githubusercontent.com/18183560/108207664-654e4600-716b-11eb-85eb-cb886c7d83c5.gif)

#### TO-BE

![correct](https://user-images.githubusercontent.com/18183560/108207689-6e3f1780-716b-11eb-88de-0695e4e05fb4.gif)

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
