### PR TITLE
fix: broken converting when there is br before and after inline in table

### DIFF
--- a/apps/editor/src/__test__/unit/convertor.spec.ts
+++ b/apps/editor/src/__test__/unit/convertor.spec.ts
@@ -451,12 +451,16 @@ describe('Convertor', () => {
         | ----- | ----- |
         | tbody<br>tbody | tbody |
         | tbody | tbody<br>tbody<br>tbody |
+        | tbody | **tbody**<br>_tbody_<br>~~tbody~~<br>\`tbody\` |
+        | tbody | ![img](imgUrl)<br>[link](linkUrl) |
       `;
       const expected = source`
         | thead<br>thead | thead |
         | ---------- | ----- |
         | tbody<br>tbody | tbody |
         | tbody | tbody<br>tbody<br>tbody |
+        | tbody | **tbody**<br>*tbody*<br>~~tbody~~<br>\`tbody\` |
+        | tbody | ![img](imgUrl)<br>[link](linkUrl) |
       `;
 
       assertConverting(markdown, `${expected}\n`);

--- a/apps/editor/src/convertors/toWysiwyg/htmlToWwConvertors.ts
+++ b/apps/editor/src/convertors/toWysiwyg/htmlToWwConvertors.ts
@@ -26,6 +26,10 @@ export function getTextWithoutTrailingNewline(text: string) {
   return text[text.length - 1] === '\n' ? text.slice(0, text.length - 1) : text;
 }
 
+export function isInlineNode({ type }: MdNode) {
+  return includes(['text', 'strong', 'emph', 'strike', 'image', 'link', 'code'], type);
+}
+
 function isListNode({ type, literal }: MdNode) {
   const matched = type === 'htmlInline' && literal!.match(reHTMLTag);
 
@@ -165,11 +169,11 @@ const convertors: HTMLToWwConvertorMap = {
         state.closeNode();
       }
     } else if (node.parent?.type === 'tableCell') {
-      if (node.prev?.type === 'text') {
+      if (node.prev && isInlineNode(node.prev)) {
         state.closeNode();
       }
 
-      if (node.next?.type === 'text') {
+      if (node.next && isInlineNode(node.next)) {
         state.openNode(paragraph);
       }
     }

--- a/apps/editor/src/convertors/toWysiwyg/toWwConvertors.ts
+++ b/apps/editor/src/convertors/toWysiwyg/toWwConvertors.ts
@@ -3,7 +3,12 @@ import toArray from 'tui-code-snippet/collection/toArray';
 import { includes } from '@/utils/common';
 import { isElemNode } from '@/utils/dom';
 
-import { reHTMLTag, htmlToWwConvertors, getTextWithoutTrailingNewline } from './htmlToWwConvertors';
+import {
+  reHTMLTag,
+  htmlToWwConvertors,
+  getTextWithoutTrailingNewline,
+  isInlineNode,
+} from './htmlToWwConvertors';
 
 import { ToWwConvertorMap } from '@t/convertor';
 import {
@@ -21,10 +26,6 @@ import { createWidgetContent, getWidgetContent } from '@/widget/rules';
 
 function isBRTag(node: MdNode) {
   return node.type === 'htmlInline' && /<br ?\/?>/.test(node.literal!);
-}
-
-function isInlineNode({ type }: MdNode) {
-  return includes(['text', 'strong', 'emph', 'strike', 'image', 'link', 'code'], type);
 }
 
 function addRawHTMLAttributeToDOM(parent: Node) {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description

Fix broken converting when there is a newline between inline nodes in a table cell.

### AS-IS

![wrong](https://user-images.githubusercontent.com/18183560/108643435-f287f680-74ed-11eb-9c8a-f76ff0905922.gif)

### TO-BE

![correct](https://user-images.githubusercontent.com/18183560/108643428-eac85200-74ed-11eb-8c4f-49f717a1c97b.gif)


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
