### PR TITLE
feat: add option(`useCommandShortcut`) and API(`replaceSelection`, `setSelection`, `getSelectedContent`, `deleteSelection`, `getRangeInfoOfNode`)

### DIFF
--- a/apps/editor/src/__test__/integration/widget/widgetNode.spec.ts
+++ b/apps/editor/src/__test__/integration/widget/widgetNode.spec.ts
@@ -8,19 +8,11 @@ describe('widgetNode', () => {
     wwEditor: HTMLElement,
     editor: Editor;
 
-  function getEditorHTML() {
-    return mdEditor.querySelector('.ProseMirror')!.innerHTML.trim();
-  }
-
   function getPreviewHTML() {
     return mdPreview
       .querySelector('.tui-editor-contents')!
       .innerHTML.replace(/\sdata-nodeid="\d+"/g, '')
       .trim();
-  }
-
-  function getWwEditorHTML() {
-    return wwEditor.querySelector('.ProseMirror')!.innerHTML.trim();
   }
 
   beforeEach(() => {
@@ -93,7 +85,7 @@ describe('widgetNode', () => {
         </p>
       `;
 
-      expect(getEditorHTML()).toBe(expectedEditor);
+      expect(mdEditor).toContainHTML(expectedEditor);
       expect(getPreviewHTML()).toBe(expectedPreview);
     });
 
@@ -126,7 +118,7 @@ describe('widgetNode', () => {
         </p>
       `;
 
-      expect(getEditorHTML()).toBe(expectedEditor);
+      expect(mdEditor).toContainHTML(expectedEditor);
       expect(getPreviewHTML()).toBe(expectedPreview);
     });
 
@@ -159,7 +151,7 @@ describe('widgetNode', () => {
         </p>
       `;
 
-      expect(getEditorHTML()).toBe(expectedEditor);
+      expect(mdEditor).toContainHTML(expectedEditor);
       expect(getPreviewHTML()).toBe(expectedPreview);
     });
 
@@ -182,7 +174,7 @@ describe('widgetNode', () => {
         </p>
       `;
 
-      expect(getEditorHTML()).toBe(expectedEditor);
+      expect(mdEditor).toContainHTML(expectedEditor);
       expect(getPreviewHTML()).toBe(expectedPreview);
     });
 
@@ -221,7 +213,7 @@ describe('widgetNode', () => {
         </p>
       `;
 
-      expect(getEditorHTML()).toBe(expectedEditor);
+      expect(mdEditor).toContainHTML(expectedEditor);
       expect(getPreviewHTML()).toBe(expectedPreview);
     });
 
@@ -243,7 +235,7 @@ describe('widgetNode', () => {
         </p>
       `;
 
-      expect(getWwEditorHTML()).toBe(expectedEditor);
+      expect(wwEditor).toContainHTML(expectedEditor);
     });
 
     it('should keep "$" character in case of plain text other than widget node', () => {
@@ -277,7 +269,7 @@ describe('widgetNode', () => {
         </p>
       `;
 
-      expect(getEditorHTML()).toBe(expectedEditor);
+      expect(mdEditor).toContainHTML(expectedEditor);
       expect(getPreviewHTML()).toBe(expectedPreview);
     });
   });
@@ -296,7 +288,7 @@ describe('widgetNode', () => {
         </p>
       `;
 
-      expect(getWwEditorHTML()).toBe(expectedEditor);
+      expect(wwEditor).toContainHTML(expectedEditor);
     });
 
     it('should render widget node with markdown text', () => {
@@ -312,7 +304,7 @@ describe('widgetNode', () => {
         </p>
       `;
 
-      expect(getWwEditorHTML()).toBe(expectedEditor);
+      expect(wwEditor).toContainHTML(expectedEditor);
     });
 
     it('should convert to markdown properly', () => {
@@ -346,7 +338,7 @@ describe('widgetNode', () => {
         </p>
       `;
 
-      expect(getEditorHTML()).toBe(expectedEditor);
+      expect(mdEditor).toContainHTML(expectedEditor);
       expect(getPreviewHTML()).toBe(expectedPreview);
     });
   });

--- a/apps/editor/src/__test__/unit/editor.spec.ts
+++ b/apps/editor/src/__test__/unit/editor.spec.ts
@@ -93,7 +93,7 @@ describe('editor', () => {
       editor.setMarkdown('# heading');
 
       expect(mdEditor).toContainHTML(
-        '<div><span class="tui-md-heading tui-md-heading1"><span class="tui-md-delimiter">#</span> heading</span></div>'
+        '<div><span class="tui-editor-md-heading tui-editor-md-heading1"><span class="tui-editor-md-delimiter">#</span> heading</span></div>'
       );
       expect(getPreviewHTML()).toBe('<h1>heading</h1>');
     });
@@ -102,7 +102,7 @@ describe('editor', () => {
       editor.setHTML('<h1>heading</h1>');
 
       expect(mdEditor).toContainHTML(
-        '<div><span class="tui-md-heading tui-md-heading1"><span class="tui-md-delimiter">#</span> heading</span></div>'
+        '<div><span class="tui-editor-md-heading tui-editor-md-heading1"><span class="tui-editor-md-delimiter">#</span> heading</span></div>'
       );
       expect(getPreviewHTML()).toBe('<h1>heading</h1>');
     });
@@ -112,7 +112,7 @@ describe('editor', () => {
       editor.reset();
 
       expect(mdEditor).not.toContainHTML(
-        '<div><span class="tui-md-heading tui-md-heading1"><span class="tui-md-delimiter">#</span> heading</span></div>'
+        '<div><span class="tui-editor-md-heading tui-editor-md-heading1"><span class="tui-editor-md-delimiter">#</span> heading</span></div>'
       );
       expect(getPreviewHTML()).toBe('');
     });

--- a/apps/editor/src/__test__/unit/editor.spec.ts
+++ b/apps/editor/src/__test__/unit/editor.spec.ts
@@ -293,7 +293,7 @@ describe('editor', () => {
       });
     });
 
-    describe.only('replaceSelection()', () => {
+    describe('replaceSelection()', () => {
       beforeEach(() => {
         editor.setMarkdown('line1\nline2');
         editor.setSelection([1, 2], [2, 4]);
@@ -326,6 +326,42 @@ describe('editor', () => {
         editor.replaceSelection('Replaced', 1, 7);
 
         expect(wwEditor).toContainHTML('<p>Replaced</p><p>line2</p>');
+      });
+    });
+
+    describe('deleteSelection()', () => {
+      beforeEach(() => {
+        editor.setMarkdown('line1\nline2');
+        editor.setSelection([1, 2], [2, 4]);
+      });
+
+      it('should delete current selection in markdown', () => {
+        editor.deleteSelection();
+
+        expect(mdEditor).toContainHTML('<div>le2</div>');
+        expect(getPreviewHTML()).toBe('<p>le2</p>');
+      });
+
+      it('should delete current selection in wysiwyg', () => {
+        editor.changeMode('wysiwyg');
+        editor.setSelection(2, 11);
+        editor.deleteSelection();
+
+        expect(wwEditor).toContainHTML('<p>le2</p>');
+      });
+
+      it('should delete given selection in markdown', () => {
+        editor.deleteSelection([1, 1], [2, 1]);
+
+        expect(mdEditor).toContainHTML('<div>line2</div>');
+        expect(getPreviewHTML()).toBe('<p>line2</p>');
+      });
+
+      it('should delete given selection in wysiwyg', () => {
+        editor.changeMode('wysiwyg');
+        editor.deleteSelection(1, 7);
+
+        expect(wwEditor).toContainHTML('<p>line2</p>');
       });
     });
   });

--- a/apps/editor/src/__test__/unit/editor.spec.ts
+++ b/apps/editor/src/__test__/unit/editor.spec.ts
@@ -273,23 +273,23 @@ describe('editor', () => {
       });
     });
 
-    describe('getSelectedContent()', () => {
+    describe('getSelectedText()', () => {
       beforeEach(() => {
         editor.setMarkdown('line1\nline2');
         editor.setSelection([1, 2], [2, 4]);
       });
 
       it('in markdown', () => {
-        expect(editor.getSelectedContent()).toEqual('ine1\nlin');
-        expect(editor.getSelectedContent([1, 2], [2, 6])).toEqual('ine1\nline2');
+        expect(editor.getSelectedText()).toEqual('ine1\nlin');
+        expect(editor.getSelectedText([1, 2], [2, 6])).toEqual('ine1\nline2');
       });
 
       it('in wysiwyg', () => {
         editor.changeMode('wysiwyg');
         editor.setSelection(2, 11);
 
-        expect(editor.getSelectedContent()).toEqual('ine1\nlin');
-        expect(editor.getSelectedContent(2, 13)).toEqual('ine1\nline2');
+        expect(editor.getSelectedText()).toEqual('ine1\nlin');
+        expect(editor.getSelectedText(2, 13)).toEqual('ine1\nline2');
       });
     });
 

--- a/apps/editor/src/__test__/unit/editor.spec.ts
+++ b/apps/editor/src/__test__/unit/editor.spec.ts
@@ -89,19 +89,6 @@ describe('editor', () => {
       expect(editor.getCurrentPreviewStyle()).toBe('vertical');
     });
 
-    it('getRange()', () => {
-      // markdown range
-      expect(editor.getRange()).toEqual([
-        [1, 1],
-        [1, 1],
-      ]);
-
-      editor.changeMode('wysiwyg');
-
-      // wysiwyg range
-      expect(editor.getRange()).toEqual([1, 1]);
-    });
-
     it('setMarkdown()', () => {
       editor.setMarkdown('# heading');
 
@@ -169,13 +156,6 @@ describe('editor', () => {
         expect(wwEditor).toHaveStyle({ minHeight: '300px' });
       });
     });
-
-    // it('insertText()', () => {
-    //   editor.insertText('test');
-
-    //   expect(mdEditor).not.toContainHTML('<div>test</div>');
-    //   expect(getPreviewHTML()).toBe('test');
-    // });
 
     it('addWidget()', () => {
       const node = document.createElement('div');
@@ -247,6 +227,106 @@ describe('editor', () => {
 
       // @ts-ignore
       expect(editor.commandManager.addCommand).toHaveBeenCalledWith('markdown', 'custom', handler);
+    });
+
+    describe('insertText()', () => {
+      it('in markdown', () => {
+        editor.insertText('test');
+
+        expect(mdEditor).toContainHTML('<div>test</div>');
+        expect(getPreviewHTML()).toBe('<p>test</p>');
+      });
+
+      it('in wysiwyg', () => {
+        editor.changeMode('wysiwyg');
+        editor.insertText('test');
+
+        expect(wwEditor).toContainHTML('<p>test</p>');
+      });
+    });
+
+    describe('setSelection(), getSelection()', () => {
+      it('in markdown', () => {
+        expect(editor.getSelection()).toEqual([
+          [1, 1],
+          [1, 1],
+        ]);
+
+        editor.setMarkdown('line1\nline2');
+        editor.setSelection([1, 2], [2, 4]);
+
+        expect(editor.getSelection()).toEqual([
+          [1, 2],
+          [2, 4],
+        ]);
+      });
+
+      it('in wysiwyg', () => {
+        editor.changeMode('wysiwyg');
+
+        expect(editor.getSelection()).toEqual([1, 1]);
+
+        editor.setMarkdown('line1\nline2');
+        editor.setSelection(2, 8);
+
+        expect(editor.getSelection()).toEqual([2, 8]);
+      });
+    });
+
+    describe('getSelectedContent()', () => {
+      beforeEach(() => {
+        editor.setMarkdown('line1\nline2');
+        editor.setSelection([1, 2], [2, 4]);
+      });
+
+      it('in markdown', () => {
+        expect(editor.getSelectedContent()).toEqual('ine1\nlin');
+        expect(editor.getSelectedContent([1, 2], [2, 6])).toEqual('ine1\nline2');
+      });
+
+      it('in wysiwyg', () => {
+        editor.changeMode('wysiwyg');
+        editor.setSelection(2, 11);
+
+        expect(editor.getSelectedContent()).toEqual('ine1\nlin');
+        expect(editor.getSelectedContent(2, 13)).toEqual('ine1\nline2');
+      });
+    });
+
+    describe.only('replaceSelection()', () => {
+      beforeEach(() => {
+        editor.setMarkdown('line1\nline2');
+        editor.setSelection([1, 2], [2, 4]);
+      });
+
+      it('should replace current selection in markdown', () => {
+        editor.replaceSelection('Replaced');
+
+        expect(mdEditor).toContainHTML('<div>lReplacede2</div>');
+        expect(getPreviewHTML()).toBe('<p>lReplacede2</p>');
+      });
+
+      it('should replace current selection in wysiwyg', () => {
+        editor.changeMode('wysiwyg');
+        editor.setSelection(2, 11);
+        editor.replaceSelection('Replaced');
+
+        expect(wwEditor).toContainHTML('<p>lReplacede2</p>');
+      });
+
+      it('should replace given selection in markdown', () => {
+        editor.replaceSelection('Replaced', [1, 1], [2, 1]);
+
+        expect(mdEditor).toContainHTML('<div>Replacedline2</div>');
+        expect(getPreviewHTML()).toBe('<p>Replacedline2</p>');
+      });
+
+      it('should replace given selection in wysiwyg', () => {
+        editor.changeMode('wysiwyg');
+        editor.replaceSelection('Replaced', 1, 7);
+
+        expect(wwEditor).toContainHTML('<p>Replaced</p><p>line2</p>');
+      });
     });
   });
 

--- a/apps/editor/src/__test__/unit/editor.spec.ts
+++ b/apps/editor/src/__test__/unit/editor.spec.ts
@@ -1,0 +1,272 @@
+import { oneLineTrim } from 'common-tags';
+import Editor from '@/editorCore';
+import Viewer from '@/Viewer';
+import i18n from '@/i18n/i18n';
+
+describe('editor', () => {
+  let container: HTMLElement,
+    mdEditor: HTMLElement,
+    mdPreview: HTMLElement,
+    wwEditor: HTMLElement,
+    editor: Editor;
+
+  function getPreviewHTML() {
+    return mdPreview
+      .querySelector('.tui-editor-contents')!
+      .innerHTML.replace(/\sdata-nodeid="\d+"/g, '')
+      .trim();
+  }
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    editor = new Editor({
+      el: container,
+      previewHighlight: false,
+      widgetRules: [
+        {
+          rule: /@\S+/,
+          toDOM(text) {
+            const span = document.createElement('span');
+
+            span.innerHTML = `<a href="www.google.com">${text}</a>`;
+            return span;
+          },
+        },
+      ],
+    });
+
+    const elements = editor.getEditorElements();
+
+    mdEditor = elements.mdEditor;
+    mdPreview = elements.mdPreview!;
+    wwEditor = elements.wwEditor!;
+
+    container.append(mdEditor);
+    container.append(mdPreview!);
+    container.append(wwEditor!);
+
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    editor.destroy();
+    document.body.removeChild(container);
+  });
+
+  describe('instance API', () => {
+    it('setPlaceholder()', () => {
+      editor.setPlaceholder('Please input text');
+
+      const expected = '<span class="placeholder ProseMirror-widget">Please input text</span>';
+
+      expect(mdEditor).toContainHTML(expected);
+      expect(wwEditor).toContainHTML(expected);
+    });
+
+    it('changeMode()', () => {
+      const spy = jest.fn();
+
+      expect(editor.isMarkdownMode()).toBe(true);
+      expect(editor.isWysiwygMode()).toBe(false);
+
+      editor.on('changeMode', spy);
+      editor.changeMode('wysiwyg');
+
+      expect(spy).toHaveBeenCalledWith('wysiwyg');
+      expect(editor.isMarkdownMode()).toBe(false);
+      expect(editor.isWysiwygMode()).toBe(true);
+    });
+
+    it('changePreviewStyle()', () => {
+      const spy = jest.fn();
+
+      expect(editor.getCurrentPreviewStyle()).toBe('tab');
+
+      editor.on('changePreviewStyle', spy);
+      editor.changePreviewStyle('vertical');
+
+      expect(spy).toHaveBeenCalledWith('vertical');
+      expect(editor.getCurrentPreviewStyle()).toBe('vertical');
+    });
+
+    it('getRange()', () => {
+      // markdown range
+      expect(editor.getRange()).toEqual([
+        [1, 1],
+        [1, 1],
+      ]);
+
+      editor.changeMode('wysiwyg');
+
+      // wysiwyg range
+      expect(editor.getRange()).toEqual([1, 1]);
+    });
+
+    it('setMarkdown()', () => {
+      editor.setMarkdown('# heading');
+
+      expect(mdEditor).toContainHTML(
+        '<div><span class="tui-md-heading tui-md-heading1"><span class="tui-md-delimiter">#</span> heading</span></div>'
+      );
+      expect(getPreviewHTML()).toBe('<h1>heading</h1>');
+    });
+
+    it('setHTML()', () => {
+      editor.setHTML('<h1>heading</h1>');
+
+      expect(mdEditor).toContainHTML(
+        '<div><span class="tui-md-heading tui-md-heading1"><span class="tui-md-delimiter">#</span> heading</span></div>'
+      );
+      expect(getPreviewHTML()).toBe('<h1>heading</h1>');
+    });
+
+    it('reset()', () => {
+      editor.setMarkdown('# heading');
+      editor.reset();
+
+      expect(mdEditor).not.toContainHTML(
+        '<div><span class="tui-md-heading tui-md-heading1"><span class="tui-md-delimiter">#</span> heading</span></div>'
+      );
+      expect(getPreviewHTML()).toBe('');
+    });
+
+    it('getCurrentModeEditor()', () => {
+      // @ts-ignore
+      expect(editor.getCurrentModeEditor()).toEqual(editor.mdEditor);
+
+      editor.changeMode('wysiwyg');
+
+      // @ts-ignore
+      expect(editor.getCurrentModeEditor()).toEqual(editor.wwEditor);
+    });
+
+    it('setMinHeight()', () => {
+      editor.setMinHeight('200px');
+
+      expect(mdEditor).toHaveStyle({ minHeight: '200px' });
+      expect(mdPreview).toHaveStyle({ minHeight: '200px' });
+      expect(wwEditor).toHaveStyle({ minHeight: '200px' });
+    });
+
+    describe('setHeight()', () => {
+      it('should set height with pixel option', () => {
+        editor.setHeight('300px');
+
+        expect(container).not.toHaveClass('auto-height');
+        expect(container).toHaveStyle({ height: '300px' });
+        expect(mdEditor).toHaveStyle({ minHeight: '300px' });
+        expect(mdPreview).toHaveStyle({ minHeight: '300px' });
+        expect(wwEditor).toHaveStyle({ minHeight: '300px' });
+      });
+
+      it('should set height with auto option', () => {
+        editor.setHeight('auto');
+
+        expect(container).toHaveClass('auto-height');
+        expect(container).toHaveStyle({ height: 'auto' });
+        expect(mdEditor).toHaveStyle({ minHeight: '300px' });
+        expect(mdPreview).toHaveStyle({ minHeight: '300px' });
+        expect(wwEditor).toHaveStyle({ minHeight: '300px' });
+      });
+    });
+
+    // it('insertText()', () => {
+    //   editor.insertText('test');
+
+    //   expect(mdEditor).not.toContainHTML('<div>test</div>');
+    //   expect(getPreviewHTML()).toBe('test');
+    // });
+
+    it('addWidget()', () => {
+      const node = document.createElement('div');
+
+      node.innerHTML = 'widget';
+
+      editor.addWidget(node, 'top');
+
+      expect(document.body).toContainElement(node);
+
+      editor.changeMode('wysiwyg');
+
+      expect(document.body).not.toContainElement(node);
+    });
+
+    describe('replaceWithWidget()', () => {
+      it('in markdown', () => {
+        editor.replaceWithWidget([1, 1], [1, 1], '@test');
+
+        const expectedEditor = oneLineTrim`
+          <span class="tui-widget">
+            <span><a href="www.google.com">@test</a></span>
+          </span>
+        `;
+        const expectedPreview = oneLineTrim`
+          <p>
+            <span class="tui-widget">
+              <span><a href="www.google.com">@test</a></span>
+            </span>
+          </p>
+        `;
+
+        expect(mdEditor).toContainHTML(expectedEditor);
+        expect(getPreviewHTML()).toBe(expectedPreview);
+      });
+
+      it('in wysiwyg', () => {
+        editor.changeMode('wysiwyg');
+        editor.replaceWithWidget(1, 1, '@test');
+
+        const expected = oneLineTrim`
+          <span class="tui-widget">
+            <span><a href="www.google.com">@test</a></span>
+          </span>
+        `;
+
+        expect(wwEditor).toContainHTML(expected);
+      });
+    });
+
+    it('exec()', () => {
+      // @ts-ignore
+      jest.spyOn(editor.commandManager, 'exec');
+
+      editor.exec('markdown', 'bold');
+
+      // @ts-ignore
+      // eslint-disable-next-line no-undefined
+      expect(editor.commandManager.exec).toHaveBeenCalledWith('markdown', 'bold', undefined);
+    });
+
+    it('addCommand()', () => {
+      const handler = jest.fn();
+
+      // @ts-ignore
+      jest.spyOn(editor.commandManager, 'addCommand');
+
+      editor.addCommand('markdown', 'custom', handler);
+
+      // @ts-ignore
+      expect(editor.commandManager.addCommand).toHaveBeenCalledWith('markdown', 'custom', handler);
+    });
+  });
+
+  describe('static API', () => {
+    it('factory()', () => {
+      const editorInst = Editor.factory({ el: document.createElement('div'), viewer: false });
+      const viewerInst = Editor.factory({ el: document.createElement('div'), viewer: true });
+
+      expect(editorInst).toBeInstanceOf(Editor);
+      expect(viewerInst).toBeInstanceOf(Viewer);
+    });
+
+    it('setLanguage()', () => {
+      const data = {};
+
+      jest.spyOn(i18n, 'setLanguage');
+
+      Editor.setLanguage('ko', data);
+
+      expect(i18n.setLanguage).toHaveBeenCalledWith('ko', data);
+    });
+  });
+});

--- a/apps/editor/src/__test__/unit/markdown/keymap.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/keymap.spec.ts
@@ -20,7 +20,7 @@ let mde: MarkdownEditor, em: EventEmitter;
 
 beforeEach(() => {
   em = new EventEmitter();
-  mde = new MarkdownEditor(new ToastMark(), em);
+  mde = new MarkdownEditor(new ToastMark(), em, true);
 });
 
 // @TODO: should add test case after developing the markdown editor API

--- a/apps/editor/src/__test__/unit/markdown/mdCommand.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/mdCommand.spec.ts
@@ -10,7 +10,7 @@ let mde: MarkdownEditor, em: EventEmitter, cmd: CommandManager;
 
 beforeEach(() => {
   em = new EventEmitter();
-  mde = new MarkdownEditor(new ToastMark(), em);
+  mde = new MarkdownEditor(new ToastMark(), em, true);
   cmd = new CommandManager(em, mde.commands, {});
 });
 

--- a/apps/editor/src/__test__/unit/markdown/mdEditor.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/mdEditor.spec.ts
@@ -58,11 +58,11 @@ describe('MarkdownEditor', () => {
     expect(getSelectedText()).toBe('#');
   });
 
-  it('getRange API', () => {
+  it('getSelection API', () => {
     mde.setMarkdown('# myText');
     mde.setSelection([1, 1], [1, 2]);
 
-    const selection = mde.getRange();
+    const selection = mde.getSelection();
 
     expect(selection).toEqual([
       [1, 1],

--- a/apps/editor/src/__test__/unit/markdown/mdEditor.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/mdEditor.spec.ts
@@ -17,7 +17,7 @@ describe('MarkdownEditor', () => {
 
   beforeEach(() => {
     em = new EventEmitter();
-    mde = new MarkdownEditor(new ToastMark(), em);
+    mde = new MarkdownEditor(new ToastMark(), em, true);
     el = mde.el;
     document.body.appendChild(el);
   });

--- a/apps/editor/src/__test__/unit/markdown/mdPreview.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/mdPreview.spec.ts
@@ -66,7 +66,7 @@ describe('preview highlight', () => {
     };
 
     eventEmitter = new EventEmitter();
-    editor = new MarkdownEditor(new ToastMark(), eventEmitter);
+    editor = new MarkdownEditor(new ToastMark(), eventEmitter, true);
     preview = new MarkdownPreview(eventEmitter, options);
     editorEl = editor.getElement();
 

--- a/apps/editor/src/__test__/unit/markdown/smartTask.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/smartTask.spec.ts
@@ -18,7 +18,7 @@ function dispatchKeyup() {
 
 beforeEach(() => {
   em = new EventEmitter();
-  mde = new MarkdownEditor(new ToastMark(), em);
+  mde = new MarkdownEditor(new ToastMark(), em, true);
 });
 
 afterEach(() => {

--- a/apps/editor/src/__test__/unit/markdown/syntaxHighlight.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/syntaxHighlight.spec.ts
@@ -12,7 +12,7 @@ let mde: MarkdownEditor, em: EventEmitter;
 
 beforeEach(() => {
   em = new EventEmitter();
-  mde = new MarkdownEditor(new ToastMark(), em);
+  mde = new MarkdownEditor(new ToastMark(), em, true);
 });
 
 afterEach(() => {

--- a/apps/editor/src/__test__/unit/wysiwyg/customBlock.spec.ts
+++ b/apps/editor/src/__test__/unit/wysiwyg/customBlock.spec.ts
@@ -34,7 +34,7 @@ beforeEach(() => {
 
   toDOMAdaptor = new WwToDOMAdaptor({}, convertors);
   em = new EventEmitter();
-  wwe = new WysiwygEditor(em, toDOMAdaptor);
+  wwe = new WysiwygEditor(em, toDOMAdaptor, true);
 
   wwe.setModel(createCustomBlockNode());
 });

--- a/apps/editor/src/__test__/unit/wysiwyg/keymap.spec.ts
+++ b/apps/editor/src/__test__/unit/wysiwyg/keymap.spec.ts
@@ -352,7 +352,7 @@ describe('keymap', () => {
 
         forceKeymapFn('table', 'moveInCell', ['up']);
 
-        expect(wwe.getRange()).toEqual([55, 55]); // in 'quux'
+        expect(wwe.getSelection()).toEqual([55, 55]); // in 'quux'
       });
 
       it('should move from first list item to end list item of up cell', () => {
@@ -360,7 +360,7 @@ describe('keymap', () => {
 
         forceKeymapFn('table', 'moveInCell', ['up']);
 
-        expect(wwe.getRange()).toEqual([33, 33]); // in 'qux'
+        expect(wwe.getSelection()).toEqual([33, 33]); // in 'qux'
       });
     });
 
@@ -370,7 +370,7 @@ describe('keymap', () => {
 
         forceKeymapFn('table', 'moveInCell', ['down']);
 
-        expect(wwe.getRange()).toEqual([23, 23]); // in 'baz'
+        expect(wwe.getSelection()).toEqual([23, 23]); // in 'baz'
       });
 
       it('should move from last list item to start list item of down cell', () => {
@@ -378,7 +378,7 @@ describe('keymap', () => {
 
         forceKeymapFn('table', 'moveInCell', ['down']);
 
-        expect(wwe.getRange()).toEqual([43, 43]); // in 'quux'
+        expect(wwe.getSelection()).toEqual([43, 43]); // in 'quux'
       });
     });
   });

--- a/apps/editor/src/__test__/unit/wysiwyg/keymap.spec.ts
+++ b/apps/editor/src/__test__/unit/wysiwyg/keymap.spec.ts
@@ -80,7 +80,7 @@ describe('keymap', () => {
 
         forceKeymapFn('table', 'moveToCell', ['right']);
 
-        expect(wwe.getRange()).toEqual([15, 15]);
+        expect(wwe.getSelection()).toEqual([15, 15]);
       });
 
       it('should move to first cell of next line', () => {
@@ -88,7 +88,7 @@ describe('keymap', () => {
 
         forceKeymapFn('table', 'moveToCell', ['right']);
 
-        expect(wwe.getRange()).toEqual([26, 26]);
+        expect(wwe.getSelection()).toEqual([26, 26]);
       });
     });
 
@@ -98,7 +98,7 @@ describe('keymap', () => {
 
         forceKeymapFn('table', 'moveToCell', ['left']);
 
-        expect(wwe.getRange()).toEqual([8, 8]);
+        expect(wwe.getSelection()).toEqual([8, 8]);
       });
 
       it('should move to last cell of previous line', () => {
@@ -106,7 +106,7 @@ describe('keymap', () => {
 
         forceKeymapFn('table', 'moveToCell', ['left']);
 
-        expect(wwe.getRange()).toEqual([15, 15]);
+        expect(wwe.getSelection()).toEqual([15, 15]);
       });
     });
 
@@ -116,7 +116,7 @@ describe('keymap', () => {
 
         forceKeymapFn('table', 'moveInCell', ['up']);
 
-        expect(wwe.getRange()).toEqual([8, 8]);
+        expect(wwe.getSelection()).toEqual([8, 8]);
       });
 
       it('should add paragraph when there is no content before table and cursor is in first row', () => {
@@ -169,7 +169,7 @@ describe('keymap', () => {
         wwe.setSelection(15, 15); // in 'foo' cell
         forceKeymapFn('table', 'moveInCell', ['up']);
 
-        expect(wwe.getRange()).toEqual([7, 7]); // 'before' paragraph
+        expect(wwe.getSelection()).toEqual([7, 7]); // 'before' paragraph
       });
     });
 
@@ -179,7 +179,7 @@ describe('keymap', () => {
 
         forceKeymapFn('table', 'moveInCell', ['down']);
 
-        expect(wwe.getRange()).toEqual([23, 23]);
+        expect(wwe.getSelection()).toEqual([23, 23]);
       });
 
       it('should add paragraph when there is no content after table and cursor is in last row', () => {
@@ -232,7 +232,7 @@ describe('keymap', () => {
         wwe.setSelection(32, 32); // in 'qux' cell
         forceKeymapFn('table', 'moveInCell', ['down']);
 
-        expect(wwe.getRange()).toEqual([39, 39]); // 'after' paragraph
+        expect(wwe.getSelection()).toEqual([39, 39]); // 'after' paragraph
       });
     });
 

--- a/apps/editor/src/__test__/unit/wysiwyg/keymap.spec.ts
+++ b/apps/editor/src/__test__/unit/wysiwyg/keymap.spec.ts
@@ -45,7 +45,7 @@ describe('keymap', () => {
     const adaptor = new WwToDOMAdaptor({}, {});
 
     em = new EventEmitter();
-    wwe = new WysiwygEditor(em, adaptor);
+    wwe = new WysiwygEditor(em, adaptor, true);
   });
 
   afterEach(() => {

--- a/apps/editor/src/__test__/unit/wysiwyg/wwCommand.spec.ts
+++ b/apps/editor/src/__test__/unit/wysiwyg/wwCommand.spec.ts
@@ -35,7 +35,7 @@ describe('wysiwyg commands', () => {
     const adaptor = new WwToDOMAdaptor({}, {});
 
     em = new EventEmitter();
-    wwe = new WysiwygEditor(em, adaptor);
+    wwe = new WysiwygEditor(em, adaptor, true);
     cmd = new CommandManager(em, {}, wwe.commands);
   });
 
@@ -526,7 +526,7 @@ describe('wysiwyg commands', () => {
       const adaptor = new WwToDOMAdaptor({}, {});
 
       em = new EventEmitter();
-      wwe = new WysiwygEditor(em, adaptor, linkAttributes);
+      wwe = new WysiwygEditor(em, adaptor, true, linkAttributes);
       cmd = new CommandManager(em, {}, wwe.commands);
     });
 

--- a/apps/editor/src/__test__/unit/wysiwyg/wwEditor.spec.ts
+++ b/apps/editor/src/__test__/unit/wysiwyg/wwEditor.spec.ts
@@ -23,7 +23,7 @@ describe('WysiwygEditor', () => {
     const adaptor = new WwToDOMAdaptor({}, {});
 
     em = new EventEmitter();
-    wwe = new WysiwygEditor(em, adaptor);
+    wwe = new WysiwygEditor(em, adaptor, true);
     el = wwe.el;
     document.body.appendChild(el);
   });

--- a/apps/editor/src/__test__/unit/wysiwyg/wwEditor.spec.ts
+++ b/apps/editor/src/__test__/unit/wysiwyg/wwEditor.spec.ts
@@ -96,7 +96,7 @@ describe('WysiwygEditor', () => {
       expect(wwe.getScrollTop()).toBe(30);
     });
 
-    it('getRange() return selection range as array', () => {
+    it('getSelection() return selection range as array', () => {
       setContent(oneLineTrim`
         <p>foo</p>
         <p>bar</p>
@@ -105,7 +105,7 @@ describe('WysiwygEditor', () => {
 
       wwe.setSelection(13, 2);
 
-      expect(wwe.getRange()).toEqual([2, 13]);
+      expect(wwe.getSelection()).toEqual([2, 13]);
     });
 
     it('replaceSelection() change text of selection range', () => {

--- a/apps/editor/src/__test__/unit/wysiwyg/wwTableCommand.spec.ts
+++ b/apps/editor/src/__test__/unit/wysiwyg/wwTableCommand.spec.ts
@@ -46,7 +46,7 @@ describe('wysiwyg table commands', () => {
     const adaptor = new WwToDOMAdaptor({}, {});
 
     em = new EventEmitter();
-    wwe = new WysiwygEditor(em, adaptor);
+    wwe = new WysiwygEditor(em, adaptor, true);
     cmd = new CommandManager(em, {}, wwe.commands);
   });
 

--- a/apps/editor/src/__test__/unit/wysiwyg/wwToDOMAdaptor.spec.ts
+++ b/apps/editor/src/__test__/unit/wysiwyg/wwToDOMAdaptor.spec.ts
@@ -72,7 +72,7 @@ beforeEach(() => {
 
   toDOMAdaptor = new WwToDOMAdaptor({}, convertors);
   em = new EventEmitter();
-  wwe = new WysiwygEditor(em, toDOMAdaptor);
+  wwe = new WysiwygEditor(em, toDOMAdaptor, true);
 });
 
 afterEach(() => {

--- a/apps/editor/src/base.ts
+++ b/apps/editor/src/base.ts
@@ -134,8 +134,8 @@ export default abstract class EditorBase {
     });
   }
 
-  createKeymaps() {
-    return this.specs.keymaps();
+  createKeymaps(useCommandShortcut: boolean) {
+    return useCommandShortcut ? this.specs.keymaps() : [];
   }
 
   createCommands() {

--- a/apps/editor/src/base.ts
+++ b/apps/editor/src/base.ts
@@ -6,7 +6,7 @@ import { baseKeymap } from 'prosemirror-commands';
 import { InputRule, inputRules } from 'prosemirror-inputrules';
 import { history } from 'prosemirror-history';
 import css from 'tui-code-snippet/domUtil/css';
-import { WidgetStyle, EditorType, EditorPos, Base } from '@t/editor';
+import { WidgetStyle, EditorType, EditorPos, Base, NodeRangeInfo } from '@t/editor';
 import { Emitter } from '@t/event';
 import { MdSourcepos } from '@t/markdown';
 import { Context, EditorAllCommandMap } from '@t/spec';
@@ -214,5 +214,5 @@ export default abstract class EditorBase implements Base {
 
   abstract getSelection(): MdSourcepos | [number, number];
 
-  abstract getRangeOfNode(pos?: EditorPos): MdSourcepos | [number, number];
+  abstract getRangeInfoOfNode(pos?: EditorPos): NodeRangeInfo;
 }

--- a/apps/editor/src/base.ts
+++ b/apps/editor/src/base.ts
@@ -6,9 +6,9 @@ import { baseKeymap } from 'prosemirror-commands';
 import { InputRule, inputRules } from 'prosemirror-inputrules';
 import { history } from 'prosemirror-history';
 import css from 'tui-code-snippet/domUtil/css';
-import { WidgetStyle, EditorType } from '@t/editor';
+import { WidgetStyle, EditorType, EditorPos, Base } from '@t/editor';
 import { Emitter } from '@t/event';
-import { MdPos, MdSourcepos } from '@t/markdown';
+import { MdSourcepos } from '@t/markdown';
 import { Context, EditorAllCommandMap } from '@t/spec';
 import SpecManager from './spec/specManager';
 import { createTextSelection } from './helper/manipulation';
@@ -20,7 +20,7 @@ import { dropImage } from './plugins/dropImage';
 import { isWidgetNode } from './widget/widgetNode';
 import { last } from './utils/common';
 
-export default abstract class EditorBase {
+export default abstract class EditorBase implements Base {
   el: HTMLElement;
 
   editorType!: EditorType;
@@ -200,11 +200,17 @@ export default abstract class EditorBase {
 
   abstract createPlugins(): Plugin[];
 
-  abstract replaceWithWidget(from: MdPos | number, to: MdPos | number, content: string): void;
+  abstract replaceWithWidget(start: EditorPos, end: EditorPos, content: string): void;
 
-  abstract addWidget(node: Node, style: WidgetStyle, pos?: MdPos | number): void;
+  abstract addWidget(node: Node, style: WidgetStyle, pos?: EditorPos): void;
 
-  abstract replaceSelection(content: string, range: Range): void;
+  abstract setSelection(start?: EditorPos, end?: EditorPos): void;
 
-  abstract getRange(): MdSourcepos | [number, number];
+  abstract replaceSelection(content: string, start?: EditorPos, end?: EditorPos): void;
+
+  abstract deleteSelection(start?: EditorPos, end?: EditorPos): void;
+
+  abstract getSelectedContent(start?: EditorPos, end?: EditorPos): string;
+
+  abstract getSelection(): MdSourcepos | [number, number];
 }

--- a/apps/editor/src/base.ts
+++ b/apps/editor/src/base.ts
@@ -200,17 +200,19 @@ export default abstract class EditorBase implements Base {
 
   abstract createPlugins(): Plugin[];
 
-  abstract replaceWithWidget(start: EditorPos, end: EditorPos, content: string): void;
+  abstract replaceWithWidget(start: EditorPos, end: EditorPos, text: string): void;
 
   abstract addWidget(node: Node, style: WidgetStyle, pos?: EditorPos): void;
 
   abstract setSelection(start?: EditorPos, end?: EditorPos): void;
 
-  abstract replaceSelection(content: string, start?: EditorPos, end?: EditorPos): void;
+  abstract replaceSelection(text: string, start?: EditorPos, end?: EditorPos): void;
 
   abstract deleteSelection(start?: EditorPos, end?: EditorPos): void;
 
-  abstract getSelectedContent(start?: EditorPos, end?: EditorPos): string;
+  abstract getSelectedText(start?: EditorPos, end?: EditorPos): string;
 
   abstract getSelection(): MdSourcepos | [number, number];
+
+  abstract getRangeOfNode(pos?: EditorPos): MdSourcepos | [number, number];
 }

--- a/apps/editor/src/editorCore.ts
+++ b/apps/editor/src/editorCore.ts
@@ -471,7 +471,7 @@ class ToastUIEditor {
    * @param {number|Array.<number>} [start] - start position
    * @param {number|Array.<number>} [end] - end position
    */
-  deleteSelection(start: EditorPos, end: EditorPos) {
+  deleteSelection(start?: EditorPos, end?: EditorPos) {
     this.getCurrentModeEditor().deleteSelection(start, end);
   }
 

--- a/apps/editor/src/editorCore.ts
+++ b/apps/editor/src/editorCore.ts
@@ -145,22 +145,26 @@ class ToastUIEditor {
       options
     );
 
-    this.codeBlockLanguages = [];
-    this.mode = this.options.initialEditType || 'markdown';
-
-    this.eventEmitter = new EventEmitter();
-
-    setWidgetRules(this.options.widgetRules);
-
-    const linkAttributes = sanitizeLinkAttribute(this.options.linkAttributes);
-    const { renderer, parser, plugins } = getPluginInfo(this.options.plugins);
     const {
       customHTMLRenderer,
       extendedAutolinks,
       referenceDefinition,
       frontMatter,
       customMarkdownRenderer,
+      useCommandShortcut,
+      initialEditType,
+      widgetRules,
     } = this.options;
+
+    this.codeBlockLanguages = [];
+    this.mode = initialEditType || 'markdown';
+
+    this.eventEmitter = new EventEmitter();
+
+    setWidgetRules(widgetRules);
+
+    const linkAttributes = sanitizeLinkAttribute(this.options.linkAttributes);
+    const { renderer, parser, plugins } = getPluginInfo(this.options.plugins);
     const rendererOptions = {
       linkAttributes,
       customHTMLRenderer: { ...renderer, ...customHTMLRenderer },
@@ -191,7 +195,7 @@ class ToastUIEditor {
       frontMatter,
     });
 
-    this.mdEditor = new MarkdownEditor(this.toastMark, this.eventEmitter);
+    this.mdEditor = new MarkdownEditor(this.toastMark, this.eventEmitter, useCommandShortcut);
 
     this.preview = new MarkdownPreview(this.eventEmitter, {
       ...rendererOptions,
@@ -199,7 +203,12 @@ class ToastUIEditor {
       highlight: this.options.previewHighlight,
     });
 
-    this.wwEditor = new WysiwygEditor(this.eventEmitter, wwToDOMAdaptor, linkAttributes!);
+    this.wwEditor = new WysiwygEditor(
+      this.eventEmitter,
+      wwToDOMAdaptor,
+      useCommandShortcut,
+      linkAttributes!
+    );
 
     this.convertor = new Convertor(
       this.wwEditor.getSchema(),

--- a/apps/editor/src/editorCore.ts
+++ b/apps/editor/src/editorCore.ts
@@ -441,10 +441,10 @@ class ToastUIEditor {
 
   /**
    * Insert text
-   * @param {string} content - text content
+   * @param {string} text - text content
    */
-  insertText(content: string) {
-    this.getCurrentModeEditor().replaceSelection(content);
+  insertText(text: string) {
+    this.getCurrentModeEditor().replaceSelection(text);
   }
 
   /**
@@ -458,12 +458,12 @@ class ToastUIEditor {
 
   /**
    * Replace selection range with given text content
-   * @param {string} content - widget text content
+   * @param {string} text - text content
    * @param {number|Array.<number>} [start] - start position
    * @param {number|Array.<number>} [end] - end position
    */
-  replaceSelection(content: string, start?: EditorPos, end?: EditorPos) {
-    this.getCurrentModeEditor().replaceSelection(content, start, end);
+  replaceSelection(text: string, start?: EditorPos, end?: EditorPos) {
+    this.getCurrentModeEditor().replaceSelection(text, start, end);
   }
 
   /**
@@ -481,8 +481,27 @@ class ToastUIEditor {
    * @param {number|Array.<number>} [end] - end position
    * @returns {string} - selected text content
    */
-  getSelectedContent(start?: EditorPos, end?: EditorPos) {
-    return this.getCurrentModeEditor().getSelectedContent(start, end);
+  getSelectedText(start?: EditorPos, end?: EditorPos) {
+    return this.getCurrentModeEditor().getSelectedText(start, end);
+  }
+
+  /**
+   * Get range of the node
+   * @param {number|Array.<number>} [pos] - position
+   * @returns {Array.<number[]>|Array.<number>} - node [start, end] range
+   * @example
+   * // Markdown mode
+   * const mdSelection = editor.getSelection();
+   *
+   * console.log(mdSelection); // [[startLineOffset, startCurorOffset], [endLineOffset, endCurorOffset]]
+   *
+   * // WYSIWYG mode
+   * const wwSelection = editor.getSelection();
+   *
+   * console.log(wwSelection); // [startCursorOffset, endCursorOffset]
+   */
+  getRangeOfNode(pos?: EditorPos) {
+    return this.getCurrentModeEditor().getRangeOfNode(pos);
   }
 
   /**
@@ -499,10 +518,10 @@ class ToastUIEditor {
    * Replace node with widget to range
    * @param {number|Array.<number>} start - start position
    * @param {number|Array.<number>} end - end position
-   * @param {string} content - widget text content
+   * @param {string} text - widget text content
    */
-  replaceWithWidget(start: EditorPos, end: EditorPos, content: string) {
-    this.getCurrentModeEditor().replaceWithWidget(start, end, content);
+  replaceWithWidget(start: EditorPos, end: EditorPos, text: string) {
+    this.getCurrentModeEditor().replaceWithWidget(start, end, text);
   }
 
   /**

--- a/apps/editor/src/editorCore.ts
+++ b/apps/editor/src/editorCore.ts
@@ -702,7 +702,7 @@ class ToastUIEditor {
    * // WYSIWYG mode
    * const wwSelection = editor.getSelection();
    *
-   * console.log(wwSelection); // [startCursorOffset, endCursorOffset]]
+   * console.log(wwSelection); // [startCursorOffset, endCursorOffset]
    */
   getSelection() {
     return this.getCurrentModeEditor().getSelection();

--- a/apps/editor/src/editorCore.ts
+++ b/apps/editor/src/editorCore.ts
@@ -449,8 +449,8 @@ class ToastUIEditor {
 
   /**
    * Set selection range
-   * @param {number|Array.<number>} [start] - start position
-   * @param {number|Array.<number>} [end] - end position
+   * @param {number|Array.<number>} start - start position
+   * @param {number|Array.<number>} end - end position
    */
   setSelection(start: EditorPos, end: EditorPos) {
     this.getCurrentModeEditor().setSelection(start, end);

--- a/apps/editor/src/editorCore.ts
+++ b/apps/editor/src/editorCore.ts
@@ -11,9 +11,16 @@ import removeClass from 'tui-code-snippet/domUtil/removeClass';
 import isString from 'tui-code-snippet/type/isString';
 
 import { Emitter, Handler } from '@t/event';
-import { EditorOptions, EditorType, PreviewStyle, ViewerOptions, WidgetStyle } from '@t/editor';
+import {
+  Base,
+  EditorOptions,
+  EditorPos,
+  EditorType,
+  PreviewStyle,
+  ViewerOptions,
+  WidgetStyle,
+} from '@t/editor';
 import { EditorCommandFn } from '@t/spec';
-import { MdPos } from '@t/markdown';
 
 import { sendHostName, sanitizeLinkAttribute } from './utils/common';
 
@@ -434,32 +441,68 @@ class ToastUIEditor {
 
   /**
    * Insert text
-   * @param {string} text - text string to insert
+   * @param {string} content - text content
    */
-  insertText(text: string) {
-    this.getCurrentModeEditor().replaceSelection(text);
+  insertText(content: string) {
+    this.getCurrentModeEditor().replaceSelection(content);
+  }
+
+  /**
+   * Set selection range
+   * @param {number|Array.<number>} [start] - start position
+   * @param {number|Array.<number>} [end] - end position
+   */
+  setSelection(start: EditorPos, end: EditorPos) {
+    this.getCurrentModeEditor().setSelection(start, end);
+  }
+
+  /**
+   * Replace selection range with given text content
+   * @param {string} content - widget text content
+   * @param {number|Array.<number>} [start] - start position
+   * @param {number|Array.<number>} [end] - end position
+   */
+  replaceSelection(content: string, start?: EditorPos, end?: EditorPos) {
+    this.getCurrentModeEditor().replaceSelection(content, start, end);
+  }
+
+  /**
+   * Delete the content of selection range
+   * @param {number|Array.<number>} [start] - start position
+   * @param {number|Array.<number>} [end] - end position
+   */
+  deleteSelection(start: EditorPos, end: EditorPos) {
+    this.getCurrentModeEditor().deleteSelection(start, end);
+  }
+
+  /**
+   * Get selected text content
+   * @param {number|Array.<number>} [start] - start position
+   * @param {number|Array.<number>} [end] - end position
+   * @returns {string} - selected text content
+   */
+  getSelectedContent(start?: EditorPos, end?: EditorPos) {
+    return this.getCurrentModeEditor().getSelectedContent(start, end);
   }
 
   /**
    * Add widget to selection
-   * @param {Node} node widget node
-   * @param {string} style Adding style "top" or "bottom"
-   * @param {number|Array.<number>} [pos] position
+   * @param {Node} node - widget node
+   * @param {string} style - Adding style "top" or "bottom"
+   * @param {number|Array.<number>} [pos] - position
    */
-  addWidget(node: Node, style: WidgetStyle, pos?: MdPos | number) {
-    // @ts-ignore
+  addWidget(node: Node, style: WidgetStyle, pos?: EditorPos) {
     this.getCurrentModeEditor().addWidget(node, style, pos);
   }
 
   /**
-   * replace node with widget to range
-   * @param {number|Array.<number>} from start position
-   * @param {number|Array.<number>} to end position
-   * @param {string} content widget text content
+   * Replace node with widget to range
+   * @param {number|Array.<number>} start - start position
+   * @param {number|Array.<number>} end - end position
+   * @param {string} content - widget text content
    */
-  replaceWithWidget(from: MdPos | number, to: MdPos | number, content: string) {
-    // @ts-ignore
-    this.getCurrentModeEditor().replaceWithWidget(from, to, content);
+  replaceWithWidget(start: EditorPos, end: EditorPos, content: string) {
+    this.getCurrentModeEditor().replaceWithWidget(start, end, content);
   }
 
   /**
@@ -524,7 +567,7 @@ class ToastUIEditor {
    * @returns {Object} MarkdownEditor or WysiwygEditor
    */
   getCurrentModeEditor() {
-    let editor;
+    let editor: Base;
 
     if (this.isMarkdownMode()) {
       editor = this.mdEditor;
@@ -598,7 +641,7 @@ class ToastUIEditor {
   }
 
   /**
-   * Remove TUIEditor from document
+   * Destroy TUIEditor from document
    */
   destroy() {
     this.wwEditor.destroy();
@@ -643,48 +686,26 @@ class ToastUIEditor {
    * Reset TUIEditor
    */
   reset() {
-    // @ts-ignore
     this.wwEditor.setModel([]);
     this.mdEditor.setMarkdown('');
   }
 
   /**
-   * Get current range
-   * @returns {Array.<string[]>|Array.<string>} Returns the range of the selection depending on the editor mode
+   * Get current selection range
+   * @returns {Array.<number[]>|Array.<number>} Returns the range of the selection depending on the editor mode
    * @example
    * // Markdown mode
-   * const mdRange = editor.getRange();
+   * const mdSelection = editor.getSelection();
    *
-   * console.log(mdRange); // [[startLineOffset, startCurorOffset], [endLineOffset, endCurorOffset]]
+   * console.log(mdSelection); // [[startLineOffset, startCurorOffset], [endLineOffset, endCurorOffset]]
    *
    * // WYSIWYG mode
-   * const wwRange = editor.getRange();
+   * const wwSelection = editor.getSelection();
    *
-   * console.log(mdRange); // [startCursorOffset, endCursorOffset]]
+   * console.log(wwSelection); // [startCursorOffset, endCursorOffset]]
    */
-  getRange() {
-    return this.getCurrentModeEditor().getRange();
-  }
-
-  /**
-   * Get text object of current range
-   * @param {{start, end}|Range} range Range object of each editor
-   * @returns {MdTextObject|WwTextObject} TextObject class
-   */
-  // @TODO: change the way to provide API
-  // eslint-disable-next-line
-  getTextObject() {}
-
-  /**
-   * get selected text
-   * @returns {string} - selected text
-   */
-  // @TODO: change the way to provide API
-  // eslint-disable-next-line
-  getSelectedText() {
-    // const range = this.getRange();
-    // const textObject = this.getTextObject(range);
-    // return textObject.getTextContent() || '';
+  getSelection() {
+    return this.getCurrentModeEditor().getSelection();
   }
 
   /**
@@ -710,7 +731,7 @@ class ToastUIEditor {
   }
 
   /**
-   * get markdown editor, preview, wysiwyg editor DOM elements
+   * Get markdown editor, preview, wysiwyg editor DOM elements
    */
   getEditorElements() {
     return {

--- a/apps/editor/src/editorCore.ts
+++ b/apps/editor/src/editorCore.ts
@@ -98,7 +98,7 @@ class ToastUIEditor {
 
   private mode!: EditorType;
 
-  private mdPreviewStyle!: PreviewStyle;
+  private mdPreviewStyle: PreviewStyle;
 
   private i18n: I18n;
 
@@ -158,6 +158,7 @@ class ToastUIEditor {
 
     this.codeBlockLanguages = [];
     this.mode = initialEditType || 'markdown';
+    this.mdPreviewStyle = this.options.previewStyle;
 
     this.eventEmitter = new EventEmitter();
 
@@ -289,13 +290,20 @@ class ToastUIEditor {
   }
 
   /**
-   * call commandManager's exec method
-   * @param {*} ...args Command argument
+   * execute editor command
+   * @param {string} type - editor type
+   * @param {string} name - command name
+   * @param {object} [payload] - payload for command
    */
-  exec(type: EditorType, name: string, payload: Record<string, any>) {
+  exec(type: EditorType, name: string, payload?: Record<string, any>) {
     this.commandManager.exec(type, name, payload);
   }
 
+  /**
+   * @param {string} type - editor type
+   * @param {string} name - command name
+   * @param {function} command - command handler
+   */
   addCommand(type: EditorType, name: string, command: EditorCommandFn) {
     this.commandManager.addCommand(type, name, command);
   }
@@ -368,9 +376,7 @@ class ToastUIEditor {
    * @param {string} markdown - markdown syntax text.
    * @param {boolean} [cursorToEnd=true] - move cursor to contents end
    */
-  setMarkdown(markdown: string, cursorToEnd = true) {
-    markdown = markdown ?? '';
-
+  setMarkdown(markdown = '', cursorToEnd = true) {
     this.mdEditor.setMarkdown(markdown, cursorToEnd);
 
     if (this.isWysiwygMode()) {
@@ -607,14 +613,14 @@ class ToastUIEditor {
    * Hide TUIEditor
    */
   hide() {
-    this.eventEmitter.emit('hide', this);
+    this.eventEmitter.emit('hide');
   }
 
   /**
    * Show TUIEditor
    */
   show() {
-    this.eventEmitter.emit('show', this);
+    this.eventEmitter.emit('show');
   }
 
   /**
@@ -715,7 +721,6 @@ class ToastUIEditor {
   }
 }
 
-// @TODO: remove below API
 // // (Not an official API)
 // // Create a function converting markdown to HTML using the internal parser and renderer.
 // ToastUIEditor._createMarkdownToHTML = createMarkdownToHTML;

--- a/apps/editor/src/editorCore.ts
+++ b/apps/editor/src/editorCore.ts
@@ -491,17 +491,17 @@ class ToastUIEditor {
    * @returns {Array.<number[]>|Array.<number>} - node [start, end] range
    * @example
    * // Markdown mode
-   * const mdSelection = editor.getSelection();
+   * const rangeInfo = editor.getRangeInfoOfNode();
    *
-   * console.log(mdSelection); // [[startLineOffset, startCurorOffset], [endLineOffset, endCurorOffset]]
+   * console.log(rangeInfo); // { range: [[startLineOffset, startCurorOffset], [endLineOffset, endCurorOffset]], type: 'emph' }
    *
    * // WYSIWYG mode
-   * const wwSelection = editor.getSelection();
+   * const rangeInfo = editor.getRangeInfoOfNode();
    *
-   * console.log(wwSelection); // [startCursorOffset, endCursorOffset]
+   * console.log(rangeInfo); // { range: [startCursorOffset, endCursorOffset], type: 'emph' }
    */
-  getRangeOfNode(pos?: EditorPos) {
-    return this.getCurrentModeEditor().getRangeOfNode(pos);
+  getRangeInfoOfNode(pos?: EditorPos) {
+    return this.getCurrentModeEditor().getRangeInfoOfNode(pos);
   }
 
   /**

--- a/apps/editor/src/markdown/mdEditor.ts
+++ b/apps/editor/src/markdown/mdEditor.ts
@@ -1,6 +1,6 @@
 import { Transaction } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
-import { Fragment, Schema, Slice } from 'prosemirror-model';
+import { Fragment, Slice } from 'prosemirror-model';
 import { Step, ReplaceAroundStep } from 'prosemirror-transform';
 // @ts-ignore
 import { ToastMark } from '@toast-ui/toastmark';
@@ -45,7 +45,7 @@ export default class MdEditor extends EditorBase {
 
   private clipboard!: HTMLTextAreaElement;
 
-  constructor(toastMark: ToastMark, eventEmitter: Emitter) {
+  constructor(toastMark: ToastMark, eventEmitter: Emitter, useCommandShortcut: boolean) {
     super(eventEmitter);
 
     this.editorType = 'markdown';
@@ -53,7 +53,7 @@ export default class MdEditor extends EditorBase {
     this.specs = this.createSpecs();
     this.schema = this.createSchema();
     this.context = this.createContext();
-    this.keymaps = this.createKeymaps();
+    this.keymaps = this.createKeymaps(useCommandShortcut);
     this.view = this.createView();
     this.commands = this.createCommands();
     this.specs.setContext({ ...this.context, view: this.view });
@@ -106,10 +106,6 @@ export default class MdEditor extends EditorBase {
     };
   }
 
-  createKeymaps() {
-    return this.specs.keymaps();
-  }
-
   createSpecs() {
     return new SpecManager([
       new Doc(),
@@ -135,13 +131,6 @@ export default class MdEditor extends EditorBase {
       new Meta(),
       new Html(),
     ]);
-  }
-
-  createSchema() {
-    return new Schema({
-      nodes: this.specs.nodes,
-      marks: this.specs.marks,
-    });
   }
 
   createPlugins() {

--- a/apps/editor/src/markdown/mdEditor.ts
+++ b/apps/editor/src/markdown/mdEditor.ts
@@ -5,7 +5,7 @@ import { Step, ReplaceAroundStep } from 'prosemirror-transform';
 // @ts-ignore
 import { ToastMark } from '@toast-ui/toastmark';
 import { Emitter } from '@t/event';
-import { MdPos } from '@t/markdown';
+import { MdNode, MdPos, MdSourcepos } from '@t/markdown';
 import { WidgetStyle } from '@t/editor';
 import EditorBase from '@/base';
 import SpecManager from '@/spec/specManager';
@@ -227,10 +227,10 @@ export default class MdEditor extends EditorBase {
     this.view.dispatch(tr.setSelection(createTextSelection(tr, from, to)));
   }
 
-  replaceSelection(content: string, start?: MdPos, end?: MdPos) {
+  replaceSelection(text: string, start?: MdPos, end?: MdPos) {
     let newTr;
     const { tr, schema, doc } = this.view.state;
-    const lineTexts = content.split('\n');
+    const lineTexts = text.split('\n');
     const nodes = lineTexts.map((lineText) =>
       schema.nodes.paragraph.create(null, createNodesWithWidget(lineText, schema))
     );
@@ -262,7 +262,7 @@ export default class MdEditor extends EditorBase {
     this.view.dispatch(newTr.scrollIntoView());
   }
 
-  getSelectedContent(start?: MdPos, end?: MdPos) {
+  getSelectedText(start?: MdPos, end?: MdPos) {
     const { doc, selection } = this.view.state;
     let { from, to } = selection;
 
@@ -303,12 +303,20 @@ export default class MdEditor extends EditorBase {
     this.view.dispatch(tr.setMeta('widget', { pos, node, style }));
   }
 
-  replaceWithWidget(start: MdPos, end: MdPos, content: string) {
+  replaceWithWidget(start: MdPos, end: MdPos, text: string) {
     const { tr, schema, doc } = this.view.state;
     const pos = getMdToEditorPos(doc, this.toastMark, start, end);
-    const nodes = createNodesWithWidget(content, schema);
+    const nodes = createNodesWithWidget(text, schema);
 
     this.view.dispatch(tr.replaceWith(pos[0], pos[1], nodes));
+  }
+
+  getRangeOfNode(pos?: MdPos): MdSourcepos {
+    const { doc, selection } = this.view.state;
+    const mdPos = pos || getEditorToMdPos(doc, selection.from)[0];
+    const mdNode: MdNode = this.toastMark.findNodeAtPosition(mdPos);
+
+    return mdNode.sourcepos!;
   }
 
   getMarkdown() {

--- a/apps/editor/src/markdown/mdEditor.ts
+++ b/apps/editor/src/markdown/mdEditor.ts
@@ -311,12 +311,18 @@ export default class MdEditor extends EditorBase {
     this.view.dispatch(tr.replaceWith(pos[0], pos[1], nodes));
   }
 
-  getRangeOfNode(pos?: MdPos): MdSourcepos {
+  getRangeInfoOfNode(pos?: MdPos) {
     const { doc, selection } = this.view.state;
     const mdPos = pos || getEditorToMdPos(doc, selection.from)[0];
-    const mdNode: MdNode = this.toastMark.findNodeAtPosition(mdPos);
+    let mdNode: MdNode = this.toastMark.findNodeAtPosition(mdPos);
 
-    return mdNode.sourcepos!;
+    if (mdNode.type === 'text' && mdNode.parent!.type !== 'paragraph') {
+      mdNode = mdNode.parent!;
+    }
+
+    mdNode.sourcepos![1][1] += 1;
+
+    return { range: mdNode.sourcepos!, type: mdNode.type };
   }
 
   getMarkdown() {

--- a/apps/editor/src/markdown/mdEditor.ts
+++ b/apps/editor/src/markdown/mdEditor.ts
@@ -5,7 +5,7 @@ import { Step, ReplaceAroundStep } from 'prosemirror-transform';
 // @ts-ignore
 import { ToastMark } from '@toast-ui/toastmark';
 import { Emitter } from '@t/event';
-import { MdNode, MdPos, MdSourcepos } from '@t/markdown';
+import { MdNode, MdPos } from '@t/markdown';
 import { WidgetStyle } from '@t/editor';
 import EditorBase from '@/base';
 import SpecManager from '@/spec/specManager';
@@ -320,6 +320,7 @@ export default class MdEditor extends EditorBase {
       mdNode = mdNode.parent!;
     }
 
+    // add 1 sync for prosemirror position
     mdNode.sourcepos![1][1] += 1;
 
     return { range: mdNode.sourcepos!, type: mdNode.type };

--- a/apps/editor/src/markdown/scroll/scrollSync.ts
+++ b/apps/editor/src/markdown/scroll/scrollSync.ts
@@ -92,7 +92,7 @@ export class ScrollSync {
   }
 
   private getScrollTopByCaretPos() {
-    const pos = this.mdEditor.getRange();
+    const pos = this.mdEditor.getSelection();
     const firstMdNode = this.toastMark.findFirstNodeAtLine(pos[0][0]);
     const previewHeight = this.previewEl.clientHeight;
     const { el } = getParentNodeObj(firstMdNode);

--- a/apps/editor/src/plugins/popupWidget.ts
+++ b/apps/editor/src/plugins/popupWidget.ts
@@ -46,8 +46,8 @@ class PopupWidget {
         opacity: '1',
       });
       this.popup = node;
+      view.focus();
     }
-    view.focus();
   }
 
   destroy() {

--- a/apps/editor/src/wysiwyg/wwEditor.ts
+++ b/apps/editor/src/wysiwyg/wwEditor.ts
@@ -1,13 +1,11 @@
 import { EditorView } from 'prosemirror-view';
-import { Schema, Node as ProsemirrorNode, Slice, Fragment } from 'prosemirror-model';
+import { Node as ProsemirrorNode, Slice, Fragment } from 'prosemirror-model';
 
 import EditorBase from '@/base';
 import { getWwCommands } from '@/commands/wwCommands';
 
 import { createTextSelection } from '@/helper/manipulation';
 import { emitImageBlobHook, pasteImageOnly } from '@/helper/image';
-
-import { placeholder } from '@/plugins/placeholder';
 
 import { tableSelection } from './plugins/tableSelection';
 import { tableContextMenu } from './plugins/tableContextMenu';
@@ -40,7 +38,12 @@ export default class WysiwygEditor extends EditorBase {
 
   private linkAttributes: LinkAttributes;
 
-  constructor(eventEmitter: Emitter, toDOMAdaptor: ToDOMAdaptor, linkAttributes = {}) {
+  constructor(
+    eventEmitter: Emitter,
+    toDOMAdaptor: ToDOMAdaptor,
+    useCommandShortcut: boolean,
+    linkAttributes = {}
+  ) {
     super(eventEmitter);
 
     this.editorType = 'wysiwyg';
@@ -49,7 +52,7 @@ export default class WysiwygEditor extends EditorBase {
     this.specs = this.createSpecs();
     this.schema = this.createSchema();
     this.context = this.createContext();
-    this.keymaps = this.createKeymaps();
+    this.keymaps = this.createKeymaps(useCommandShortcut);
     this.view = this.createView();
     this.commands = this.createCommands();
     this.specs.setContext({ ...this.context, view: this.view });
@@ -58,17 +61,6 @@ export default class WysiwygEditor extends EditorBase {
 
   createSpecs() {
     return createSpecs(this.toDOMAdaptor, this.linkAttributes);
-  }
-
-  createKeymaps() {
-    return this.specs.keymaps();
-  }
-
-  createSchema() {
-    return new Schema({
-      nodes: this.specs.nodes,
-      marks: this.specs.marks,
-    });
   }
 
   createContext() {

--- a/apps/editor/src/wysiwyg/wwEditor.ts
+++ b/apps/editor/src/wysiwyg/wwEditor.ts
@@ -163,11 +163,11 @@ export default class WysiwygEditor extends EditorBase {
     return this.view.state.schema;
   }
 
-  replaceSelection(content: string, start?: number, end?: number) {
+  replaceSelection(text: string, start?: number, end?: number) {
     const { schema, tr } = this.view.state;
     const { paragraph } = schema.nodes;
-    const texts = content.split('\n');
-    const paras = texts.map((text) => paragraph.create(null, schema.text(text)));
+    const lineTexts = text.split('\n');
+    const paras = lineTexts.map((lineText) => paragraph.create(null, schema.text(lineText)));
     const slice = new Slice(Fragment.from(paras), 1, 1);
     const newTr =
       isNumber(start) && isNumber(end)
@@ -186,7 +186,7 @@ export default class WysiwygEditor extends EditorBase {
     this.view.dispatch(newTr.scrollIntoView());
   }
 
-  getSelectedContent(start?: number, end?: number) {
+  getSelectedText(start?: number, end?: number) {
     const { doc, selection } = this.view.state;
     let { from, to } = selection;
 
@@ -220,10 +220,17 @@ export default class WysiwygEditor extends EditorBase {
     dispatch(state.tr.setMeta('widget', { pos: pos ?? state.selection.to, node, style }));
   }
 
-  replaceWithWidget(start: number, end: number, content: string) {
+  replaceWithWidget(start: number, end: number, text: string) {
     const { tr, schema } = this.view.state;
-    const nodes = createNodesWithWidget(content, schema);
+    const nodes = createNodesWithWidget(text, schema);
 
     this.view.dispatch(tr.replaceWith(start, end, nodes));
+  }
+
+  getRangeOfNode(pos?: number): [number, number] {
+    const { doc, selection } = this.view.state;
+    const $pos = pos ? doc.resolve(pos) : selection.$from;
+
+    return [$pos.start(), $pos.end()];
   }
 }

--- a/apps/editor/src/wysiwyg/wwEditor.ts
+++ b/apps/editor/src/wysiwyg/wwEditor.ts
@@ -1,6 +1,6 @@
 import { EditorView } from 'prosemirror-view';
 import { Node as ProsemirrorNode, Slice, Fragment } from 'prosemirror-model';
-
+import isNumber from 'tui-code-snippet/type/isNumber';
 import EditorBase from '@/base';
 import { getWwCommands } from '@/commands/wwCommands';
 
@@ -153,7 +153,7 @@ export default class WysiwygEditor extends EditorBase {
     return this.view.state.doc;
   }
 
-  getRange(): [number, number] {
+  getSelection(): [number, number] {
     const { from, to } = this.view.state.selection;
 
     return [from, to];
@@ -163,17 +163,41 @@ export default class WysiwygEditor extends EditorBase {
     return this.view.state.schema;
   }
 
-  replaceSelection(content: string) {
+  replaceSelection(content: string, start?: number, end?: number) {
     const { schema, tr } = this.view.state;
     const { paragraph } = schema.nodes;
     const texts = content.split('\n');
     const paras = texts.map((text) => paragraph.create(null, schema.text(text)));
+    const slice = new Slice(Fragment.from(paras), 1, 1);
+    const newTr =
+      isNumber(start) && isNumber(end)
+        ? tr.replaceRange(start, end, slice)
+        : tr.replaceSelection(slice);
 
-    this.view.dispatch(tr.replaceSelection(new Slice(Fragment.from(paras), 1, 1)));
+    this.view.dispatch(newTr);
     this.focus();
   }
 
-  setModel(newDoc: ProsemirrorNode, cursorToEnd = false) {
+  deleteSelection(start?: number, end?: number) {
+    const { tr } = this.view.state;
+    const newTr =
+      isNumber(start) && isNumber(end) ? tr.deleteRange(start, end) : tr.deleteSelection();
+
+    this.view.dispatch(newTr.scrollIntoView());
+  }
+
+  getSelectedContent(start?: number, end?: number) {
+    const { doc, selection } = this.view.state;
+    let { from, to } = selection;
+
+    if (isNumber(start) && isNumber(end)) {
+      from = start;
+      to = end;
+    }
+    return doc.textBetween(from, to, '\n');
+  }
+
+  setModel(newDoc: ProsemirrorNode | [], cursorToEnd = false) {
     const { tr, doc } = this.view.state;
 
     this.view.dispatch(tr.replaceWith(0, doc.content.size, newDoc));
@@ -183,7 +207,7 @@ export default class WysiwygEditor extends EditorBase {
     }
   }
 
-  setSelection(start = 0, end = 0) {
+  setSelection(start: number, end: number) {
     const { tr } = this.view.state;
     const selection = createTextSelection(tr, start, end);
 
@@ -196,10 +220,10 @@ export default class WysiwygEditor extends EditorBase {
     dispatch(state.tr.setMeta('widget', { pos: pos ?? state.selection.to, node, style }));
   }
 
-  replaceWithWidget(from: number, to: number, content: string) {
+  replaceWithWidget(start: number, end: number, content: string) {
     const { tr, schema } = this.view.state;
     const nodes = createNodesWithWidget(content, schema);
 
-    this.view.dispatch(tr.replaceWith(from, to, nodes));
+    this.view.dispatch(tr.replaceWith(start, end, nodes));
   }
 }

--- a/apps/editor/types/editor.d.ts
+++ b/apps/editor/types/editor.d.ts
@@ -290,15 +290,17 @@ export interface Base {
 
   setSelection(start: EditorPos, end: EditorPos): void;
 
-  replaceWithWidget(start: EditorPos, end: EditorPos, content: string): void;
+  replaceWithWidget(start: EditorPos, end: EditorPos, text: string): void;
 
   addWidget(node: Node, style: WidgetStyle, pos?: EditorPos): void;
 
-  replaceSelection(content: string, start?: EditorPos, end?: EditorPos): void;
+  replaceSelection(text: string, start?: EditorPos, end?: EditorPos): void;
 
   deleteSelection(start?: EditorPos, end?: EditorPos): void;
 
-  getSelectedContent(start?: EditorPos, end?: EditorPos): string;
+  getSelectedText(start?: EditorPos, end?: EditorPos): string;
 
   getSelection(): MdSourcepos | [number, number];
+
+  getRangeOfNode(pos?: EditorPos): MdSourcepos | [number, number];
 }

--- a/apps/editor/types/editor.d.ts
+++ b/apps/editor/types/editor.d.ts
@@ -1,8 +1,19 @@
-import { CustomHTMLRenderer, CustomHTMLRendererMap, CustomParserMap, MdPos } from './markdown';
-import { Handler } from './event';
-import { EditorCommandFn } from './spec';
+import { Schema } from 'prosemirror-model';
+import { EditorView } from 'prosemirror-view';
+import { Plugin } from 'prosemirror-state';
+import {
+  CustomHTMLRenderer,
+  CustomHTMLRendererMap,
+  CustomParserMap,
+  MdPos,
+  MdSourcepos,
+} from './markdown';
+import { Emitter, Handler } from './event';
+import { Context, EditorAllCommandMap, EditorCommandFn } from './spec';
 import { ToMdConvertorMap } from './convertor';
 import { DefaultUI, ToolbarItemOptions } from './ui';
+import { StateOptions } from '@/base';
+import SpecManager from '@/spec/specManager';
 
 export type PreviewStyle = 'tab' | 'vertical';
 export type EditorType = 'markdown' | 'wysiwyg';
@@ -216,4 +227,78 @@ export class EditorCore {
 
 export class Editor extends EditorCore {
   getDefaultUI(): DefaultUI;
+}
+
+export type EditorPos = MdPos | number;
+
+export interface Base {
+  el: HTMLElement;
+
+  editorType: EditorType;
+
+  eventEmitter: Emitter;
+
+  context: Context;
+
+  schema: Schema;
+
+  keymaps: Plugin[];
+
+  view: EditorView;
+
+  commands: EditorAllCommandMap;
+
+  specs: SpecManager;
+
+  placeholder: { text: string };
+
+  createSpecs(): SpecManager;
+
+  createContext(): Context;
+
+  createState(state?: StateOptions): void;
+
+  createView(): EditorView;
+
+  createSchema(): Schema;
+
+  createKeymaps(useCommandShortcut: boolean): Plugin<any, any>[];
+
+  createCommands(): Record<string, EditorCommandFn<Record<string, any>>>;
+
+  focus(): void;
+
+  blur(): void;
+
+  destroy(): void;
+
+  moveCursorToStart(): void;
+
+  moveCursorToEnd(): void;
+
+  setScrollTop(top: number): void;
+
+  getScrollTop(): number;
+
+  setPlaceholder(text: string): void;
+
+  setHeight(height: number): void;
+
+  setMinHeight(minHeight: number): void;
+
+  getElement(): HTMLElement;
+
+  setSelection(start: EditorPos, end: EditorPos): void;
+
+  replaceWithWidget(start: EditorPos, end: EditorPos, content: string): void;
+
+  addWidget(node: Node, style: WidgetStyle, pos?: EditorPos): void;
+
+  replaceSelection(content: string, start?: EditorPos, end?: EditorPos): void;
+
+  deleteSelection(start?: EditorPos, end?: EditorPos): void;
+
+  getSelectedContent(start?: EditorPos, end?: EditorPos): string;
+
+  getSelection(): MdSourcepos | [number, number];
 }

--- a/apps/editor/types/editor.d.ts
+++ b/apps/editor/types/editor.d.ts
@@ -1,4 +1,4 @@
-import { CustomHTMLRenderer, CustomHTMLRendererMap, CustomParserMap } from './markdown';
+import { CustomHTMLRenderer, CustomHTMLRendererMap, CustomParserMap, MdPos } from './markdown';
 import { Handler } from './event';
 import { EditorCommandFn } from './spec';
 import { ToMdConvertorMap } from './convertor';
@@ -137,7 +137,7 @@ export class EditorCore {
 
   changePreviewStyle(style: PreviewStyle): void;
 
-  exec(type: EditorType, name: string, payload: Record<string, any>): void;
+  exec(type: EditorType, name: string, payload?: Record<string, any>): void;
 
   addCommand(type: EditorType, name: string, command: EditorCommandFn): void;
 
@@ -208,6 +208,10 @@ export class EditorCore {
   setCodeBlockLanguages(languages: string[]): void;
 
   getEditorElements(): Slots;
+
+  addWidget(node: Node, style: WidgetStyle, pos?: MdPos | number): void;
+
+  replaceWithWidget(from: MdPos | number, to: MdPos | number, content: string): void;
 }
 
 export class Editor extends EditorCore {

--- a/apps/editor/types/editor.d.ts
+++ b/apps/editor/types/editor.d.ts
@@ -12,7 +12,6 @@ import { Emitter, Handler } from './event';
 import { Context, EditorAllCommandMap, EditorCommandFn } from './spec';
 import { ToMdConvertorMap } from './convertor';
 import { DefaultUI, ToolbarItemOptions } from './ui';
-import { StateOptions } from '@/base';
 import SpecManager from '@/spec/specManager';
 
 export type PreviewStyle = 'tab' | 'vertical';
@@ -260,7 +259,7 @@ export interface Base {
 
   createContext(): Context;
 
-  createState(state?: StateOptions): EditorState;
+  createState(): EditorState;
 
   createView(): EditorView;
 

--- a/apps/editor/types/editor.d.ts
+++ b/apps/editor/types/editor.d.ts
@@ -1,6 +1,6 @@
 import { Schema } from 'prosemirror-model';
 import { EditorView } from 'prosemirror-view';
-import { Plugin } from 'prosemirror-state';
+import { EditorState, Plugin } from 'prosemirror-state';
 import {
   CustomHTMLRenderer,
   CustomHTMLRendererMap,
@@ -260,7 +260,7 @@ export interface Base {
 
   createContext(): Context;
 
-  createState(state?: StateOptions): void;
+  createState(state?: StateOptions): EditorState;
 
   createView(): EditorView;
 

--- a/apps/editor/types/editor.d.ts
+++ b/apps/editor/types/editor.d.ts
@@ -230,6 +230,10 @@ export class Editor extends EditorCore {
 }
 
 export type EditorPos = MdPos | number;
+export interface NodeRangeInfo {
+  range: MdSourcepos | [number, number];
+  type: string;
+}
 
 export interface Base {
   el: HTMLElement;
@@ -302,5 +306,5 @@ export interface Base {
 
   getSelection(): MdSourcepos | [number, number];
 
-  getRangeOfNode(pos?: EditorPos): MdSourcepos | [number, number];
+  getRangeInfoOfNode(pos?: EditorPos): NodeRangeInfo;
 }


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
#### added option
* `useComamndShortcut`: if this options has `false` value, keymap would not be operated.
#### added API
* `setSelection(start: EditorPos, end: EditorPos)`: Set selection range in editor.
* `replaceSelection(content: string, start?: EditorPos, end?: EditorPos)`: Replace the content with given text content in editor. If the `start`, `end` range is passed, the content included that range would be replaced, otherwise the content of the current selection would be replaced.
* `deleteSelection(start?: EditorPos, end?: EditorPos)`: Delete the content in editor. If the `start`, `end` range is passed, the content included that range would be deleted, otherwise the content of the current selection would be deleted.
* `getSelectedContent(start?: EditorPos, end?: EditorPos)`: get the text content in editor. If the `start`, `end` range is passed, the content included that range would be returned, otherwise the content of the current selection would be returned.
* `getRangeInfoOfNode(pos?: EditorPos)`: get the range of the closest node based on specific position. If the `pos` is passed, the node range in the position would be returned, otherwise the node range in the current selection would be returned.

**addional context**
The selection range position for above APIs should be distinguished by the editor type(markdown, wysiwyg) like below.
```ts
// in markdown
start - [startLineOffset, startCharactorOffset]: [number, number], 
end - [endLineOffset, endCharactorOffset]: [number, number], 
// wysiwyg
start - startCursorOffset: number, 
end - endCursorOffset: number
```
#### Breaking changes
* remove` getTextObject` API: This API will be removed and replaced with above the new APIs
* `getRange` API => `getSelection` API: `getRange` API is replaced with `getSelection` API and the returned value would be changed as the format described above.


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
