### PR TITLE
fix: remove toastmark `getInlineMarkdownText` API

### DIFF
--- a/apps/editor/src/utils/markdown.ts
+++ b/apps/editor/src/utils/markdown.ts
@@ -1,6 +1,7 @@
 import {
   CodeBlockMdNode,
   CustomBlockMdNode,
+  LinkMdNode,
   ListItemMdNode,
   MdNode,
   MdNodeType,
@@ -134,4 +135,28 @@ export function addOffsetPos(originPos: MdPos, offset: number): MdPos {
 
 export function setOffsetPos(originPos: MdPos, newOffset: number): MdPos {
   return [originPos[0], newOffset];
+}
+
+export function getInlineMarkdownText(mdNode: MdNode) {
+  const text = mdNode.firstChild!.literal;
+
+  switch (mdNode.type) {
+    case 'emph':
+      return `*${text}*`;
+    case 'strong':
+      return `**${text}**`;
+    case 'strike':
+      return `~~${text}~~`;
+    case 'code':
+      return `\`${text}\``;
+    case 'link':
+    case 'image':
+      /* eslint-disable no-case-declarations */
+      const { destination, title } = mdNode as LinkMdNode;
+      const delim = mdNode.type === 'link' ? '' : '!';
+
+      return `${delim}[${text}](${destination}${title ? ` "${title}"` : ''})`;
+    default:
+      return null;
+  }
 }

--- a/apps/editor/src/widget/rules.ts
+++ b/apps/editor/src/widget/rules.ts
@@ -1,6 +1,7 @@
 import { Schema, ProsemirrorNode } from 'prosemirror-model';
 import { WidgetRule, WidgetRuleMap } from '@t/editor';
 import { CustomInlineMdNode } from '@t/markdown';
+import { getInlineMarkdownText } from '@/utils/markdown';
 
 let widgetRules: WidgetRule[] = [];
 
@@ -114,7 +115,7 @@ export function getWidgetContent(widgetNode: CustomInlineMdNode) {
 
     if (entering) {
       if (node !== widgetNode && node.type !== 'text') {
-        text += node.getInlineMarkdownText();
+        text += getInlineMarkdownText(node);
         // skip the children
         walker.resumeAt(widgetNode, false);
         walker.next();

--- a/apps/editor/types/markdown.d.ts
+++ b/apps/editor/types/markdown.d.ts
@@ -67,7 +67,6 @@ export interface MdNode {
   appendChild(child: MdNode): void;
   prependChild(child: MdNode): void;
   walker(): NodeWalker;
-  getInlineMarkdownText(): string | null;
 }
 
 export interface CodeBlockMdNode extends MdNode {

--- a/libs/toastmark/src/commonmark/node.ts
+++ b/libs/toastmark/src/commonmark/node.ts
@@ -190,22 +190,6 @@ export class Node {
   walker() {
     return new NodeWalker(this);
   }
-
-  getInlineMarkdownText() {
-    const text = this.firstChild!.literal;
-    switch (this.type) {
-      case 'emph':
-        return `*${text}*`;
-      case 'strong':
-        return `**${text}**`;
-      case 'strike':
-        return `~~${text}~~`;
-      case 'code':
-        return `\`${text}\``;
-      default:
-        return null;
-    }
-  }
 }
 
 export class BlockNode extends Node {
@@ -249,14 +233,6 @@ export class LinkNode extends Node {
   public destination: string | null = null;
   public title: string | null = null;
   public extendedAutolink = false;
-
-  getInlineMarkdownText() {
-    const text = this.firstChild!.literal;
-    const { destination, title } = this as LinkNode;
-    const delim = this.type === 'link' ? '' : '!';
-
-    return `${delim}[${text}](${destination}${title ? ` "${title}"` : ''})`;
-  }
 }
 
 export class CodeBlockNode extends BlockNode {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
* removed toastmark `getInlineMarkdownText` API and implemented it `getInlineMarkdownText` in editor


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
