### PR TITLE
fix: popupWidget should be closed when emitting blur event

### DIFF
--- a/apps/editor/src/__test__/unit/markdown/mdEditor.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/mdEditor.spec.ts
@@ -127,5 +127,9 @@ describe('MarkdownEditor', () => {
     mde.addWidget(ul, 'top');
 
     expect(document.body).toContainElement(ul);
+
+    mde.blur();
+
+    expect(document.body).not.toContainElement(ul);
   });
 });

--- a/apps/editor/src/__test__/unit/markdown/mdPreview.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/mdPreview.spec.ts
@@ -52,7 +52,10 @@ describe('Preview', () => {
 });
 
 describe('preview highlight', () => {
-  let eventEmitter: EventEmitter, preview: MarkdownPreview, editor: MarkdownEditor;
+  let eventEmitter: EventEmitter,
+    preview: MarkdownPreview,
+    editor: MarkdownEditor,
+    editorEl: HTMLElement;
 
   function init(highlight: boolean) {
     const options = {
@@ -62,16 +65,13 @@ describe('preview highlight', () => {
       highlight,
     };
 
-    const editorEl = document.createElement('div');
-    const previewEl = document.createElement('div');
-
-    document.body.innerHTML = '';
-    document.body.appendChild(editorEl);
-    document.body.appendChild(previewEl);
-
     eventEmitter = new EventEmitter();
     editor = new MarkdownEditor(new ToastMark(), eventEmitter);
     preview = new MarkdownPreview(eventEmitter, options);
+    editorEl = editor.getElement();
+
+    document.body.appendChild(editorEl);
+    document.body.appendChild(preview.getElement()!);
   }
 
   function setMarkdown(markdown: string) {
@@ -96,6 +96,12 @@ describe('preview highlight', () => {
     expect(el.tagName).toBe(tagName);
     expect(el.innerHTML).toBe(html);
   }
+
+  afterEach(() => {
+    document.body.removeChild(editorEl);
+    editor.destroy();
+    preview.destroy();
+  });
 
   it('highlighted element should be one', () => {
     init(true);

--- a/apps/editor/src/__test__/unit/wysiwyg/wwEditor.spec.ts
+++ b/apps/editor/src/__test__/unit/wysiwyg/wwEditor.spec.ts
@@ -134,6 +134,10 @@ describe('WysiwygEditor', () => {
       wwe.addWidget(ul, 'top');
 
       expect(document.body).toContainElement(ul);
+
+      wwe.blur();
+
+      expect(document.body).not.toContainElement(ul);
     });
   });
 

--- a/apps/editor/src/base.ts
+++ b/apps/editor/src/base.ts
@@ -81,12 +81,10 @@ export default abstract class EditorBase {
 
   focus() {
     this.view.focus();
-    this.eventEmitter.emit('focus', this.editorType);
   }
 
   blur() {
     (this.view.dom as HTMLElement).blur();
-    this.eventEmitter.emit('blur', this.editorType);
   }
 
   destroy() {

--- a/apps/editor/src/markdown/mdEditor.ts
+++ b/apps/editor/src/markdown/mdEditor.ts
@@ -169,7 +169,7 @@ export default class MdEditor extends EditorBase {
         smartTask(this.context),
         dropImage(this.context, 'markdown'),
         placeholder(this.placeholder),
-        addWidget(),
+        addWidget(this.eventEmitter),
       ],
     });
   }

--- a/apps/editor/src/plugins/popupWidget.ts
+++ b/apps/editor/src/plugins/popupWidget.ts
@@ -1,7 +1,8 @@
 import { EditorView } from 'prosemirror-view';
 import { Plugin, PluginKey } from 'prosemirror-state';
-import { WidgetStyle } from '@t/editor';
 import css from 'tui-code-snippet/domUtil/css';
+import { WidgetStyle } from '@t/editor';
+import { Emitter } from '@t/event';
 
 interface Widget {
   node: HTMLElement;
@@ -14,11 +15,11 @@ const pluginKey = new PluginKey('widget');
 class PopupWidget {
   private popup: HTMLElement | null = null;
 
-  private view: EditorView;
+  private eventEmitter: Emitter;
 
-  constructor(view: EditorView) {
-    view.dom.addEventListener('blur', this.removeWidget);
-    this.view = view;
+  constructor(eventEmitter: Emitter) {
+    this.eventEmitter = eventEmitter;
+    this.eventEmitter.listen('blur', this.removeWidget);
   }
 
   private removeWidget = () => {
@@ -50,11 +51,11 @@ class PopupWidget {
   }
 
   destroy() {
-    this.view.dom.removeEventListener('blur', this.removeWidget);
+    this.eventEmitter.removeEventHandler('blur', this.removeWidget);
   }
 }
 
-export function addWidget() {
+export function addWidget(eventEmitter: Emitter) {
   return new Plugin({
     key: pluginKey,
     state: {
@@ -65,8 +66,8 @@ export function addWidget() {
         return tr.getMeta('widget');
       },
     },
-    view(editorView: EditorView) {
-      return new PopupWidget(editorView);
+    view() {
+      return new PopupWidget(eventEmitter);
     },
   });
 }

--- a/apps/editor/src/wysiwyg/wwEditor.ts
+++ b/apps/editor/src/wysiwyg/wwEditor.ts
@@ -102,7 +102,7 @@ export default class WysiwygEditor extends EditorBase {
         tableContextMenu(this.eventEmitter),
         task(),
         dropImage(this.context, 'wysiwyg'),
-        addWidget(),
+        addWidget(this.eventEmitter),
         toolbarState(this.eventEmitter),
       ],
       ...addedStates,


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
* changed DOM event to eventEmitter `blur` event


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
