### PR TITLE
fix: remove nbsp converting in markdown

### DIFF
--- a/apps/editor/src/__test__/unit/markdown/keymap.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/keymap.spec.ts
@@ -796,17 +796,18 @@ describe('move lines keymap', () => {
 describe('keep indentation in code block', () => {
   it('should keep indentation in next new line', () => {
     const input = stripIndent`
-      \`\`\`js
-      console.log('line1');
-          console.log('line2');
-      \`\`\`
+    \`\`\`js
+    console.log('line1');
+        console.log('line2');
+    \`\`\`
     `;
+
     const result = stripIndent`
-      \`\`\`js
-      console.log('line1');
-          console.log('line2');
-          
-      \`\`\`
+    \`\`\`js
+    console.log('line1');
+        console.log('line2');
+        
+    \`\`\`
     `;
 
     mde.setMarkdown(input);
@@ -821,7 +822,7 @@ describe('keep indentation in code block', () => {
     const input = stripIndent`
       \`\`\`js
       console.log('line1');
-          console.log('line2');
+          console.log('line2');
       \`\`\`
     `;
     const result = stripIndent`

--- a/apps/editor/src/__test__/unit/markdown/util.ts
+++ b/apps/editor/src/__test__/unit/markdown/util.ts
@@ -1,5 +1,4 @@
 import MarkdownEditor from '@/markdown/mdEditor';
-import { nbspToSpace } from '@/helper/manipulation';
 
 export function getTextContent(editor: MarkdownEditor) {
   const { doc } = editor.view.state;
@@ -14,5 +13,5 @@ export function getTextContent(editor: MarkdownEditor) {
     }
   });
 
-  return nbspToSpace(text);
+  return text;
 }

--- a/apps/editor/src/helper/manipulation.ts
+++ b/apps/editor/src/helper/manipulation.ts
@@ -34,34 +34,17 @@ export function insertNodes(
   );
 }
 
-export function nbspToSpace(text: string) {
-  return text.replace(/\u00a0/g, ' ');
-}
-
-export function spaceToNbsp(text: string) {
-  return text.replace(/ /g, '\u00a0');
-}
-
-export function createParagraph(
-  schema: Schema,
-  content?: string | ProsemirrorNode[],
-  spaceChange = true
-) {
+export function createParagraph(schema: Schema, content?: string | ProsemirrorNode[]) {
   const { paragraph } = schema.nodes;
 
   if (!content) {
     return paragraph.createAndFill()!;
   }
-
-  if (isString(content)) {
-    return paragraph.create(null, schema.text(spaceChange ? spaceToNbsp(content) : content));
-  }
-
-  return paragraph.create(null, content);
+  return paragraph.create(null, isString(content) ? schema.text(content) : content);
 }
 
-export function createText(schema: Schema, text: string, marks?: Mark[], spaceChange = true) {
-  return schema.text(spaceChange ? spaceToNbsp(text) : text, marks);
+export function createText(schema: Schema, text: string, marks?: Mark[]) {
+  return schema.text(text, marks);
 }
 
 export function createTextSelection(tr: Transaction, from: number, to = from) {

--- a/apps/editor/src/markdown/helper/query.ts
+++ b/apps/editor/src/markdown/helper/query.ts
@@ -1,6 +1,5 @@
 import { ProsemirrorNode } from 'prosemirror-model';
-import { nbspToSpace } from '@/helper/manipulation';
 
 export function getTextByMdLine(doc: ProsemirrorNode, mdLine: number) {
-  return nbspToSpace(doc.content.child(mdLine - 1).textContent);
+  return doc.content.child(mdLine - 1).textContent;
 }

--- a/apps/editor/src/markdown/marks/blockQuote.ts
+++ b/apps/editor/src/markdown/marks/blockQuote.ts
@@ -7,7 +7,6 @@ import {
   createParagraph,
   createTextSelection,
   insertNodes,
-  nbspToSpace,
   replaceNodes,
 } from '@/helper/manipulation';
 import { getExtendedRangeOffset, resolveSelectionPos } from '../helper/pos';
@@ -28,7 +27,6 @@ export class BlockQuote extends Mark {
   }
 
   private getChangedText(text: string, isBlockQuote?: boolean) {
-    text = nbspToSpace(text);
     if (isBlockQuote) {
       return text.replace(reBlockQuote, '').trim();
     }
@@ -40,7 +38,7 @@ export class BlockQuote extends Mark {
       const [, to] = resolveSelectionPos(selection);
       const startResolvedPos = doc.resolve(to);
 
-      const lineText = nbspToSpace(startResolvedPos.node().textContent);
+      const lineText = startResolvedPos.node().textContent;
       const isBlockQuote = reBlockQuote.test(lineText);
 
       const [startOffset, endOffset] = getExtendedRangeOffset(to, to, doc);
@@ -76,7 +74,7 @@ export class BlockQuote extends Mark {
       const [startOffset, endOffset] = getExtendedRangeOffset(from, to, doc);
       const startResolvedPos = doc.resolve(from);
 
-      const lineText = nbspToSpace(startResolvedPos.node().textContent);
+      const lineText = startResolvedPos.node().textContent;
       const isBlockQuote = reBlockQuote.test(lineText);
 
       const nodes: ProsemirrorNode[] = [];

--- a/apps/editor/src/markdown/mdEditor.ts
+++ b/apps/editor/src/markdown/mdEditor.ts
@@ -14,7 +14,7 @@ import EditorBase from '@/base';
 import SpecManager from '@/spec/specManager';
 import { cls, toggleClass } from '@/utils/dom';
 import { emitImageBlobHook, pasteImageOnly } from '@/helper/image';
-import { createTextSelection, nbspToSpace } from '@/helper/manipulation';
+import { createTextSelection } from '@/helper/manipulation';
 import { placeholder } from '@/plugins/placeholder';
 import { getDefaultCommands } from '@/commands/defaultCommands';
 import { dropImage } from '@/plugins/dropImage';
@@ -250,7 +250,7 @@ export default class MdEditor extends EditorBase {
       }
     });
 
-    return nbspToSpace(changed);
+    return changed;
   }
 
   setSelection(start: MdPos, end: MdPos) {

--- a/apps/editor/src/wysiwyg/marks/link.ts
+++ b/apps/editor/src/wysiwyg/marks/link.ts
@@ -70,7 +70,7 @@ export class Link extends Mark {
         const mark = schema.mark('link', attrs);
 
         if (empty && linkText) {
-          const node = createText(schema, linkText, mark, false);
+          const node = createText(schema, linkText, mark);
 
           tr.replaceRangeWith(from, to, node);
         } else {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
* removed unnecessary converting `nbsp` to space or space to `nbsp`


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
