### PR TITLE
fix: maintain html list in table when converting to markdown

### DIFF
--- a/apps/editor/src/convertors/toMarkdown/toMdConvertorState.ts
+++ b/apps/editor/src/convertors/toMarkdown/toMdConvertorState.ts
@@ -25,6 +25,8 @@ export default class ToMdConvertorState {
 
   public stopNewline: boolean;
 
+  public inTable: boolean;
+
   constructor({ nodeTypeConvertors, markTypeConvertors }: ToMdConvertors) {
     this.nodeTypeConvertors = nodeTypeConvertors;
     this.markTypeConvertors = markTypeConvertors;
@@ -33,6 +35,7 @@ export default class ToMdConvertorState {
     this.closed = false;
     this.tightList = false;
     this.stopNewline = false;
+    this.inTable = false;
   }
 
   private isInBlank() {
@@ -301,6 +304,7 @@ export default class ToMdConvertorState {
 
   convertTableCell(node: Node) {
     this.stopNewline = true;
+    this.inTable = true;
 
     node.forEach((child, _, index) => {
       if (includes(['bulletList', 'orderedList'], child.type.name)) {
@@ -320,6 +324,7 @@ export default class ToMdConvertorState {
     });
 
     this.stopNewline = false;
+    this.inTable = false;
   }
 
   convertNode(parent: Node) {

--- a/apps/editor/src/convertors/toMarkdown/toMdConvertors.ts
+++ b/apps/editor/src/convertors/toMarkdown/toMdConvertors.ts
@@ -88,21 +88,38 @@ export const toMdConvertors: ToMdConvertorMap = {
     };
   },
 
-  bulletList({ node }) {
+  bulletList({ node }, { inTable }) {
+    let { rawHTML } = node.attrs;
+
+    if (inTable) {
+      rawHTML = rawHTML || 'ul';
+    }
+
     return {
       delim: '*',
-      rawHTML: getPairRawHTML(node.attrs.rawHTML),
+      rawHTML: getPairRawHTML(rawHTML),
     };
   },
 
-  orderedList({ node }) {
+  orderedList({ node }, { inTable }) {
+    let { rawHTML } = node.attrs;
+
+    if (inTable) {
+      rawHTML = rawHTML || 'ol';
+    }
+
     return {
-      rawHTML: getPairRawHTML(node.attrs.rawHTML),
+      rawHTML: getPairRawHTML(rawHTML),
     };
   },
 
-  listItem({ node }) {
-    const { task, checked, rawHTML } = node.attrs;
+  listItem({ node }, { inTable }) {
+    const { task, checked } = node.attrs;
+    let { rawHTML } = node.attrs;
+
+    if (inTable) {
+      rawHTML = rawHTML || 'li';
+    }
 
     const className = task ? ` class="task-list-item${checked ? ' checked' : ''}"` : '';
     const dataset = task ? ` data-task${checked ? ` data-task-checked` : ''}` : '';
@@ -286,7 +303,11 @@ function createNodeTypeConvertors(convertors: ToMdConvertorMap) {
 
       if (writer) {
         const convertor = convertors[type];
-        const params = convertor ? convertor(nodeInfo as NodeInfo, {}) : {};
+        const params = convertor
+          ? convertor(nodeInfo as NodeInfo, {
+              inTable: state.inTable,
+            })
+          : {};
 
         write(type, { state, nodeInfo, params });
       }

--- a/apps/editor/types/convertor.d.ts
+++ b/apps/editor/types/convertor.d.ts
@@ -47,6 +47,7 @@ export type FirstDelimFn = (index: number) => string;
 
 export interface ToMdConvertorState {
   stopNewline: boolean;
+  inTable: boolean;
   flushClose(size?: number): void;
   wrapBlock(delim: string, firstDelim: string | null, node: ProsemirrorNode, fn: () => void): void;
   ensureNewLine(): void;
@@ -122,6 +123,7 @@ export type ToMdMarkTypeConvertorMap = Partial<Record<WwMarkType, ToMdMarkTypeCo
 interface ToMdConvertorContext {
   origin?: () => ReturnType<ToMdConvertor>;
   entering?: boolean;
+  inTable?: boolean;
 }
 
 type ToMdConvertor = (


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description

Fixed a problem where converting was broken when adding a list to a table in WYSIWYG.

#### AS-IS

![wrong](https://user-images.githubusercontent.com/18183560/109584193-76705d00-7b44-11eb-9106-52a2b7b1739a.gif)

#### TO-BE

![correct](https://user-images.githubusercontent.com/18183560/109584203-7c663e00-7b44-11eb-9b72-4ff2cc9c97e6.gif)

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
