### PR TITLE
fix: not create cursor when clicking table

### DIFF
--- a/apps/editor/src/css/contents.css
+++ b/apps/editor/src/css/contents.css
@@ -204,6 +204,7 @@ table.ProseMirror-selectednode {
 
 .tui-editor-contents td p {
   margin: 0;
+  padding: 0 2px;
 }
 
 .tui-editor-contents ul,


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description

Fix an issue where the cursor does not appear when selecting a table cell. As the paragraph was added to the table cells (`th`, `td`), the minimum width was not secured and the cursor disappeared.

#### AS-IS

![wrong](https://user-images.githubusercontent.com/18183560/109760031-5cf90f00-7c31-11eb-8868-545502f4369b.gif)

#### TO-BE

![correct](https://user-images.githubusercontent.com/18183560/109760042-62565980-7c31-11eb-817b-f8ec8a5f5e2c.gif)


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
