### PR TITLE
feat: add html block, inline schema to wysiwyg

### DIFF
--- a/apps/editor/src/__test__/integration/widget/widgetNode.spec.ts
+++ b/apps/editor/src/__test__/integration/widget/widgetNode.spec.ts
@@ -1,5 +1,6 @@
 import { oneLineTrim } from 'common-tags';
 import Editor from '@/editorCore';
+import { trailingDataAttr } from '@/__test__/unit/markdown/util';
 
 describe('widgetNode', () => {
   let container: HTMLElement,
@@ -9,10 +10,7 @@ describe('widgetNode', () => {
     editor: Editor;
 
   function getPreviewHTML() {
-    return mdPreview
-      .querySelector('.tui-editor-contents')!
-      .innerHTML.replace(/\sdata-nodeid="\d+"/g, '')
-      .trim();
+    return trailingDataAttr(mdPreview.querySelector('.tui-editor-contents')!.innerHTML);
   }
 
   beforeEach(() => {

--- a/apps/editor/src/__test__/unit/markdown/keymap.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/keymap.spec.ts
@@ -20,7 +20,7 @@ let mde: MarkdownEditor, em: EventEmitter;
 
 beforeEach(() => {
   em = new EventEmitter();
-  mde = new MarkdownEditor(new ToastMark(), em, true);
+  mde = new MarkdownEditor(em, { toastMark: new ToastMark() });
 });
 
 // @TODO: should add test case after developing the markdown editor API

--- a/apps/editor/src/__test__/unit/markdown/mdCommand.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/mdCommand.spec.ts
@@ -10,7 +10,7 @@ let mde: MarkdownEditor, em: EventEmitter, cmd: CommandManager;
 
 beforeEach(() => {
   em = new EventEmitter();
-  mde = new MarkdownEditor(new ToastMark(), em, true);
+  mde = new MarkdownEditor(em, { toastMark: new ToastMark() });
   cmd = new CommandManager(em, mde.commands, {});
 });
 

--- a/apps/editor/src/__test__/unit/markdown/mdEditor.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/mdEditor.spec.ts
@@ -17,7 +17,7 @@ describe('MarkdownEditor', () => {
 
   beforeEach(() => {
     em = new EventEmitter();
-    mde = new MarkdownEditor(new ToastMark(), em, true);
+    mde = new MarkdownEditor(em, { toastMark: new ToastMark() });
     el = mde.el;
     document.body.appendChild(el);
   });

--- a/apps/editor/src/__test__/unit/markdown/mdPreview.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/mdPreview.spec.ts
@@ -5,11 +5,18 @@ import MarkdownPreview, { CLASS_HIGHLIGHT } from '@/markdown/mdPreview';
 import MarkdownEditor from '@/markdown/mdEditor';
 import EventEmitter from '@/event/eventEmitter';
 import * as sanitizer from '@/sanitizer/htmlSanitizer';
+import { createHTMLrenderer, trailingDataAttr } from './util';
+
+function getHTML(preview: MarkdownPreview) {
+  return trailingDataAttr(preview.getHTML());
+}
 
 describe('Preview', () => {
   let eventEmitter: EventEmitter, preview: MarkdownPreview;
 
   beforeEach(() => {
+    jest.spyOn(sanitizer, 'sanitizeHTML');
+
     const options = {
       linkAttributes: null,
       customHTMLRenderer: {},
@@ -24,6 +31,7 @@ describe('Preview', () => {
   });
 
   afterEach(() => {
+    jest.restoreAllMocks();
     preview.destroy();
   });
 
@@ -33,12 +41,10 @@ describe('Preview', () => {
 
     eventEmitter.emit('updatePreview', editResult);
 
-    expect(preview.getHTML()).toBe(`<p data-nodeid="${editResult[0].nodes[0].id}">changed</p>\n`);
+    expect(getHTML(preview)).toBe('<p>changed</p>');
   });
 
   it('should call sanitizeHTML', () => {
-    jest.spyOn(sanitizer, 'sanitizeHTML');
-
     const doc = new ToastMark();
     const editResult = doc.editMarkdown(
       [1, 1],
@@ -204,5 +210,51 @@ describe('preview highlight', () => {
     blur();
 
     expect(getHighlightedCount()).toBe(0);
+  });
+});
+
+describe('Preview with html renderer', () => {
+  let eventEmitter: EventEmitter, preview: MarkdownPreview;
+
+  function createPreviewWithHTMLRenderer() {
+    const options = {
+      linkAttributes: null,
+      customHTMLRenderer: createHTMLrenderer(),
+      isViewer: false,
+      highlight: true,
+      sanitizer: sanitizer.sanitizeHTML,
+    };
+
+    eventEmitter = new EventEmitter();
+
+    preview = new MarkdownPreview(eventEmitter, options);
+  }
+
+  beforeEach(() => {
+    createPreviewWithHTMLRenderer();
+  });
+
+  it('should render iframe node to preview ignoring sanitizer tag', () => {
+    const doc = new ToastMark();
+    const editResult = doc.editMarkdown(
+      [1, 1],
+      [1, 1],
+      '<iframe width="420" height="315" src="https://www.youtube.com/embed/XyenY12fzAk"></iframe>'
+    );
+
+    eventEmitter.emit('updatePreview', editResult);
+
+    expect(getHTML(preview)).toBe(
+      '<iframe width="420" height="315" src="https://www.youtube.com/embed/XyenY12fzAk"></iframe>'
+    );
+  });
+
+  it('should render html inline node', () => {
+    const doc = new ToastMark();
+    const editResult = doc.editMarkdown([1, 1], [1, 1], '<big class="my-big">content</big>');
+
+    eventEmitter.emit('updatePreview', editResult);
+
+    expect(getHTML(preview)).toBe('<p><big class="my-big">content</big></p>');
   });
 });

--- a/apps/editor/src/__test__/unit/markdown/mdPreview.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/mdPreview.spec.ts
@@ -225,6 +225,8 @@ describe('Preview with html renderer', () => {
       sanitizer: sanitizer.sanitizeHTML,
     };
 
+    sanitizer.registerWhiteTaglistIfPossible('iframe');
+
     eventEmitter = new EventEmitter();
 
     preview = new MarkdownPreview(eventEmitter, options);

--- a/apps/editor/src/__test__/unit/markdown/mdPreview.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/mdPreview.spec.ts
@@ -15,6 +15,7 @@ describe('Preview', () => {
       customHTMLRenderer: {},
       isViewer: false,
       highlight: true,
+      sanitizer: sanitizer.sanitizeHTML,
     };
 
     eventEmitter = new EventEmitter();
@@ -63,6 +64,7 @@ describe('preview highlight', () => {
       customHTMLRenderer: {},
       isViewer: false,
       highlight,
+      sanitizer: sanitizer.sanitizeHTML,
     };
 
     eventEmitter = new EventEmitter();

--- a/apps/editor/src/__test__/unit/markdown/mdPreview.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/mdPreview.spec.ts
@@ -226,9 +226,7 @@ describe('Preview with html renderer', () => {
     };
 
     sanitizer.registerWhiteTaglistIfPossible('iframe');
-
     eventEmitter = new EventEmitter();
-
     preview = new MarkdownPreview(eventEmitter, options);
   }
 

--- a/apps/editor/src/__test__/unit/markdown/mdPreview.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/mdPreview.spec.ts
@@ -225,7 +225,7 @@ describe('Preview with html renderer', () => {
       sanitizer: sanitizer.sanitizeHTML,
     };
 
-    sanitizer.registerWhiteTaglistIfPossible('iframe');
+    sanitizer.registerTagWhitelistIfPossible('iframe');
     eventEmitter = new EventEmitter();
     preview = new MarkdownPreview(eventEmitter, options);
   }

--- a/apps/editor/src/__test__/unit/markdown/mdPreview.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/mdPreview.spec.ts
@@ -74,7 +74,7 @@ describe('preview highlight', () => {
     };
 
     eventEmitter = new EventEmitter();
-    editor = new MarkdownEditor(new ToastMark(), eventEmitter, true);
+    editor = new MarkdownEditor(eventEmitter, { toastMark: new ToastMark() });
     preview = new MarkdownPreview(eventEmitter, options);
     editorEl = editor.getElement();
 

--- a/apps/editor/src/__test__/unit/markdown/smartTask.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/smartTask.spec.ts
@@ -18,7 +18,7 @@ function dispatchKeyup() {
 
 beforeEach(() => {
   em = new EventEmitter();
-  mde = new MarkdownEditor(new ToastMark(), em, true);
+  mde = new MarkdownEditor(em, { toastMark: new ToastMark() });
 });
 
 afterEach(() => {

--- a/apps/editor/src/__test__/unit/markdown/syntaxHighlight.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/syntaxHighlight.spec.ts
@@ -12,7 +12,7 @@ let mde: MarkdownEditor, em: EventEmitter;
 
 beforeEach(() => {
   em = new EventEmitter();
-  mde = new MarkdownEditor(new ToastMark(), em, true);
+  mde = new MarkdownEditor(em, { toastMark: new ToastMark() });
 });
 
 afterEach(() => {

--- a/apps/editor/src/__test__/unit/markdown/util.ts
+++ b/apps/editor/src/__test__/unit/markdown/util.ts
@@ -1,4 +1,5 @@
 import MarkdownEditor from '@/markdown/mdEditor';
+import { CustomHTMLRendererMap } from '@t/markdown';
 
 export function getTextContent(editor: MarkdownEditor) {
   const { doc } = editor.view.state;
@@ -14,4 +15,33 @@ export function getTextContent(editor: MarkdownEditor) {
   });
 
   return text;
+}
+
+export function trailingDataAttr(html: string) {
+  return html.replace(/\sdata-nodeid="\d{1,}"/g, '').trim();
+}
+
+export function createHTMLrenderer() {
+  const customHTMLRenderer: CustomHTMLRendererMap = {
+    htmlBlock: {
+      // @ts-ignore
+      iframe(node: MdLikeNode) {
+        return [
+          { type: 'openTag', tagName: 'iframe', outerNewLine: true, attributes: node.attrs },
+          { type: 'html', content: node.childrenHTML },
+          { type: 'closeTag', tagName: 'iframe', outerNewLine: true },
+        ];
+      },
+    },
+    htmlInline: {
+      // @ts-ignore
+      big(node: MdLikeNode, { entering }: Context) {
+        return entering
+          ? { type: 'openTag', tagName: 'big', attributes: node.attrs }
+          : { type: 'closeTag', tagName: 'big' };
+      },
+    },
+  };
+
+  return customHTMLRenderer;
 }

--- a/apps/editor/src/__test__/unit/sanitizer.spec.ts
+++ b/apps/editor/src/__test__/unit/sanitizer.spec.ts
@@ -1,9 +1,9 @@
-import { sanitizeHTML } from '@/sanitizer/htmlSanitizer';
+import { registerWhiteTaglistIfPossible, sanitizeHTML } from '@/sanitizer/htmlSanitizer';
 
 describe('sanitizeHTML', () => {
   it('removes unnecessary tags', () => {
     expect(sanitizeHTML('<script>alert("test");</script>')).toBe('');
-    expect(sanitizeHTML('<embed>child alive</embed>')).toBe('child alive');
+    expect(sanitizeHTML('<embed type="image/jpg" src="">')).toBe('');
     expect(sanitizeHTML('<object>child die</object>')).toBe('');
     expect(sanitizeHTML('<details><summary>foo</summary></details>')).toBe('');
     expect(sanitizeHTML('<input type="image" />')).toBe('');
@@ -48,6 +48,26 @@ describe('sanitizeHTML', () => {
         expect(sanitizeHTML('<img src=x:alert(alt) onerror=eval(src) alt=0>')).toBe(
           '<img alt="0">'
         );
+      });
+    });
+
+    describe('registerWhiteTaglistIfPossible', () => {
+      it('if possible, should keep the tags when registered in the white tag list', () => {
+        registerWhiteTaglistIfPossible('embed');
+        registerWhiteTaglistIfPossible('iframe');
+
+        expect(sanitizeHTML('<iframe src=""></iframe>')).toBe('<iframe src=""></iframe>');
+        expect(sanitizeHTML('<embed type="image/jpg" src="">')).toBe(
+          '<embed type="image/jpg" src="">'
+        );
+      });
+
+      it('should remove the tags in case that the tag name cannot be white list', () => {
+        registerWhiteTaglistIfPossible('sript');
+        registerWhiteTaglistIfPossible('input');
+
+        expect(sanitizeHTML('<script>alert("test");</script>')).toBe('');
+        expect(sanitizeHTML('<input type="image" />')).toBe('');
       });
     });
   });

--- a/apps/editor/src/__test__/unit/sanitizer.spec.ts
+++ b/apps/editor/src/__test__/unit/sanitizer.spec.ts
@@ -2,89 +2,50 @@ import { sanitizeHTML } from '@/sanitizer/htmlSanitizer';
 
 describe('sanitizeHTML', () => {
   it('removes unnecessary tags', () => {
-    expect(sanitizeHTML('<script>alert("test");</script>', true)).toBe('');
-    expect(sanitizeHTML('<embed>child alive</embed>', true)).toBe('child alive');
-    expect(sanitizeHTML('<object>child die</object>', true)).toBe('');
-    expect(sanitizeHTML('<details><summary>foo</summary></details>', true)).toBe('');
-    expect(sanitizeHTML('<input type="image" />', true)).toBe('');
+    expect(sanitizeHTML('<script>alert("test");</script>')).toBe('');
+    expect(sanitizeHTML('<embed>child alive</embed>')).toBe('child alive');
+    expect(sanitizeHTML('<object>child die</object>')).toBe('');
+    expect(sanitizeHTML('<details><summary>foo</summary></details>')).toBe('');
+    expect(sanitizeHTML('<input type="image" />')).toBe('');
   });
 
   describe('attributes', () => {
-    it('removes all attribute but white list', () => {
-      const html =
-        '<img style="display:inline" class="V" title="V" data-custom="V" src="http://www.nhn.com/renewal/img/ci_nhn.png" onload="dd=1" onerror="javascript:alert();"/>';
-
-      const dom = sanitizeHTML(html);
-      const img = (dom as DocumentFragment).querySelector('img');
-
-      expect(img).toHaveAttribute('src');
-      expect(img).toHaveAttribute('class');
-      expect(img).toHaveAttribute('title');
-      expect(img).toHaveAttribute('style');
-      expect(img).toHaveAttribute('data-custom');
-
-      expect(img).not.toHaveAttribute('onload');
-      expect(img).not.toHaveAttribute('onerror');
-    });
-
-    it('leaves svg attributes', () => {
-      const html =
-        '<svg width="100" height="100"><circle cx="50" cy="50" r="40" stroke="green" stroke-width="4" fill="yellow" /></svg>';
-
-      const dom = sanitizeHTML(html);
-      const circle = (dom as DocumentFragment).querySelector('circle');
-
-      expect(circle).toHaveAttribute('cx');
-      expect(circle).toHaveAttribute('cy');
-      expect(circle).toHaveAttribute('r');
-      expect(circle).toHaveAttribute('stroke');
-      expect(circle).toHaveAttribute('stroke-width');
-      expect(circle).toHaveAttribute('fill');
-    });
-
     describe('removes attributes with invalid value including xss script', () => {
       it('table', () => {
-        expect(sanitizeHTML(`<TABLE BACKGROUND="javascript:alert('XSS')">`, true)).toBe(
+        expect(sanitizeHTML(`<TABLE BACKGROUND="javascript:alert('XSS')">`)).toBe(
           '<table></table>'
         );
-        expect(sanitizeHTML(`<TABLE><TD BACKGROUND="javascript:alert('XSS')"></TD>`, true)).toBe(
+        expect(sanitizeHTML(`<TABLE><TD BACKGROUND="javascript:alert('XSS')"></TD>`)).toBe(
           '<table><tbody><tr><td></td></tr></tbody></table>'
         );
       });
 
       it('href attribute with a tag', () => {
-        expect(sanitizeHTML('<a href="javascript:alert();">xss</a>', true)).toBe('<a>xss</a>');
-        expect(sanitizeHTML('<a href="  JaVaScRiPt: alert();">xss</a>', true)).toBe('<a>xss</a>');
-        expect(sanitizeHTML('<a href="vbscript:alert();">xss</a>', true)).toBe('<a>xss</a>');
-        expect(sanitizeHTML('<a href="  VBscript: alert(); ">xss</a>', true)).toBe('<a>xss</a>');
-        expect(sanitizeHTML('<a href="livescript:alert();">xss</a>', true)).toBe('<a>xss</a>');
-        expect(sanitizeHTML('<a href="  LIVEScript: alert() ;">xss</a>', true)).toBe('<a>xss</a>');
-        expect(sanitizeHTML(`123<a href=' javascript:alert();'>xss</a>`, true)).toBe(
-          '123<a>xss</a>'
-        );
-        expect(sanitizeHTML(`<a href='javas<!-- -->cript:alert()'>xss</a>`, true)).toBe(
-          '<a>xss</a>'
-        );
+        expect(sanitizeHTML('<a href="javascript:alert();">xss</a>')).toBe('<a>xss</a>');
+        expect(sanitizeHTML('<a href="  JaVaScRiPt: alert();">xss</a>')).toBe('<a>xss</a>');
+        expect(sanitizeHTML('<a href="vbscript:alert();">xss</a>')).toBe('<a>xss</a>');
+        expect(sanitizeHTML('<a href="  VBscript: alert(); ">xss</a>')).toBe('<a>xss</a>');
+        expect(sanitizeHTML('<a href="livescript:alert();">xss</a>')).toBe('<a>xss</a>');
+        expect(sanitizeHTML('<a href="  LIVEScript: alert() ;">xss</a>')).toBe('<a>xss</a>');
+        expect(sanitizeHTML(`123<a href=' javascript:alert();'>xss</a>`)).toBe('123<a>xss</a>');
+        expect(sanitizeHTML(`<a href='javas<!-- -->cript:alert()'>xss</a>`)).toBe('<a>xss</a>');
       });
 
       it('src attribute with img tag', () => {
-        expect(sanitizeHTML('<img src="javascript:alert();">', true)).toBe('<img>');
-        expect(sanitizeHTML('<img src="  JaVaScRiPt: alert();">', true)).toBe('<img>');
-        expect(sanitizeHTML('<img src="vbscript:alert();">', true)).toBe('<img>');
-        expect(sanitizeHTML('<img src="  VBscript: alert(); ">', true)).toBe('<img>');
-        expect(sanitizeHTML('<img src="  LIVEScript: alert() ;">', true)).toBe('<img>');
-        expect(sanitizeHTML('<img src="java<!-- -->script:alert();">', true)).toBe('<img>');
+        expect(sanitizeHTML('<img src="javascript:alert();">')).toBe('<img>');
+        expect(sanitizeHTML('<img src="  JaVaScRiPt: alert();">')).toBe('<img>');
+        expect(sanitizeHTML('<img src="vbscript:alert();">')).toBe('<img>');
+        expect(sanitizeHTML('<img src="  VBscript: alert(); ">')).toBe('<img>');
+        expect(sanitizeHTML('<img src="  LIVEScript: alert() ;">')).toBe('<img>');
+        expect(sanitizeHTML('<img src="java<!-- -->script:alert();">')).toBe('<img>');
       });
 
       it('src and onerror attribute with img tag', () => {
         expect(
-          sanitizeHTML(
-            '<img src = x onerror = "javascript: window.onerror = alert; throw XSS">',
-            true
-          )
+          sanitizeHTML('<img src = x onerror = "javascript: window.onerror = alert; throw XSS">')
         ).toBe('<img src="x">');
-        expect(sanitizeHTML('"><img src="x:x" onerror="alert(XSS)">', true)).toBe('"&gt;<img>');
-        expect(sanitizeHTML('<img src=x:alert(alt) onerror=eval(src) alt=0>', true)).toBe(
+        expect(sanitizeHTML('"><img src="x:x" onerror="alert(XSS)">')).toBe('"&gt;<img>');
+        expect(sanitizeHTML('<img src=x:alert(alt) onerror=eval(src) alt=0>')).toBe(
           '<img alt="0">'
         );
       });

--- a/apps/editor/src/__test__/unit/sanitizer.spec.ts
+++ b/apps/editor/src/__test__/unit/sanitizer.spec.ts
@@ -1,4 +1,4 @@
-import { registerWhiteTaglistIfPossible, sanitizeHTML } from '@/sanitizer/htmlSanitizer';
+import { registerTagWhitelistIfPossible, sanitizeHTML } from '@/sanitizer/htmlSanitizer';
 
 describe('sanitizeHTML', () => {
   it('removes unnecessary tags', () => {
@@ -51,10 +51,10 @@ describe('sanitizeHTML', () => {
       });
     });
 
-    describe('registerWhiteTaglistIfPossible', () => {
+    describe('registerTagWhitelistIfPossible', () => {
       it('if possible, should keep the tags when registered in the white tag list', () => {
-        registerWhiteTaglistIfPossible('embed');
-        registerWhiteTaglistIfPossible('iframe');
+        registerTagWhitelistIfPossible('embed');
+        registerTagWhitelistIfPossible('iframe');
 
         expect(sanitizeHTML('<iframe src=""></iframe>')).toBe('<iframe src=""></iframe>');
         expect(sanitizeHTML('<embed type="image/jpg" src="">')).toBe(
@@ -63,8 +63,8 @@ describe('sanitizeHTML', () => {
       });
 
       it('should remove the tags in case that the tag name cannot be white list', () => {
-        registerWhiteTaglistIfPossible('sript');
-        registerWhiteTaglistIfPossible('input');
+        registerTagWhitelistIfPossible('sript');
+        registerTagWhitelistIfPossible('input');
 
         expect(sanitizeHTML('<script>alert("test");</script>')).toBe('');
         expect(sanitizeHTML('<input type="image" />')).toBe('');

--- a/apps/editor/src/__test__/unit/viewer.spec.ts
+++ b/apps/editor/src/__test__/unit/viewer.spec.ts
@@ -1,13 +1,14 @@
 import { oneLineTrim } from 'common-tags';
 import Viewer from '@/viewer';
+import { trailingDataAttr } from './markdown/util';
 
 describe('Viewer', () => {
   let viewer: Viewer, container: HTMLElement;
 
   function getViewerHTML() {
-    return oneLineTrim`${container
-      .querySelector('.tui-editor-contents')!
-      .innerHTML.replace(/\sdata-nodeid="\d{1,}"/g, '')}`;
+    return oneLineTrim`${trailingDataAttr(
+      container.querySelector('.tui-editor-contents')!.innerHTML
+    )}`;
   }
 
   beforeEach(() => {

--- a/apps/editor/src/__test__/unit/wysiwyg/customBlock.spec.ts
+++ b/apps/editor/src/__test__/unit/wysiwyg/customBlock.spec.ts
@@ -35,7 +35,6 @@ beforeEach(() => {
   toDOMAdaptor = new WwToDOMAdaptor({}, convertors);
   em = new EventEmitter();
   wwe = new WysiwygEditor(em, toDOMAdaptor, true);
-
   wwe.setModel(createCustomBlockNode());
 });
 

--- a/apps/editor/src/__test__/unit/wysiwyg/customBlock.spec.ts
+++ b/apps/editor/src/__test__/unit/wysiwyg/customBlock.spec.ts
@@ -34,7 +34,7 @@ beforeEach(() => {
 
   toDOMAdaptor = new WwToDOMAdaptor({}, convertors);
   em = new EventEmitter();
-  wwe = new WysiwygEditor(em, toDOMAdaptor, true);
+  wwe = new WysiwygEditor(em, { toDOMAdaptor });
   wwe.setModel(createCustomBlockNode());
 });
 

--- a/apps/editor/src/__test__/unit/wysiwyg/keymap.spec.ts
+++ b/apps/editor/src/__test__/unit/wysiwyg/keymap.spec.ts
@@ -42,10 +42,10 @@ describe('keymap', () => {
   }
 
   beforeEach(() => {
-    const adaptor = new WwToDOMAdaptor({}, {});
+    const toDOMAdaptor = new WwToDOMAdaptor({}, {});
 
     em = new EventEmitter();
-    wwe = new WysiwygEditor(em, adaptor, true);
+    wwe = new WysiwygEditor(em, { toDOMAdaptor });
   });
 
   afterEach(() => {

--- a/apps/editor/src/__test__/unit/wysiwyg/wwCommand.spec.ts
+++ b/apps/editor/src/__test__/unit/wysiwyg/wwCommand.spec.ts
@@ -32,10 +32,10 @@ describe('wysiwyg commands', () => {
   }
 
   beforeEach(() => {
-    const adaptor = new WwToDOMAdaptor({}, {});
+    const toDOMAdaptor = new WwToDOMAdaptor({}, {});
 
     em = new EventEmitter();
-    wwe = new WysiwygEditor(em, adaptor, true);
+    wwe = new WysiwygEditor(em, { toDOMAdaptor });
     cmd = new CommandManager(em, {}, wwe.commands);
   });
 
@@ -523,10 +523,10 @@ describe('wysiwyg commands', () => {
         target: '_blank',
         rel: 'noopener noreferrer',
       };
-      const adaptor = new WwToDOMAdaptor({}, {});
+      const toDOMAdaptor = new WwToDOMAdaptor({}, {});
 
       em = new EventEmitter();
-      wwe = new WysiwygEditor(em, adaptor, true, linkAttributes);
+      wwe = new WysiwygEditor(em, { toDOMAdaptor, linkAttributes });
       cmd = new CommandManager(em, {}, wwe.commands);
     });
 

--- a/apps/editor/src/__test__/unit/wysiwyg/wwEditor.spec.ts
+++ b/apps/editor/src/__test__/unit/wysiwyg/wwEditor.spec.ts
@@ -24,11 +24,11 @@ describe('WysiwygEditor', () => {
 
   beforeEach(() => {
     const htmlRenderer = createHTMLrenderer();
-    const adaptor = new WwToDOMAdaptor({}, htmlRenderer);
-    const htmlSchemaMap = createHTMLSchemaMap(htmlRenderer, sanitizeHTML, adaptor);
+    const toDOMAdaptor = new WwToDOMAdaptor({}, htmlRenderer);
+    const htmlSchemaMap = createHTMLSchemaMap(htmlRenderer, sanitizeHTML, toDOMAdaptor);
 
     em = new EventEmitter();
-    wwe = new WysiwygEditor(em, adaptor, htmlSchemaMap);
+    wwe = new WysiwygEditor(em, { toDOMAdaptor, htmlSchemaMap });
     el = wwe.el;
     document.body.appendChild(el);
   });

--- a/apps/editor/src/__test__/unit/wysiwyg/wwEditor.spec.ts
+++ b/apps/editor/src/__test__/unit/wysiwyg/wwEditor.spec.ts
@@ -5,6 +5,9 @@ import { DOMParser } from 'prosemirror-model';
 import WysiwygEditor from '@/wysiwyg/wwEditor';
 import EventEmitter from '@/event/eventEmitter';
 import { WwToDOMAdaptor } from '@/wysiwyg/adaptor/wwToDOMAdaptor';
+import { createHTMLSchemaMap } from '@/wysiwyg/nodes/html';
+import { sanitizeHTML } from '@/sanitizer/htmlSanitizer';
+import { createHTMLrenderer } from '../markdown/util';
 
 describe('WysiwygEditor', () => {
   let wwe: WysiwygEditor, em: EventEmitter, el: HTMLElement;
@@ -20,10 +23,12 @@ describe('WysiwygEditor', () => {
   }
 
   beforeEach(() => {
-    const adaptor = new WwToDOMAdaptor({}, {});
+    const htmlRenderer = createHTMLrenderer();
+    const adaptor = new WwToDOMAdaptor({}, htmlRenderer);
+    const htmlSchemaMap = createHTMLSchemaMap(htmlRenderer, sanitizeHTML, adaptor);
 
     em = new EventEmitter();
-    wwe = new WysiwygEditor(em, adaptor, true);
+    wwe = new WysiwygEditor(em, adaptor, htmlSchemaMap);
     el = wwe.el;
     document.body.appendChild(el);
   });
@@ -154,5 +159,29 @@ describe('WysiwygEditor', () => {
     wwe.setSelection(3, 3);
 
     expect(spy).toHaveBeenCalled();
+  });
+
+  it('should display html block element properly', () => {
+    setContent(
+      '<iframe width="420" height="315" src="https://www.youtube.com/embed/XyenY12fzAk"></iframe>'
+    );
+
+    expect(wwe.getHTML()).toBe(
+      '<iframe width="420" height="315" src="https://www.youtube.com/embed/XyenY12fzAk" class="html-block ProseMirror-selectednode" draggable="true"></iframe>'
+    );
+  });
+
+  it('should display html inline element properly', () => {
+    setContent('<big class="my-inline">text</big>');
+
+    expect(wwe.getHTML()).toBe('<p><big class="my-inline">text</big><br></p>');
+  });
+
+  it('should sanitize html element', () => {
+    setContent('<iframe width="420" height="315" src="javascript: alert(1);"></iframe>');
+
+    expect(wwe.getHTML()).toBe(
+      '<iframe width="420" height="315" class="html-block ProseMirror-selectednode" draggable="true"></iframe>'
+    );
   });
 });

--- a/apps/editor/src/__test__/unit/wysiwyg/wwTableCommand.spec.ts
+++ b/apps/editor/src/__test__/unit/wysiwyg/wwTableCommand.spec.ts
@@ -43,10 +43,10 @@ describe('wysiwyg table commands', () => {
   }
 
   beforeEach(() => {
-    const adaptor = new WwToDOMAdaptor({}, {});
+    const toDOMAdaptor = new WwToDOMAdaptor({}, {});
 
     em = new EventEmitter();
-    wwe = new WysiwygEditor(em, adaptor, true);
+    wwe = new WysiwygEditor(em, { toDOMAdaptor });
     cmd = new CommandManager(em, {}, wwe.commands);
   });
 

--- a/apps/editor/src/__test__/unit/wysiwyg/wwToDOMAdaptor.spec.ts
+++ b/apps/editor/src/__test__/unit/wysiwyg/wwToDOMAdaptor.spec.ts
@@ -6,6 +6,8 @@ import { WwToDOMAdaptor } from '@/wysiwyg/adaptor/wwToDOMAdaptor';
 import EventEmitter from '@/event/eventEmitter';
 import WysiwygEditor from '@/wysiwyg/wwEditor';
 import { createMdLikeNode } from '@/wysiwyg/adaptor/mdLikeNode';
+import { createHTMLSchemaMap } from '@/wysiwyg/nodes/html';
+import { sanitizeHTML } from '@/sanitizer/htmlSanitizer';
 
 let wwe: WysiwygEditor, em: EventEmitter, toDOMAdaptor: ToDOMAdaptor;
 
@@ -68,11 +70,32 @@ beforeEach(() => {
         classNames: ['custom-emph'],
       };
     },
+    htmlBlock: {
+      // @ts-ignore
+      nav(node) {
+        return [
+          { type: 'openTag', tagName: 'nav', outerNewLine: true, attributes: node.attrs },
+          { type: 'html', content: node.childrenHTML },
+          { type: 'closeTag', tagName: 'nav', outerNewLine: true },
+        ];
+      },
+    },
+    htmlInline: {
+      // @ts-ignore
+      big(node: MdLikeNode, { entering }: Context) {
+        return entering
+          ? { type: 'openTag', tagName: 'big', attributes: { class: node.attrs.class } }
+          : { type: 'closeTag', tagName: 'big' };
+      },
+    },
   };
 
   toDOMAdaptor = new WwToDOMAdaptor({}, convertors);
   em = new EventEmitter();
-  wwe = new WysiwygEditor(em, toDOMAdaptor, true);
+
+  const htmlSchemaMap = createHTMLSchemaMap(convertors, sanitizeHTML, toDOMAdaptor);
+
+  wwe = new WysiwygEditor(em, toDOMAdaptor, htmlSchemaMap);
 });
 
 afterEach(() => {
@@ -195,6 +218,34 @@ describe('mdLikeNode', () => {
       destination: 'myLinkUrl',
     });
   });
+
+  it('html block should be changed to markdown-like-node', () => {
+    const navNode = createMdLikeNode(
+      createNode('nav', {
+        htmlAttrs: { class: 'my-nav', 'data-my-nav': 'my-nav' },
+        childrenHTML: 'text',
+      })
+    );
+
+    expect(navNode).toEqual({
+      type: 'nav',
+      literal: '',
+      wysiwygNode: true,
+      attrs: { class: 'my-nav', 'data-my-nav': 'my-nav' },
+      childrenHTML: 'text',
+    });
+  });
+
+  it('html inline should be changed to markdown-like-node', () => {
+    const bigNode = createMdLikeNode(createNode('big', { htmlAttrs: { class: 'my-big' } }));
+
+    expect(bigNode).toEqual({
+      type: 'big',
+      literal: '',
+      wysiwygNode: true,
+      attrs: { class: 'my-big' },
+    });
+  });
 });
 
 describe('wysiwyg adaptor toDOM using custom renderer', () => {
@@ -242,6 +293,25 @@ describe('wysiwyg adaptor toDOM using custom renderer', () => {
     const toDOM = toDOMAdaptor.getToDOM('blockQuote');
 
     expect(toDOM).toBe(null);
+  });
+
+  it('toDOM should be parsed with the html block renderer tokens', () => {
+    const toDOM = toDOMAdaptor.getToDOM('nav')!;
+    const navNode = createNode('nav', {
+      htmlAttrs: { class: 'my-nav' },
+      childrenHTML: 'text',
+    });
+
+    expect(toDOM(navNode)).toEqual(['nav', { class: 'my-nav' }, 0]);
+  });
+
+  it('toDOM should be parsed with the html inline renderer tokens', () => {
+    const toDOM = toDOMAdaptor.getToDOM('big')!;
+    const navNode = createNode('big', {
+      htmlAttrs: { class: 'my-big', 'data-my-attr': 'my-attr' },
+    });
+
+    expect(toDOM(navNode)).toEqual(['big', { class: 'my-big' }, 0]);
   });
 });
 
@@ -294,5 +364,38 @@ describe('wysiwyg adaptor toDOMNode using custom renderer', () => {
     const toDOMNode = toDOMAdaptor.getToDOMNode('blockQuote');
 
     expect(toDOMNode).toBe(null);
+  });
+
+  it('toDOMNode should be parsed with the html block renderer tokens', () => {
+    const toDOMNode = toDOMAdaptor.getToDOMNode('nav')!;
+    const navNode = createNode('nav', {
+      htmlAttrs: { class: 'my-nav' },
+      childrenHTML: 'text',
+    });
+
+    const expected = oneLineTrim`
+      <nav class="my-nav">
+        text
+      </nav>
+    `;
+
+    expect(getHTML(toDOMNode(navNode))).toBe(expected);
+  });
+
+  it('toDOMNode should be parsed with the html inline renderer tokens', () => {
+    const toDOMNode = toDOMAdaptor.getToDOMNode('big')!;
+    const bigNode = createNode(
+      'big',
+      {
+        htmlAttrs: { class: 'my-big', 'data-my-attr': 'my-attr' },
+      },
+      createText('text')
+    );
+
+    const expected = oneLineTrim`
+      <big class="my-big">text</big>
+    `;
+
+    expect(getHTML(toDOMNode(bigNode))).toBe(expected);
   });
 });

--- a/apps/editor/src/__test__/unit/wysiwyg/wwToDOMAdaptor.spec.ts
+++ b/apps/editor/src/__test__/unit/wysiwyg/wwToDOMAdaptor.spec.ts
@@ -95,7 +95,7 @@ beforeEach(() => {
 
   const htmlSchemaMap = createHTMLSchemaMap(convertors, sanitizeHTML, toDOMAdaptor);
 
-  wwe = new WysiwygEditor(em, toDOMAdaptor, htmlSchemaMap);
+  wwe = new WysiwygEditor(em, { toDOMAdaptor, htmlSchemaMap });
 });
 
 afterEach(() => {

--- a/apps/editor/src/base.ts
+++ b/apps/editor/src/base.ts
@@ -6,7 +6,7 @@ import { baseKeymap } from 'prosemirror-commands';
 import { InputRule, inputRules } from 'prosemirror-inputrules';
 import { history } from 'prosemirror-history';
 import css from 'tui-code-snippet/domUtil/css';
-import { WidgetStyle, EditorType, EditorPos, Base, NodeRangeInfo, SchemaMap } from '@t/editor';
+import { WidgetStyle, EditorType, EditorPos, Base, NodeRangeInfo } from '@t/editor';
 import { Emitter } from '@t/event';
 import { MdSourcepos } from '@t/markdown';
 import { Context, EditorAllCommandMap } from '@t/spec';
@@ -127,9 +127,9 @@ export default abstract class EditorBase implements Base {
     return rules.length ? inputRules({ rules }) : null;
   }
 
-  createSchema(htmlSchemaMap?: SchemaMap) {
+  createSchema() {
     return new Schema({
-      nodes: { ...this.specs.nodes, ...htmlSchemaMap },
+      nodes: this.specs.nodes,
       marks: this.specs.marks,
     });
   }

--- a/apps/editor/src/base.ts
+++ b/apps/editor/src/base.ts
@@ -6,7 +6,7 @@ import { baseKeymap } from 'prosemirror-commands';
 import { InputRule, inputRules } from 'prosemirror-inputrules';
 import { history } from 'prosemirror-history';
 import css from 'tui-code-snippet/domUtil/css';
-import { WidgetStyle, EditorType, EditorPos, Base, NodeRangeInfo } from '@t/editor';
+import { WidgetStyle, EditorType, EditorPos, Base, NodeRangeInfo, SchemaMap } from '@t/editor';
 import { Emitter } from '@t/event';
 import { MdSourcepos } from '@t/markdown';
 import { Context, EditorAllCommandMap } from '@t/spec';
@@ -127,9 +127,9 @@ export default abstract class EditorBase implements Base {
     return rules.length ? inputRules({ rules }) : null;
   }
 
-  createSchema() {
+  createSchema(htmlSchemaMap?: SchemaMap) {
     return new Schema({
-      nodes: this.specs.nodes,
+      nodes: { ...this.specs.nodes, ...htmlSchemaMap },
       marks: this.specs.marks,
     });
   }

--- a/apps/editor/src/convertors/toMarkdown/toMdConvertorState.ts
+++ b/apps/editor/src/convertors/toMarkdown/toMdConvertorState.ts
@@ -132,10 +132,11 @@ export default class ToMdConvertorState {
   convertBlock(node: Node, parent: Node, index: number) {
     const type = node.type.name as WwNodeType;
     const convertor = this.nodeTypeConvertors[type];
+    const nodeInfo = { node, parent, index };
 
-    if (convertor) {
-      const nodeInfo = { node, parent, index };
-
+    if (node.attrs.htmlAttrs) {
+      this.nodeTypeConvertors.html!(this, nodeInfo);
+    } else if (convertor) {
       convertor(this, nodeInfo);
     }
   }

--- a/apps/editor/src/convertors/toMarkdown/toMdConvertors.ts
+++ b/apps/editor/src/convertors/toMarkdown/toMdConvertors.ts
@@ -268,6 +268,26 @@ export const toMdConvertors: ToMdConvertorMap = {
       rawHTML,
     };
   },
+
+  // html inline node, html block node
+  html({ node }) {
+    const content = node.attrs.inline
+      ? (node as ProsemirrorNode).textContent
+      : node.attrs.childrenHTML;
+    const tagName = node.type.name;
+    const attrs = node.attrs.htmlAttrs;
+    let openTag = `<${tagName}`;
+    const closeTag = `</${tagName}>`;
+
+    Object.keys(attrs).forEach((attrName) => {
+      openTag += ` ${attrName}="${attrs[attrName]}"`;
+    });
+    openTag += '>';
+
+    return {
+      text: `${openTag}${content}${closeTag}`,
+    };
+  },
 };
 
 const markTypeOptions: ToMdMarkTypeOptions = {

--- a/apps/editor/src/convertors/toMarkdown/toMdNodeTypeWriters.ts
+++ b/apps/editor/src/convertors/toMarkdown/toMdNodeTypeWriters.ts
@@ -224,6 +224,10 @@ export const nodeTypeWriters: ToMdNodeTypeWriterMap = {
   widget(state, _, { text }) {
     state.write(text);
   },
+
+  html(state, _, { text }) {
+    state.write(text);
+  },
 };
 
 export function write(

--- a/apps/editor/src/convertors/toWysiwyg/htmlToWwConvertors.ts
+++ b/apps/editor/src/convertors/toWysiwyg/htmlToWwConvertors.ts
@@ -13,7 +13,8 @@ const DOUBLE_QUOTED_VALUE = '"[^"]*"';
 
 const ATTRIBUTE_VALUE = `(?:${UNQUOTED_VALUE}|${SINGLE_QUOTED_VALUE}|${DOUBLE_QUOTED_VALUE})`;
 const ATTRIBUTE_VALUE_SPEC = `${'(?:\\s*=\\s*'}${ATTRIBUTE_VALUE})`;
-const ATTRIBUTE = `${'(?:\\s+'}${ATTRIBUTE_NAME}${ATTRIBUTE_VALUE_SPEC}?)`;
+
+export const ATTRIBUTE = `${'(?:\\s+'}${ATTRIBUTE_NAME}${ATTRIBUTE_VALUE_SPEC}?)`;
 
 const OPEN_TAG = `<(${TAG_NAME})(${ATTRIBUTE})*\\s*/?>`;
 const CLOSE_TAG = `</(${TAG_NAME})\\s*[>]`;

--- a/apps/editor/src/convertors/toWysiwyg/toWwConvertors.ts
+++ b/apps/editor/src/convertors/toWysiwyg/toWwConvertors.ts
@@ -22,6 +22,7 @@ import {
   CustomInlineMdNode,
 } from '@t/markdown';
 import { createWidgetContent, getWidgetContent } from '@/widget/rules';
+import { getHtmlAttrs } from '@/wysiwyg/nodes/html';
 
 function isBRTag(node: MdNode) {
   return node.type === 'htmlInline' && /<br ?\/?>/.test(node.literal!);
@@ -310,14 +311,13 @@ export const toWwConvertors: ToWwConvertorMap = {
     container.innerHTML = html;
 
     if (matched) {
-      const nodeType = state.schema.nodes[matched[1]];
+      const [, typeName] = matched;
+      const nodeType = state.schema.nodes[typeName];
 
       if (nodeType) {
-        const { attributes, childNodes } = container.firstChild as HTMLElement;
-        const htmlAttrs: Record<string, string | null> = {};
+        const htmlAttrs = getHtmlAttrs(container.firstChild as HTMLElement);
 
-        toArray(attributes).forEach((attr) => (htmlAttrs[attr.nodeName] = attr.nodeValue));
-        state.addNode(nodeType, { htmlAttrs, childNodes, literal: html });
+        state.addNode(nodeType, { htmlAttrs, literal: html });
       }
     } else {
       addRawHTMLAttributeToDOM(container);

--- a/apps/editor/src/convertors/toWysiwyg/toWwConvertors.ts
+++ b/apps/editor/src/convertors/toWysiwyg/toWwConvertors.ts
@@ -22,7 +22,7 @@ import {
   CustomInlineMdNode,
 } from '@t/markdown';
 import { createWidgetContent, getWidgetContent } from '@/widget/rules';
-import { getHTMLAttrsByHTMLString } from '@/wysiwyg/nodes/html';
+import { getChildrenHTML, getHTMLAttrsByHTMLString } from '@/wysiwyg/nodes/html';
 
 function isBRTag(node: MdNode) {
   return node.type === 'htmlInline' && /<br ?\/?>/.test(node.literal!);
@@ -321,9 +321,7 @@ export const toWwConvertors: ToWwConvertorMap = {
     // for user defined html schema
     if (nodeType?.spec.attrs!.htmlAttrs) {
       const htmlAttrs = getHTMLAttrsByHTMLString(html);
-      const childrenHTML = node
-        .literal!.replace(new RegExp(`(<\\s*${typeName}[^>]+?>)|(</${typeName}\\s*[>])`, 'ig'), '')
-        .trim();
+      const childrenHTML = getChildrenHTML(node, typeName);
 
       state.addNode(nodeType, { htmlAttrs, childrenHTML });
     } else {

--- a/apps/editor/src/css/contents.css
+++ b/apps/editor/src/css/contents.css
@@ -17,6 +17,10 @@ table.ProseMirror-selectednode {
   outline: 1px solid lime;
 }
 
+.html-block.ProseMirror-selectednode {
+  outline: 1px solid lime;
+}
+
 .tui-editor-contents {
   margin: 0;
   padding: 0;

--- a/apps/editor/src/editorCore.ts
+++ b/apps/editor/src/editorCore.ts
@@ -44,7 +44,7 @@ import { addDefaultImageBlobHook } from './helper/image';
 import { setWidgetRules } from './widget/rules';
 import { cls } from './utils/dom';
 import { sanitizeHTML } from './sanitizer/htmlSanitizer';
-import { createHTMLBlockSchemaMap } from './wysiwyg/nodes/html';
+import { createHTMLSchemaMap } from './wysiwyg/nodes/html';
 
 /**
  * ToastUI Editor
@@ -194,10 +194,7 @@ class ToastUIEditor {
     if (this.options.events) {
       forEachOwnProperties(this.options.events, (fn, key) => this.on(key, fn));
     }
-    const htmlBlockSchemaMap = createHTMLBlockSchemaMap(
-      rendererOptions.customHTMLRenderer,
-      wwToDOMAdaptor
-    );
+    const htmlSchemaMap = createHTMLSchemaMap(rendererOptions.customHTMLRenderer, wwToDOMAdaptor);
 
     this.i18n = i18n;
     this.i18n.setCode(this.options.language);
@@ -223,7 +220,7 @@ class ToastUIEditor {
       this.eventEmitter,
       wwToDOMAdaptor,
       useCommandShortcut,
-      htmlBlockSchemaMap,
+      htmlSchemaMap,
       linkAttributes!
     );
 

--- a/apps/editor/src/editorCore.ts
+++ b/apps/editor/src/editorCore.ts
@@ -210,7 +210,10 @@ class ToastUIEditor {
       frontMatter,
     });
 
-    this.mdEditor = new MarkdownEditor(this.toastMark, this.eventEmitter, useCommandShortcut);
+    this.mdEditor = new MarkdownEditor(this.eventEmitter, {
+      toastMark: this.toastMark,
+      useCommandShortcut,
+    });
 
     this.preview = new MarkdownPreview(this.eventEmitter, {
       ...rendererOptions,
@@ -218,13 +221,12 @@ class ToastUIEditor {
       highlight: this.options.previewHighlight,
     });
 
-    this.wwEditor = new WysiwygEditor(
-      this.eventEmitter,
-      wwToDOMAdaptor,
+    this.wwEditor = new WysiwygEditor(this.eventEmitter, {
+      toDOMAdaptor: wwToDOMAdaptor,
       useCommandShortcut,
       htmlSchemaMap,
-      linkAttributes!
-    );
+      linkAttributes,
+    });
 
     this.convertor = new Convertor(
       this.wwEditor.getSchema(),

--- a/apps/editor/src/editorCore.ts
+++ b/apps/editor/src/editorCore.ts
@@ -44,7 +44,7 @@ import { addDefaultImageBlobHook } from './helper/image';
 import { setWidgetRules } from './widget/rules';
 import { cls } from './utils/dom';
 import { sanitizeHTML } from './sanitizer/htmlSanitizer';
-import { createHTMLSchema } from './wysiwyg/nodes/html';
+import { createHTMLBlockSchemaMap } from './wysiwyg/nodes/html';
 
 /**
  * ToastUI Editor
@@ -194,17 +194,10 @@ class ToastUIEditor {
     if (this.options.events) {
       forEachOwnProperties(this.options.events, (fn, key) => this.on(key, fn));
     }
-    const html = {};
-
-    if (customHTMLRenderer?.htmlBlock) {
-      const map = customHTMLRenderer.htmlBlock;
-
-      Object.keys(map).forEach((key) => {
-        const schema = createHTMLSchema(key, map[key], wwToDOMAdaptor);
-
-        html[key] = schema;
-      });
-    }
+    const htmlBlockSchemaMap = createHTMLBlockSchemaMap(
+      rendererOptions.customHTMLRenderer,
+      wwToDOMAdaptor
+    );
 
     this.i18n = i18n;
     this.i18n.setCode(this.options.language);
@@ -230,8 +223,8 @@ class ToastUIEditor {
       this.eventEmitter,
       wwToDOMAdaptor,
       useCommandShortcut,
-      linkAttributes!,
-      html
+      htmlBlockSchemaMap,
+      linkAttributes!
     );
 
     this.convertor = new Convertor(

--- a/apps/editor/src/editorCore.ts
+++ b/apps/editor/src/editorCore.ts
@@ -194,7 +194,11 @@ class ToastUIEditor {
     if (this.options.events) {
       forEachOwnProperties(this.options.events, (fn, key) => this.on(key, fn));
     }
-    const htmlSchemaMap = createHTMLSchemaMap(rendererOptions.customHTMLRenderer, wwToDOMAdaptor);
+    const htmlSchemaMap = createHTMLSchemaMap(
+      rendererOptions.customHTMLRenderer,
+      rendererOptions.sanitizer,
+      wwToDOMAdaptor
+    );
 
     this.i18n = i18n;
     this.i18n.setCode(this.options.language);

--- a/apps/editor/src/editorCore.ts
+++ b/apps/editor/src/editorCore.ts
@@ -70,7 +70,6 @@ import { createHTMLSchemaMap } from './wysiwyg/nodes/html';
  *         @param {addImageBlobHook} [options.hooks.addImageBlobHook] - hook for image upload
  *     @param {string} [options.language='en-US'] - language
  *     @param {boolean} [options.useCommandShortcut=true] - whether use keyboard shortcuts to perform commands
- *     @param {boolean} [options.useDefaultHTMLSanitizer=true] - use default htmlSanitizer
  *     @param {boolean} [options.usageStatistics=true] - send hostname to google analytics
  *     @param {Array.<string|toolbarItemsValue>} [options.toolbarItems] - toolbar items.
  *     @param {boolean} [options.hideModeSwitch=false] - hide mode switch tab bar
@@ -129,7 +128,6 @@ class ToastUIEditor {
         height: '300px',
         minHeight: '200px',
         language: 'en-US',
-        useDefaultHTMLSanitizer: true,
         useCommandShortcut: true,
         usageStatistics: true,
         toolbarItems: [

--- a/apps/editor/src/markdown/htmlRenderConvertors.ts
+++ b/apps/editor/src/markdown/htmlRenderConvertors.ts
@@ -176,7 +176,7 @@ export function getHTMLRenderConvertors(
               newNode.attrs = getHTMLAttrsByHTMLString(rootHTML);
               newNode.childrenHTML = childrenHTML;
               newNode.type = typeName;
-              newNode.open = !/^\s*<\s*\//.test(node.literal!);
+              context.entering = !/^\s*<\s*\//.test(node.literal!);
 
               return htmlConvertor(newNode, context);
             }

--- a/apps/editor/src/markdown/mdEditor.ts
+++ b/apps/editor/src/markdown/mdEditor.ts
@@ -40,13 +40,20 @@ interface WindowWithClipboard extends Window {
   clipboardData?: DataTransfer | null;
 }
 
+interface MarkdownOptions {
+  toastMark: ToastMark;
+  useCommandShortcut?: boolean;
+}
+
 export default class MdEditor extends EditorBase {
   private toastMark: ToastMark;
 
   private clipboard!: HTMLTextAreaElement;
 
-  constructor(toastMark: ToastMark, eventEmitter: Emitter, useCommandShortcut: boolean) {
+  constructor(eventEmitter: Emitter, options: MarkdownOptions) {
     super(eventEmitter);
+
+    const { toastMark, useCommandShortcut = true } = options;
 
     this.editorType = 'markdown';
     this.toastMark = toastMark;

--- a/apps/editor/src/markdown/mdPreview.ts
+++ b/apps/editor/src/markdown/mdPreview.ts
@@ -179,23 +179,6 @@ class MarkdownPreview extends Preview {
     const contentEl = this.previewContent;
     const newHtml = this.eventEmitter.emitReduce(
       'beforePreviewRender',
-      // nodes
-      //   .map((node) => {
-      //     if (isHTMLNode(node)) {
-      //       const matched = node.literal!.match(reHTMLTag);
-
-      //       if (matched) {
-      //         const [, typeName] = matched;
-
-      //         // @ts-expect-error
-      //         if (this.customHTMLRenderer[node.type][typeName]) {
-      //           return this.renderer.render(node);
-      //         }
-      //       }
-      //     }
-      //     return this.sanitizer(this.renderer.render(node));
-      //   })
-      //   .join('')
       this.sanitizer(nodes.map((node) => this.renderer.render(node)).join(''))
     );
 

--- a/apps/editor/src/markdown/mdPreview.ts
+++ b/apps/editor/src/markdown/mdPreview.ts
@@ -17,7 +17,6 @@ import Preview from '@/preview';
 import { cls, removeNode, toggleClass } from '@/utils/dom';
 import { getHTMLRenderConvertors } from '@/markdown/htmlRenderConvertors';
 import { isInlineNode, findClosestNode, getMdStartCh } from '@/utils/markdown';
-import { reHTMLTag } from '@/convertors/toWysiwyg/htmlToWwConvertors';
 import { findAdjacentElementToScrollTop } from './scroll/dom';
 import { removeOffsetInfoByNode } from './scroll/offset';
 
@@ -180,23 +179,24 @@ class MarkdownPreview extends Preview {
     const contentEl = this.previewContent;
     const newHtml = this.eventEmitter.emitReduce(
       'beforePreviewRender',
-      nodes
-        .map((node) => {
-          if (node.type === 'htmlBlock') {
-            const matched = node.literal!.match(reHTMLTag);
+      // nodes
+      //   .map((node) => {
+      //     if (isHTMLNode(node)) {
+      //       const matched = node.literal!.match(reHTMLTag);
 
-            if (matched) {
-              const [, typeName] = matched;
+      //       if (matched) {
+      //         const [, typeName] = matched;
 
-              // @ts-expect-error
-              if (this.customHTMLRenderer[node.type][typeName]) {
-                return this.renderer.render(node);
-              }
-            }
-          }
-          return this.sanitizer(this.renderer.render(node));
-        })
-        .join('')
+      //         // @ts-expect-error
+      //         if (this.customHTMLRenderer[node.type][typeName]) {
+      //           return this.renderer.render(node);
+      //         }
+      //       }
+      //     }
+      //     return this.sanitizer(this.renderer.render(node));
+      //   })
+      //   .join('')
+      this.sanitizer(nodes.map((node) => this.renderer.render(node)).join(''))
     );
 
     if (!removedNodeRange) {

--- a/apps/editor/src/markdown/mdPreview.ts
+++ b/apps/editor/src/markdown/mdPreview.ts
@@ -185,8 +185,13 @@ class MarkdownPreview extends Preview {
           if (node.type === 'htmlBlock') {
             const matched = node.literal!.match(reHTMLTag);
 
-            if (matched && this.customHTMLRenderer[node.type][matched[1]]) {
-              return this.renderer.render(node);
+            if (matched) {
+              const [, typeName] = matched;
+
+              // @ts-expect-error
+              if (this.customHTMLRenderer[node.type][typeName]) {
+                return this.renderer.render(node);
+              }
             }
           }
           return this.sanitizer(this.renderer.render(node));

--- a/apps/editor/src/markdown/scroll/scrollSync.ts
+++ b/apps/editor/src/markdown/scroll/scrollSync.ts
@@ -1,7 +1,7 @@
 import { ProsemirrorNode } from 'prosemirror-model';
 import { EditorView } from 'prosemirror-view';
 import { Emitter } from '@t/event';
-import { isHtmlNode, getMdStartLine } from '@/utils/markdown';
+import { isHTMLNode, getMdStartLine } from '@/utils/markdown';
 import MarkdownPreview from '../mdPreview';
 import MdEditor from '../mdEditor';
 import { animate } from './animation';
@@ -115,7 +115,7 @@ export class ScrollSync {
     const { doc } = editorView.state;
     const firstMdNode = this.getMdNodeAtPos(doc, posInfo);
 
-    if (!firstMdNode || isHtmlNode(firstMdNode)) {
+    if (!firstMdNode || isHTMLNode(firstMdNode)) {
       return;
     }
 

--- a/apps/editor/src/sanitizer/htmlSanitizer.ts
+++ b/apps/editor/src/sanitizer/htmlSanitizer.ts
@@ -6,6 +6,7 @@ import toArray from 'tui-code-snippet/collection/toArray';
 import isString from 'tui-code-snippet/type/isString';
 
 import { finalizeHtml, findNodes, removeNode } from '@/utils/dom';
+import { includes } from '@/utils/common';
 
 type GlobalEventTypes = keyof Omit<
   Omit<GlobalEventHandlers, 'addEventListener'>,
@@ -45,6 +46,31 @@ const reXSSAttr = /href|src|background/i;
 const reXSSAttrValue = /((java|vb|live)script|x):/i;
 const reOnEvent = /^on\S+/i;
 const reComment = /<!--[\s\S]*?-->/g;
+const DEFAULT_BLACK_TAG_LIST = [
+  'script',
+  'iframe',
+  'textarea',
+  'form',
+  'button',
+  'select',
+  'input',
+  'meta',
+  'style',
+  'link',
+  'title',
+  'embed',
+  'object',
+  'details',
+  'summary',
+];
+const CAN_BE_WHITE_TAG_LIST = ['iframe', 'embed', 'details', 'summary'];
+const blackTagList = [...DEFAULT_BLACK_TAG_LIST];
+
+export function registerWhiteTaglistIfPossible(tagName: string) {
+  if (includes(CAN_BE_WHITE_TAG_LIST, tagName)) {
+    blackTagList.splice(blackTagList.indexOf(tagName), 1);
+  }
+}
 
 export function sanitizeHTML(html: string) {
   const root = document.createElement('div');
@@ -61,10 +87,7 @@ export function sanitizeHTML(html: string) {
 }
 
 function removeUnnecessaryTags(html: HTMLElement) {
-  const removedTags = findNodes(
-    html,
-    'script, iframe, textarea, form, button, select, input, meta, style, link, title, embed, object, details, summary'
-  );
+  const removedTags = findNodes(html, blackTagList.join(','));
 
   removedTags.forEach((node) => {
     removeNode(node);

--- a/apps/editor/src/sanitizer/htmlSanitizer.ts
+++ b/apps/editor/src/sanitizer/htmlSanitizer.ts
@@ -46,7 +46,7 @@ const reXSSAttr = /href|src|background/i;
 const reXSSAttrValue = /((java|vb|live)script|x):/i;
 const reOnEvent = /^on\S+/i;
 const reComment = /<!--[\s\S]*?-->/g;
-const DEFAULT_BLACK_TAG_LIST = [
+const DEFAULT_TAG_BLACK_LIST = [
   'script',
   'iframe',
   'textarea',
@@ -63,12 +63,12 @@ const DEFAULT_BLACK_TAG_LIST = [
   'details',
   'summary',
 ];
-const CAN_BE_WHITE_TAG_LIST = ['iframe', 'embed', 'details', 'summary'];
-const blackTagList = [...DEFAULT_BLACK_TAG_LIST];
+const CAN_BE_TAG_WHITE_LIST = ['iframe', 'embed', 'details', 'summary'];
+const tagBlacklist = [...DEFAULT_TAG_BLACK_LIST];
 
-export function registerWhiteTaglistIfPossible(tagName: string) {
-  if (includes(CAN_BE_WHITE_TAG_LIST, tagName)) {
-    blackTagList.splice(blackTagList.indexOf(tagName), 1);
+export function registerTagWhitelistIfPossible(tagName: string) {
+  if (includes(CAN_BE_TAG_WHITE_LIST, tagName)) {
+    tagBlacklist.splice(tagBlacklist.indexOf(tagName), 1);
   }
 }
 
@@ -87,7 +87,7 @@ export function sanitizeHTML(html: string) {
 }
 
 function removeUnnecessaryTags(html: HTMLElement) {
-  const removedTags = findNodes(html, blackTagList.join(','));
+  const removedTags = findNodes(html, tagBlacklist.join(','));
 
   removedTags.forEach((node) => {
     removeNode(node);

--- a/apps/editor/src/sanitizer/htmlSanitizer.ts
+++ b/apps/editor/src/sanitizer/htmlSanitizer.ts
@@ -46,20 +46,18 @@ const reXSSAttrValue = /((java|vb|live)script|x):/i;
 const reOnEvent = /^on\S+/i;
 const reComment = /<!--[\s\S]*?-->/g;
 
-export function sanitizeHTML(html: string | Node, needHtmlText = false) {
+export function sanitizeHTML(html: string) {
   const root = document.createElement('div');
 
   if (isString(html)) {
     html = html.replace(reComment, '');
     root.innerHTML = html;
-  } else {
-    root.appendChild(html);
   }
 
   removeUnnecessaryTags(root);
   leaveOnlyWhitelistAttribute(root);
 
-  return finalizeHtml(root, needHtmlText);
+  return finalizeHtml(root, true) as string;
 }
 
 function removeUnnecessaryTags(html: HTMLElement) {

--- a/apps/editor/src/utils/markdown.ts
+++ b/apps/editor/src/utils/markdown.ts
@@ -42,7 +42,7 @@ export function isMultiLineNode(mdNode: MdNode) {
   return type === 'codeBlock' || type === 'paragraph';
 }
 
-export function isHtmlNode(mdNode: MdNode) {
+export function isHTMLNode(mdNode: MdNode) {
   const { type } = mdNode;
 
   return type === 'htmlBlock' || type === 'htmlInline';

--- a/apps/editor/src/viewer.ts
+++ b/apps/editor/src/viewer.ts
@@ -34,7 +34,6 @@ const TASK_CHECKED_CLASS_NAME = 'checked';
  *         @param {function} [options.events.focus] - It would be emitted when editor get focus
  *         @param {function} [options.events.blur] - It would be emitted when editor loose focus
  *     @param {Array.<function|Array>} [options.plugins] - Array of plugins. A plugin can be either a function or an array in the form of [function, options].
- *     @param {boolean} [options.useDefaultHTMLSanitizer=true] - use default htmlSanitizer
  *     @param {Object} [options.extendedAutolinks] - Using extended Autolinks specified in GFM spec
  *     @param {Object} [options.customConvertor] - convertor extention
  *     @param {Object} [options.linkAttributes] - Attributes of anchor element that should be rel, target, hreflang, type
@@ -64,7 +63,6 @@ class ToastUIEditorViewer {
   constructor(options: ViewerOptions) {
     this.options = extend(
       {
-        useDefaultHTMLSanitizer: true,
         linkAttributes: null,
         extendedAutolinks: false,
         customConvertor: null,

--- a/apps/editor/src/viewer.ts
+++ b/apps/editor/src/viewer.ts
@@ -16,6 +16,7 @@ import { invokePlugins, getPluginInfo } from './pluginHelper';
 import { last, sanitizeLinkAttribute } from './utils/common';
 import EventEmitter from './event/eventEmitter';
 import { isPositionInBox, toggleClass } from './utils/dom';
+import { sanitizeHTML } from './sanitizer/htmlSanitizer';
 
 const TASK_ATTR_NAME = 'data-task';
 const DISABLED_TASK_ATTR_NAME = 'data-task-disabled';
@@ -85,6 +86,7 @@ class ToastUIEditorViewer {
       extendedAutolinks,
       referenceDefinition,
       frontMatter,
+      customHTMLSanitizer,
     } = this.options;
 
     const rendererOptions = {
@@ -94,6 +96,7 @@ class ToastUIEditorViewer {
       referenceDefinition,
       customParser: parser,
       frontMatter,
+      sanitizer: customHTMLSanitizer || sanitizeHTML,
     };
 
     if (this.options.events) {

--- a/apps/editor/src/wysiwyg/adaptor/mdLikeNode.ts
+++ b/apps/editor/src/wysiwyg/adaptor/mdLikeNode.ts
@@ -53,6 +53,12 @@ export function createMdLikeNode(node: ProsemirrorNode | Mark): MdLikeNode {
     customBlock: { info: attrs.info },
   } as const;
   const nodeInfo = nodeTypeMap[nodeType as keyof typeof nodeTypeMap];
+  let attributes = { ...mdLikeNode, ...nodeInfo };
 
-  return { ...mdLikeNode, ...nodeInfo };
+  if (node.attrs.htmlAttrs) {
+    attributes = { ...attributes, ...node.attrs.htmlAttrs, literal: node.attrs.literal };
+  }
+  console.log(node);
+
+  return attributes;
 }

--- a/apps/editor/src/wysiwyg/adaptor/mdLikeNode.ts
+++ b/apps/editor/src/wysiwyg/adaptor/mdLikeNode.ts
@@ -54,13 +54,15 @@ export function createMdLikeNode(node: ProsemirrorNode | Mark): MdLikeNode {
   } as const;
   const nodeInfo = nodeTypeMap[nodeType as keyof typeof nodeTypeMap];
   const attributes = { ...mdLikeNode, ...nodeInfo };
-  const { htmlAttrs, literal } = node.attrs;
+
+  // html block, inline node
+  const { htmlAttrs, childrenHTML } = node.attrs;
 
   if (htmlAttrs) {
     return {
       ...attributes,
       attrs: htmlAttrs,
-      literal,
+      childrenHTML,
     };
   }
 

--- a/apps/editor/src/wysiwyg/adaptor/mdLikeNode.ts
+++ b/apps/editor/src/wysiwyg/adaptor/mdLikeNode.ts
@@ -53,12 +53,16 @@ export function createMdLikeNode(node: ProsemirrorNode | Mark): MdLikeNode {
     customBlock: { info: attrs.info },
   } as const;
   const nodeInfo = nodeTypeMap[nodeType as keyof typeof nodeTypeMap];
-  let attributes = { ...mdLikeNode, ...nodeInfo };
+  const attributes = { ...mdLikeNode, ...nodeInfo };
+  const { htmlAttrs, literal } = node.attrs;
 
-  if (node.attrs.htmlAttrs) {
-    attributes = { ...attributes, ...node.attrs.htmlAttrs, literal: node.attrs.literal };
+  if (htmlAttrs) {
+    return {
+      ...attributes,
+      attrs: htmlAttrs,
+      literal,
+    };
   }
-  console.log(node);
 
   return attributes;
 }

--- a/apps/editor/src/wysiwyg/adaptor/wwToDOMAdaptor.ts
+++ b/apps/editor/src/wysiwyg/adaptor/wwToDOMAdaptor.ts
@@ -25,16 +25,13 @@ export class WwToDOMAdaptor implements ToDOMAdaptor {
   public convertors: CustomHTMLRendererMap;
 
   constructor(linkAttributes: LinkAttributes | null, customRenderer: CustomHTMLRendererMap) {
-    const convertors = {
-      ...getHTMLRenderConvertors(linkAttributes, customRenderer),
-      ...customRenderer.htmlBlock,
-      ...customRenderer.htmlInline,
-    };
+    const convertors = getHTMLRenderConvertors(linkAttributes, customRenderer);
+    const customHTMLConvertor = { ...customRenderer.htmlBlock, ...customRenderer.htmlInline };
 
-    this.customConvertorKeys = Object.keys(convertors);
+    this.customConvertorKeys = Object.keys(customRenderer).concat(Object.keys(customHTMLConvertor));
     this.renderer = new Renderer({
       gfm: true,
-      convertors,
+      convertors: { ...convertors, ...customHTMLConvertor },
     });
     this.convertors = this.renderer.getConvertors();
   }

--- a/apps/editor/src/wysiwyg/adaptor/wwToDOMAdaptor.ts
+++ b/apps/editor/src/wysiwyg/adaptor/wwToDOMAdaptor.ts
@@ -53,7 +53,7 @@ export class WwToDOMAdaptor implements ToDOMAdaptor {
     const converted = convertor(mdLikeNode as MdNode, context, this.convertors)!;
     const tokens: HTMLToken[] = isArray(converted) ? converted : [converted];
 
-    if (isContainer(node.type.name)) {
+    if (isContainer(node.type.name) || node.attrs.inline) {
       context.entering = false;
 
       tokens.push({ type: 'text', content: isPmNode(node) ? node.textContent : '' } as TextToken);

--- a/apps/editor/src/wysiwyg/adaptor/wwToDOMAdaptor.ts
+++ b/apps/editor/src/wysiwyg/adaptor/wwToDOMAdaptor.ts
@@ -28,6 +28,7 @@ export class WwToDOMAdaptor implements ToDOMAdaptor {
     const convertors = getHTMLRenderConvertors(linkAttributes, customRenderer);
     const customHTMLConvertor = { ...customRenderer.htmlBlock, ...customRenderer.htmlInline };
 
+    // flatten the html block, inline convertor to other custom convertors
     this.customConvertorKeys = Object.keys(customRenderer).concat(Object.keys(customHTMLConvertor));
     this.renderer = new Renderer({
       gfm: true,

--- a/apps/editor/src/wysiwyg/nodes/html.ts
+++ b/apps/editor/src/wysiwyg/nodes/html.ts
@@ -4,7 +4,7 @@ import { ToDOMAdaptor } from '@t/convertor';
 import { CustomHTMLRendererMap, MdNode } from '@t/markdown';
 import { SchemaMap, Sanitizer } from '@t/editor';
 import { ATTRIBUTE, reHTMLTag } from '@/convertors/toWysiwyg/htmlToWwConvertors';
-import { registerWhiteTaglistIfPossible } from '@/sanitizer/htmlSanitizer';
+import { registerTagWhitelistIfPossible } from '@/sanitizer/htmlSanitizer';
 
 export function getChildrenHTML(node: MdNode, typeName: string) {
   return node
@@ -122,8 +122,8 @@ export function createHTMLSchemaMap(
   (['htmlBlock', 'htmlInline'] as const).forEach((htmlType) => {
     if (renderer[htmlType]) {
       Object.keys(renderer[htmlType]!).forEach((type) => {
-        // register white tag list for preventing to remove the html in sanitizer
-        registerWhiteTaglistIfPossible(type);
+        // register tag white list for preventing to remove the html in sanitizer
+        registerTagWhitelistIfPossible(type);
         htmlSchemaMap[type] = schemaFactory[htmlType](type, sanitizeHTML, wwToDOMAdaptor);
       });
     }

--- a/apps/editor/src/wysiwyg/nodes/html.ts
+++ b/apps/editor/src/wysiwyg/nodes/html.ts
@@ -1,0 +1,43 @@
+import { Node as ProsemirrorNode, DOMOutputSpecArray } from 'prosemirror-model';
+import toArray from 'tui-code-snippet/collection/toArray';
+
+export function createHTMLSchema(tagName: string, renderer, wwToDOMAdaptor) {
+  return {
+    content: 'block+',
+    atom: true,
+    group: 'block',
+    attrs: {
+      childNodes: { default: null },
+      htmlAttrs: { default: {} },
+      literal: { default: '' },
+    },
+    parseDOM: [
+      {
+        tag: tagName,
+        getAttrs(dom: Node | string) {
+          const { attributes, childNodes, outerHTML } = dom as HTMLElement;
+          const htmlAttrs: Record<string, string | null> = {};
+
+          toArray(attributes).forEach((attr) => (htmlAttrs[attr.nodeName] = attr.nodeValue));
+
+          return { childNodes, htmlAttrs, literal: outerHTML };
+        },
+      },
+    ],
+    toDOM(node: ProsemirrorNode): DOMOutputSpecArray {
+      const { htmlAttrs, childNodes } = node.attrs;
+      const className = htmlAttrs.class ? `${htmlAttrs.class} html-block` : 'html-block';
+
+      const specArray = wwToDOMAdaptor.getToDOM(tagName)(node);
+
+      console.log(specArray);
+
+      htmlAttrs.class = className;
+
+      if (childNodes) {
+        return [tagName, htmlAttrs, ...toArray(childNodes)];
+      }
+      return [tagName, htmlAttrs, 0];
+    },
+  };
+}

--- a/apps/editor/src/wysiwyg/wwEditor.ts
+++ b/apps/editor/src/wysiwyg/wwEditor.ts
@@ -43,7 +43,7 @@ export default class WysiwygEditor extends EditorBase {
     eventEmitter: Emitter,
     toDOMAdaptor: ToDOMAdaptor,
     useCommandShortcut: boolean,
-    htmlBlockSchemaMap: SchemaMap,
+    htmlSchemaMap: SchemaMap,
     linkAttributes = {}
   ) {
     super(eventEmitter);
@@ -52,7 +52,7 @@ export default class WysiwygEditor extends EditorBase {
     this.toDOMAdaptor = toDOMAdaptor;
     this.linkAttributes = linkAttributes;
     this.specs = this.createSpecs();
-    this.schema = this.createSchema(htmlBlockSchemaMap);
+    this.schema = this.createSchema(htmlSchemaMap);
     this.context = this.createContext();
     this.keymaps = this.createKeymaps(useCommandShortcut);
     this.view = this.createView();

--- a/apps/editor/src/wysiwyg/wwEditor.ts
+++ b/apps/editor/src/wysiwyg/wwEditor.ts
@@ -22,7 +22,7 @@ import { createSpecs } from './specCreator';
 
 import { Emitter } from '@t/event';
 import { ToDOMAdaptor } from '@t/convertor';
-import { LinkAttributes, WidgetStyle } from '@t/editor';
+import { LinkAttributes, SchemaMap, WidgetStyle } from '@t/editor';
 import { createNodesWithWidget } from '@/widget/rules';
 import { widgetNodeView } from '@/widget/widgetNode';
 import { cls } from '@/utils/dom';
@@ -43,8 +43,8 @@ export default class WysiwygEditor extends EditorBase {
     eventEmitter: Emitter,
     toDOMAdaptor: ToDOMAdaptor,
     useCommandShortcut: boolean,
-    linkAttributes = {},
-    html
+    htmlBlockSchemaMap: SchemaMap,
+    linkAttributes = {}
   ) {
     super(eventEmitter);
 
@@ -52,7 +52,7 @@ export default class WysiwygEditor extends EditorBase {
     this.toDOMAdaptor = toDOMAdaptor;
     this.linkAttributes = linkAttributes;
     this.specs = this.createSpecs();
-    this.schema = this.createSchema(html);
+    this.schema = this.createSchema(htmlBlockSchemaMap);
     this.context = this.createContext();
     this.keymaps = this.createKeymaps(useCommandShortcut);
     this.view = this.createView();

--- a/apps/editor/src/wysiwyg/wwEditor.ts
+++ b/apps/editor/src/wysiwyg/wwEditor.ts
@@ -1,6 +1,7 @@
 import { EditorView } from 'prosemirror-view';
 import { Node as ProsemirrorNode, Slice, Fragment, Mark } from 'prosemirror-model';
 import isNumber from 'tui-code-snippet/type/isNumber';
+
 import EditorBase from '@/base';
 import { getWwCommands } from '@/commands/wwCommands';
 

--- a/apps/editor/src/wysiwyg/wwEditor.ts
+++ b/apps/editor/src/wysiwyg/wwEditor.ts
@@ -43,7 +43,8 @@ export default class WysiwygEditor extends EditorBase {
     eventEmitter: Emitter,
     toDOMAdaptor: ToDOMAdaptor,
     useCommandShortcut: boolean,
-    linkAttributes = {}
+    linkAttributes = {},
+    html
   ) {
     super(eventEmitter);
 
@@ -51,7 +52,7 @@ export default class WysiwygEditor extends EditorBase {
     this.toDOMAdaptor = toDOMAdaptor;
     this.linkAttributes = linkAttributes;
     this.specs = this.createSpecs();
-    this.schema = this.createSchema();
+    this.schema = this.createSchema(html);
     this.context = this.createContext();
     this.keymaps = this.createKeymaps(useCommandShortcut);
     this.view = this.createView();
@@ -62,6 +63,10 @@ export default class WysiwygEditor extends EditorBase {
 
   createSpecs() {
     return createSpecs(this.toDOMAdaptor, this.linkAttributes);
+  }
+
+  createKeymaps() {
+    return this.specs.keymaps();
   }
 
   createContext() {

--- a/apps/editor/types/convertor.d.ts
+++ b/apps/editor/types/convertor.d.ts
@@ -41,7 +41,7 @@ type ToWwConvertor = (
   }
 ) => void;
 
-export type ToWwConvertorMap = Partial<Record<MdNodeType, ToWwConvertor>>;
+export type ToWwConvertorMap = Partial<Record<string, ToWwConvertor>>;
 
 export type FirstDelimFn = (index: number) => string;
 

--- a/apps/editor/types/editor.d.ts
+++ b/apps/editor/types/editor.d.ts
@@ -57,7 +57,7 @@ export type LinkAttributeNames = 'rel' | 'target' | 'hreflang' | 'type';
 // @TODO change option and type name from singular to plural
 export type LinkAttributes = Partial<Record<LinkAttributeNames, string>>;
 
-export type CustomHTMLSanitizer = (content: string) => string | DocumentFragment;
+export type CustomHTMLSanitizer = (content: string) => string;
 
 export interface ViewerOptions {
   el: HTMLElement;

--- a/apps/editor/types/editor.d.ts
+++ b/apps/editor/types/editor.d.ts
@@ -1,12 +1,12 @@
-import { Schema } from 'prosemirror-model';
+import { Schema, NodeSpec } from 'prosemirror-model';
 import { EditorView } from 'prosemirror-view';
 import { EditorState, Plugin } from 'prosemirror-state';
 import {
+  MdPos,
+  MdSourcepos,
   CustomHTMLRenderer,
   CustomHTMLRendererMap,
   CustomParserMap,
-  MdPos,
-  MdSourcepos,
 } from './markdown';
 import { Emitter, Handler } from './event';
 import { Context, EditorAllCommandMap, EditorCommandFn } from './spec';
@@ -307,3 +307,5 @@ export interface Base {
 
   getRangeInfoOfNode(pos?: EditorPos): NodeRangeInfo;
 }
+
+export type SchemaMap = Record<string, NodeSpec>;

--- a/apps/editor/types/editor.d.ts
+++ b/apps/editor/types/editor.d.ts
@@ -57,7 +57,7 @@ export type LinkAttributeNames = 'rel' | 'target' | 'hreflang' | 'type';
 // @TODO change option and type name from singular to plural
 export type LinkAttributes = Partial<Record<LinkAttributeNames, string>>;
 
-export type CustomHTMLSanitizer = (content: string) => string;
+export type Sanitizer = (content: string) => string;
 
 export interface ViewerOptions {
   el: HTMLElement;
@@ -69,7 +69,7 @@ export interface ViewerOptions {
   linkAttributes?: LinkAttributes;
   customHTMLRenderer?: CustomHTMLRenderer;
   referenceDefinition?: boolean;
-  customHTMLSanitizer?: CustomHTMLSanitizer;
+  customHTMLSanitizer?: Sanitizer;
   frontMatter?: boolean;
 }
 
@@ -126,7 +126,7 @@ export interface EditorOptions {
   customHTMLRenderer?: CustomHTMLRenderer;
   customMarkdownRenderer?: ToMdConvertorMap;
   referenceDefinition?: boolean;
-  customHTMLSanitizer?: CustomHTMLSanitizer;
+  customHTMLSanitizer?: Sanitizer;
   previewHighlight?: boolean;
   frontMatter?: boolean;
   widgetRules?: WidgetRule[];

--- a/apps/editor/types/editor.d.ts
+++ b/apps/editor/types/editor.d.ts
@@ -64,7 +64,6 @@ export interface ViewerOptions {
   initialValue?: string;
   events?: EventMap;
   plugins?: (EditorPlugin | EditorPluginInfo)[];
-  useDefaultHTMLSanitizer?: boolean;
   extendedAutolinks?: ExtendedAutolinks;
   linkAttributes?: LinkAttributes;
   customHTMLRenderer?: CustomHTMLRenderer;
@@ -115,7 +114,6 @@ export interface EditorOptions {
   hooks?: EditorHookMap;
   language?: string;
   useCommandShortcut?: boolean;
-  useDefaultHTMLSanitizer?: boolean;
   usageStatistics?: boolean;
   toolbarItems?: (string | ToolbarItemOptions)[];
   hideModeSwitch?: boolean;

--- a/apps/editor/types/index.d.ts
+++ b/apps/editor/types/index.d.ts
@@ -8,7 +8,7 @@ import {
   ViewerOptions,
   ExtendedAutolinks,
   LinkAttributes,
-  CustomHTMLSanitizer,
+  Sanitizer,
   EditorType,
   PreviewStyle,
 } from './editor';
@@ -31,7 +31,7 @@ export {
   ViewerOptions,
   ExtendedAutolinks,
   LinkAttributes,
-  CustomHTMLSanitizer,
+  Sanitizer,
   EditorType,
   PreviewStyle,
 };

--- a/apps/editor/types/markdown.d.ts
+++ b/apps/editor/types/markdown.d.ts
@@ -115,8 +115,10 @@ export interface CodeMdNode extends MdNode {
   tickCount: number;
 }
 
-export interface HTMLBlockMdNode extends MdNode {
+export interface HTMLMdNode extends MdNode {
   attrs: Record<string, string | null>;
+  childrenHTML?: string;
+  open?: boolean;
 }
 
 export interface TableColumn {
@@ -270,4 +272,5 @@ export interface MdLikeNode {
     checked?: boolean;
   };
   attrs?: Record<string, string | null>;
+  childrenHTML?: string;
 }

--- a/apps/editor/types/markdown.d.ts
+++ b/apps/editor/types/markdown.d.ts
@@ -49,7 +49,7 @@ export type MdPos = [number, number];
 export type MdSourcepos = [MdPos, MdPos];
 
 export interface MdNode {
-  type: MdNodeType;
+  type: string;
   id: number;
   parent: MdNode | null;
   prev: MdNode | null;
@@ -113,6 +113,10 @@ export interface LinkMdNode extends MdNode {
 export interface CodeMdNode extends MdNode {
   parent: NonNullable<MdNode>;
   tickCount: number;
+}
+
+export interface HTMLBlockMdNode extends MdNode {
+  attrs: Record<string, string | null>;
 }
 
 export interface TableColumn {
@@ -226,7 +230,7 @@ export type CustomHTMLRenderer = (
   convertors?: CustomHTMLRendererMap
 ) => HTMLToken | HTMLToken[] | null;
 
-export interface HTMLBlockRendererMap {
+export interface HTMLRendererMap {
   [type: string]: CustomHTMLRenderer;
 }
 
@@ -250,7 +254,7 @@ export interface Context {
 }
 
 export interface MdLikeNode {
-  type: MdNodeType;
+  type: string;
   literal: string | null;
   wysiwygNode?: boolean;
   level?: number;
@@ -265,4 +269,5 @@ export interface MdLikeNode {
     task?: boolean;
     checked?: boolean;
   };
+  attrs?: Record<string, string | null>;
 }

--- a/apps/editor/types/markdown.d.ts
+++ b/apps/editor/types/markdown.d.ts
@@ -226,6 +226,10 @@ export type CustomHTMLRenderer = (
   convertors?: CustomHTMLRendererMap
 ) => HTMLToken | HTMLToken[] | null;
 
+export interface HTMLBlockRendererMap {
+  [type: string]: CustomHTMLRenderer;
+}
+
 export type CustomHTMLRendererMap = Partial<Record<string, CustomHTMLRenderer>>;
 
 export interface ContextOptions {

--- a/apps/editor/types/wysiwyg.d.ts
+++ b/apps/editor/types/wysiwyg.d.ts
@@ -22,7 +22,8 @@ export type WwNodeType =
   | 'lineBreak'
   | 'customBlock'
   | 'frontMatter'
-  | 'widget';
+  | 'widget'
+  | 'html';
 
 export type WwMarkType = 'strong' | 'emph' | 'strike' | 'link' | 'code';
 


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
#### Create html schema
Since the abstract model is applied to our new WYSIWYG Editor, WYSIWYG editor can only display element added to abstract model(officially supported by markdown text). So, we need the option or functionality to create html block or html inline schema in WYSIWYG. For example, `<video>` element can be edited in both Markdown and WYSIWYG through the `customHTMLRenderer` option as below.

```js
customHTMLRenderer: {
  htmlBlock: {
    video(node) {
      return [
        { type: 'openTag', tagName: 'video', outerNewLine: true, attributes: node.attrs },
        { type: 'html', content: node.childrenHTML },
        { type: 'closeTag', tagName: 'video', outerNewLine: true }
      ];
    }
  },
  htmlInline: {
    // big inline tag
    big(node, { entering }) {
      return entering ? 
        { type: 'openTag', tagName: 'big', attributes: node.attrs } :
        { type: 'closeTag', tagName: 'big' }
    }
  }
},
// ...
```

**`htmlBlock`**
The video block node can be registered with WYSIWYG using the nested the option structure above example. 
The attributes of the root node are passed to the property called `node.attrs`, which can be selected as desired. You can also get html strings of child elements into `node.childrenHTML` if they exist.

**`htmlInline`**
`htmlInline` options is similar to `htmlBlock` option. But `htmlInline` has `node.entering` property which is for open tag, close  tag instead of `node.childrenHTML`. Because the `htmlInline` is regarded as the container element containing text, but our markdown parser doesn't have the child information for `htmlInline`.

In addition, it cannot be created as a schema if there is a risk to XSS like `script`, `input`, `select` etc. `Iframe` and `video` tags are not included in this black list.


#### Breaking changes
remove `useDefaultHTMLSanitizer` option: This option will be removed. If user want to change own sanitizer, use existing `customHTMLSanitizer` option.



---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
