### PR TITLE
refactor: improve markdown syntax highlighting

### DIFF
--- a/apps/editor/src/__test__/unit/markdown/keymap.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/keymap.spec.ts
@@ -298,6 +298,19 @@ describe('extend list keymap', () => {
 
       expect(getTextContent(mde)).toBe(result);
     });
+
+    it('should not extend list when paragraph includes `* `', () => {
+      const input = source`
+        just paragraph* bullet
+      `;
+
+      mde.setMarkdown(input);
+      mde.setSelection([1, 9], [1, 9]);
+
+      forceKeymapFn('listItem', 'extendList');
+
+      expect(getTextContent(mde)).toBe(input);
+    });
   });
 
   describe('ordered list', () => {

--- a/apps/editor/src/markdown/helper/list.ts
+++ b/apps/editor/src/markdown/helper/list.ts
@@ -59,13 +59,13 @@ interface ExtendList {
   ordered: ExtendListFn;
 }
 
-export const reList = /^([-*+] |[\d]+\. )/;
-export const reOrderedList = /^([\d])+\.( \[[ xX]])? /;
+export const reList = /(^\s*)([-*+] |[\d]+\. )/;
+export const reOrderedList = /(^\s*)([\d])+\.( \[[ xX]])? /;
 export const reOrderedListGroup = /^(\s*)((\d+)([.)]\s(?:\[(?:x|\s)\]\s)?))(.*)/;
-export const reCanBeTaskList = /([-*+]|[\d]+\.)( \[[ xX]])? /;
+export const reCanBeTaskList = /(^\s*)([-*+]|[\d]+\.)( \[[ xX]])? /;
 const reBulletListGroup = /^(\s*)([-*+]+(\s(?:\[(?:x|\s)\]\s)?))(.*)/;
-const reTaskList = /([-*+] |[\d]+\. )(\[[ xX]] )/;
-const reBulletTaskList = /([-*+])( \[[ xX]]) /;
+const reTaskList = /(^\s*)([-*+] |[\d]+\. )(\[[ xX]] )/;
+const reBulletTaskList = /(^\s*)([-*+])( \[[ xX]]) /;
 
 export function getListType(text: string): ListType {
   return reOrderedList.test(text) ? 'ordered' : 'bullet';
@@ -124,9 +124,9 @@ function textToBullet(text: string) {
   const type = getListType(text);
 
   if (type === 'bullet' && reCanBeTaskList.test(text)) {
-    text = text.replace(reBulletTaskList, '$1 ');
+    text = text.replace(reBulletTaskList, '$1$2 ');
   } else if (type === 'ordered') {
-    text = text.replace(reOrderedList, '* ');
+    text = text.replace(reOrderedList, '$1* ');
   }
 
   return text;
@@ -139,13 +139,13 @@ function textToOrdered(text: string, ordinalNum: number) {
   const type = getListType(text);
 
   if (type === 'bullet' || (type === 'ordered' && reCanBeTaskList.test(text))) {
-    text = text.replace(reCanBeTaskList, `${ordinalNum}. `);
+    text = text.replace(reCanBeTaskList, `$1${ordinalNum}. `);
   } else if (type === 'ordered') {
     // eslint-disable-next-line prefer-destructuring
     const start = reOrderedListGroup.exec(text)![3];
 
     if (Number(start) !== ordinalNum) {
-      text = text.replace(reOrderedList, `${ordinalNum}. `);
+      text = text.replace(reOrderedList, `$1${ordinalNum}. `);
     }
   }
 
@@ -192,9 +192,9 @@ export const otherListToList: ListToList = {
     let text = getTextByMdLine(doc, line);
 
     if (mdNode.listData.task) {
-      text = text.replace(reTaskList, '$1');
+      text = text.replace(reTaskList, '$1$2');
     } else if (isListNode(mdNode)) {
-      text = text.replace(reList, '$1[ ] ');
+      text = text.replace(reList, '$1$2[ ] ');
     }
 
     return { changedResults: [{ text, line }] };

--- a/apps/editor/src/markdown/helper/list.ts
+++ b/apps/editor/src/markdown/helper/list.ts
@@ -59,8 +59,8 @@ interface ExtendList {
   ordered: ExtendListFn;
 }
 
-export const reList = /([-*+] |[\d]+\. )/;
-export const reOrderedList = /([\d])+\.( \[[ xX]])? /;
+export const reList = /^([-*+] |[\d]+\. )/;
+export const reOrderedList = /^([\d])+\.( \[[ xX]])? /;
 export const reOrderedListGroup = /^(\s*)((\d+)([.)]\s(?:\[(?:x|\s)\]\s)?))(.*)/;
 export const reCanBeTaskList = /([-*+]|[\d]+\.)( \[[ xX]])? /;
 const reBulletListGroup = /^(\s*)([-*+]+(\s(?:\[(?:x|\s)\]\s)?))(.*)/;

--- a/apps/editor/src/markdown/helper/pos.ts
+++ b/apps/editor/src/markdown/helper/pos.ts
@@ -8,13 +8,9 @@ export function resolveSelectionPos(selection: Selection) {
   const { from, to } = selection;
 
   if (selection instanceof AllSelection) {
-    return resolvePos(from, to);
+    return [from + 1, to - 1];
   }
   return [from, to];
-}
-
-export function resolvePos(from: number, to: number) {
-  return [from + 1, to - 1];
 }
 
 export function getEditorToMdLine(
@@ -105,17 +101,16 @@ export function getMdToEditorPos(
   let from = 0;
   let to = 0;
 
-  for (let i = 0; i < endPos[0] - 1; i += 1) {
-    const len = lineTexts[i].length;
-    const child = doc.child(i);
-    const additionalPos = getWidgetNodePos(child, child.content.size);
+  const fragment = doc.content;
 
-    // should plus 2(end tag, start tag) to consider line breaking
-    if (i < startPos[0] - 1) {
-      from += len + 2 + additionalPos;
+  for (let i = 0, p = 0; i < endPos[0]; i += 1) {
+    const child = fragment.content[i];
+
+    if (i < startPos[0]) {
+      from = p;
     }
-
-    to += len + 2 + additionalPos;
+    to = p;
+    p += child.nodeSize;
   }
 
   const startNode = doc.child(startPos[0] - 1);
@@ -125,14 +120,6 @@ export function getMdToEditorPos(
   to += endPos[1] + getWidgetNodePos(endNode, endPos[1] - 1);
 
   return [from, Math.min(to, doc.content.size)];
-}
-
-export function getExtendedRangeOffset(from: number, to: number, doc: ProsemirrorNode) {
-  const startResolvedPos = doc.resolve(from);
-  const startOffset = startResolvedPos.start();
-  const endOffset = from === to ? startResolvedPos.end() : doc.resolve(to).end();
-
-  return [startOffset, endOffset];
 }
 
 export function getRangeInfo(selection: Selection) {

--- a/apps/editor/src/markdown/mdEditor.ts
+++ b/apps/editor/src/markdown/mdEditor.ts
@@ -234,7 +234,7 @@ export default class MdEditor extends EditorBase {
 
   setSelection(start: MdPos, end: MdPos) {
     const { tr } = this.view.state;
-    const [from, to] = getMdToEditorPos(tr.doc, this.toastMark, start, end);
+    const [from, to] = getMdToEditorPos(tr.doc, start, end);
 
     this.view.dispatch(tr.setSelection(createTextSelection(tr, from, to)));
   }
@@ -251,7 +251,7 @@ export default class MdEditor extends EditorBase {
     this.focus();
 
     if (start && end) {
-      const [from, to] = getMdToEditorPos(doc, this.toastMark, start, end);
+      const [from, to] = getMdToEditorPos(doc, start, end);
 
       newTr = tr.replaceRange(from, to, slice);
     } else {
@@ -265,7 +265,7 @@ export default class MdEditor extends EditorBase {
     const { tr, doc } = this.view.state;
 
     if (start && end) {
-      const [from, to] = getMdToEditorPos(doc, this.toastMark, start, end);
+      const [from, to] = getMdToEditorPos(doc, start, end);
 
       newTr = tr.deleteRange(from, to);
     } else {
@@ -279,7 +279,7 @@ export default class MdEditor extends EditorBase {
     let { from, to } = selection;
 
     if (start && end) {
-      const pos = getMdToEditorPos(doc, this.toastMark, start, end);
+      const pos = getMdToEditorPos(doc, start, end);
 
       from = pos[0];
       to = pos[1];
@@ -310,14 +310,14 @@ export default class MdEditor extends EditorBase {
 
   addWidget(node: Node, style: WidgetStyle, mdPos?: MdPos) {
     const { tr, doc, selection } = this.view.state;
-    const pos = mdPos ? getMdToEditorPos(doc, this.toastMark, mdPos, mdPos)[0] : selection.to;
+    const pos = mdPos ? getMdToEditorPos(doc, mdPos, mdPos)[0] : selection.to;
 
     this.view.dispatch(tr.setMeta('widget', { pos, node, style }));
   }
 
   replaceWithWidget(start: MdPos, end: MdPos, text: string) {
     const { tr, schema, doc } = this.view.state;
-    const pos = getMdToEditorPos(doc, this.toastMark, start, end);
+    const pos = getMdToEditorPos(doc, start, end);
     const nodes = createNodesWithWidget(text, schema);
 
     this.view.dispatch(tr.replaceWith(pos[0], pos[1], nodes));

--- a/apps/editor/src/markdown/mdEditor.ts
+++ b/apps/editor/src/markdown/mdEditor.ts
@@ -198,8 +198,12 @@ export default class MdEditor extends EditorBase {
         if (step.slice && !(step instanceof ReplaceAroundStep)) {
           const doc = tr.docs[index];
           const [from, to] = this.getResolvedRange(tr, step);
-          const changed = this.getChanged(step.slice);
           const [startPos, endPos] = getEditorToMdPos(doc, from, to);
+          let changed = this.getChanged(step.slice);
+
+          if (startPos[0] === endPos[0] && startPos[1] === endPos[1] && changed === '') {
+            changed = '\n';
+          }
           const editResult = this.toastMark.editMarkdown(startPos, endPos, changed);
 
           this.eventEmitter.emit('updatePreview', editResult);

--- a/apps/editor/src/markdown/plugins/helper/markInfo.ts
+++ b/apps/editor/src/markdown/plugins/helper/markInfo.ts
@@ -107,11 +107,10 @@ function image({ lastChild }: LinkMdNode, start: MdPos, end: MdPos) {
 
 function link({ lastChild, extendedAutolink }: LinkMdNode, start: MdPos, end: MdPos) {
   const lastChildCh = lastChild ? getMdEndCh(lastChild) + 1 : 2; // 2: length of '[]'
-  const marks = extendedAutolink
+
+  return extendedAutolink
     ? [markInfo(start, end, LINK, { desc: true })]
     : markLink(start, end, start, lastChildCh);
-
-  return marks;
 }
 
 function code({ tickCount }: CodeMdNode, start: MdPos, end: MdPos) {

--- a/apps/editor/src/markdown/plugins/helper/markInfo.ts
+++ b/apps/editor/src/markdown/plugins/helper/markInfo.ts
@@ -50,10 +50,11 @@ type MarkType =
   | typeof HTML
   | typeof META;
 
-interface MarkInfo {
+export interface MarkInfo {
   start: MdPos;
   end: MdPos;
-  spec: { type?: MarkType; attrs?: Record<string, any> };
+  spec?: { type?: MarkType; attrs?: Record<string, any> };
+  lineBackground?: boolean;
 }
 
 function markInfo(start: MdPos, end: MdPos, type: MarkType, attrs?: Record<string, any>): MarkInfo {
@@ -69,7 +70,7 @@ function heading({ level, headingType }: HeadingMdNode, start: MdPos, end: MdPos
     marks.push(markInfo(setOffsetPos(end, 0), end, HEADING, { seText: true }));
   }
 
-  return { marks };
+  return marks;
 }
 
 function emphasisAndStrikethrough(
@@ -80,13 +81,11 @@ function emphasisAndStrikethrough(
   const startDelimPos = addOffsetPos(start, delimSize[type]);
   const endDelimPos = addOffsetPos(end, -delimSize[type]);
 
-  return {
-    marks: [
-      markInfo(startDelimPos, endDelimPos, type),
-      markInfo(start, startDelimPos, DELIM),
-      markInfo(endDelimPos, end, DELIM),
-    ],
-  };
+  return [
+    markInfo(startDelimPos, endDelimPos, type),
+    markInfo(start, startDelimPos, DELIM),
+    markInfo(endDelimPos, end, DELIM),
+  ];
 }
 
 function markLink(start: MdPos, end: MdPos, linkTextStart: MdPos, lastChildCh: number) {
@@ -103,9 +102,7 @@ function image({ lastChild }: LinkMdNode, start: MdPos, end: MdPos) {
   const lastChildCh = lastChild ? getMdEndCh(lastChild) + 1 : 3; // 3: length of '![]'
   const linkTextEnd = addOffsetPos(start, 1);
 
-  return {
-    marks: [markInfo(start, linkTextEnd, META), ...markLink(start, end, linkTextEnd, lastChildCh)],
-  };
+  return [markInfo(start, linkTextEnd, META), ...markLink(start, end, linkTextEnd, lastChildCh)];
 }
 
 function link({ lastChild, extendedAutolink }: LinkMdNode, start: MdPos, end: MdPos) {
@@ -114,21 +111,19 @@ function link({ lastChild, extendedAutolink }: LinkMdNode, start: MdPos, end: Md
     ? [markInfo(start, end, LINK, { desc: true })]
     : markLink(start, end, start, lastChildCh);
 
-  return { marks };
+  return marks;
 }
 
 function code({ tickCount }: CodeMdNode, start: MdPos, end: MdPos) {
   const openDelimEnd = addOffsetPos(start, tickCount);
   const closeDelimStart = addOffsetPos(end, -tickCount);
 
-  return {
-    marks: [
-      markInfo(start, end, CODE),
-      markInfo(start, openDelimEnd, CODE, { start: true }),
-      markInfo(openDelimEnd, closeDelimStart, CODE, { marked: true }),
-      markInfo(closeDelimStart, end, CODE, { end: true }),
-    ],
-  };
+  return [
+    markInfo(start, end, CODE),
+    markInfo(start, openDelimEnd, CODE, { start: true }),
+    markInfo(openDelimEnd, closeDelimStart, CODE, { marked: true }),
+    markInfo(closeDelimStart, end, CODE, { end: true }),
+  ];
 }
 
 function lineBackground(parent: MdNode, start: MdPos, end: MdPos, prefix: string) {
@@ -137,6 +132,7 @@ function lineBackground(parent: MdNode, start: MdPos, end: MdPos, prefix: string
         start,
         end,
         spec: { attrs: { className: `${prefix}-line-background` } },
+        lineBackground: true,
       }
     : null;
 }
@@ -167,10 +163,9 @@ function codeBlock(node: CodeBlockMdNode, start: MdPos, end: MdPos, endLine: str
     marks.push(markInfo(setOffsetPos(end, 1), end, DELIM));
   }
 
-  return {
-    marks,
-    lineBackground: lineBackground(parent!, start, end, 'code-block'),
-  };
+  const lineBackgroundMarkInfo = lineBackground(parent!, start, end, 'code-block');
+
+  return lineBackgroundMarkInfo ? marks.concat(lineBackgroundMarkInfo) : marks;
 }
 
 function customBlock(node: MdNode, start: MdPos, end: MdPos) {
@@ -188,10 +183,9 @@ function customBlock(node: MdNode, start: MdPos, end: MdPos) {
 
   marks.push(markInfo(setOffsetPos(end, 1), end, DELIM));
 
-  return {
-    marks,
-    lineBackground: lineBackground(parent!, start, end, 'custom-block'),
-  };
+  const lineBackgroundMarkInfo = lineBackground(parent!, start, end, 'custom-block');
+
+  return lineBackgroundMarkInfo ? marks.concat(lineBackgroundMarkInfo) : marks;
 }
 
 function markListItemChildren(node: MdNode, markType: MarkType) {
@@ -248,7 +242,7 @@ function blockQuote(node: MdNode, start: MdPos, end: MdPos) {
     marks = [...marks, ...childMarks];
   }
 
-  return { marks };
+  return marks;
 }
 
 function getSpecOfListItemStyle(node: MdNode): [MarkType, Record<string, any>] {
@@ -276,7 +270,7 @@ function item(node: ListItemMdNode, start: MdPos) {
     marks.push(markInfo(addOffsetPos(start, padding + 1), addOffsetPos(start, padding + 2), META));
   }
 
-  return { marks: marks.concat(markListItemChildren(node.firstChild!, TEXT)) };
+  return marks.concat(markListItemChildren(node.firstChild!, TEXT));
 }
 
 const markNodeFuncMap = {
@@ -302,37 +296,17 @@ const simpleMarkClassNameMap = {
 
 type MarkNodeFuncMapKey = keyof typeof markNodeFuncMap;
 type SimpleNodeFuncMapKey = keyof typeof simpleMarkClassNameMap;
-interface MarkNodeFuncMapResult {
-  marks: MarkInfo[];
-  lineBackground?: MarkInfo | null;
-}
 
-/**
- * Gets mark information to the markdown node.
- * @param {Object} node - node returned from ToastMark
- * @param {Array} start - start position
- * @param {Array} end - end position
- * @param {string} endLine - end line's data
- * @returns {?Object} mark information
- * @ignore
- */
 export function getMarkInfo(node: MdNode, start: MdPos, end: MdPos, endLine: string) {
   const { type } = node;
 
   if (isFunction(markNodeFuncMap[type as MarkNodeFuncMapKey])) {
-    return markNodeFuncMap[type as MarkNodeFuncMapKey](
-      // @ts-ignore
-      node,
-      start,
-      end,
-      endLine
-    ) as MarkNodeFuncMapResult;
+    // @ts-ignore
+    return markNodeFuncMap[type as MarkNodeFuncMapKey](node, start, end, endLine);
   }
 
   if (simpleMarkClassNameMap[type as SimpleNodeFuncMapKey]) {
-    return {
-      marks: [markInfo(start, end, simpleMarkClassNameMap[type as SimpleNodeFuncMapKey])],
-    };
+    return [markInfo(start, end, simpleMarkClassNameMap[type as SimpleNodeFuncMapKey])];
   }
 
   return null;

--- a/apps/editor/src/markdown/plugins/helper/markInfo.ts
+++ b/apps/editor/src/markdown/plugins/helper/markInfo.ts
@@ -131,7 +131,7 @@ function lineBackground(parent: MdNode, start: MdPos, end: MdPos, prefix: string
     ? {
         start,
         end,
-        spec: { attrs: { className: `${prefix}-line-background` } },
+        spec: { attrs: { className: `${prefix}-line-background`, codeStart: start, codeEnd: end } },
         lineBackground: true,
       }
     : null;

--- a/apps/editor/src/markdown/plugins/syntaxHighlight.ts
+++ b/apps/editor/src/markdown/plugins/syntaxHighlight.ts
@@ -58,8 +58,8 @@ function appendMarkTr(tr: Transaction, schema: Schema, marks: MarkInfo[]) {
   const startPosListPerLine = getStartPosListPerLine(doc, doc.childCount);
 
   marks.forEach(({ start, end, spec, lineBackground }) => {
-    const startIndex = start[0] - 1;
-    const endIndex = end[0] - 1;
+    const startIndex = Math.min(start[0], doc.childCount) - 1;
+    const endIndex = Math.min(end[0], doc.childCount) - 1;
     const startNode = doc.child(startIndex);
     const endNode = doc.child(endIndex);
 
@@ -71,13 +71,12 @@ function appendMarkTr(tr: Transaction, schema: Schema, marks: MarkInfo[]) {
     from += start[1] + getWidgetNodePos(startNode, start[1] - 1);
     to += end[1] + getWidgetNodePos(endNode, end[1] - 1);
 
-    if (lineBackground) {
-      const attrs = spec ? { codeStart: start, codeEnd: end, ...spec.attrs } : null;
-
-      // @ts-ignore
-      tr.setBlockType(from, to, paragraph, attrs);
-    } else if (spec) {
-      tr.addMark(from, to, schema.mark(spec.type!, spec.attrs));
+    if (spec) {
+      if (lineBackground) {
+        tr.setBlockType(from, to, paragraph, { codeStart: start, codeEnd: end, ...spec.attrs });
+      } else {
+        tr.addMark(from, to, schema.mark(spec.type!, spec.attrs));
+      }
     } else {
       tr.removeMark(from, to);
     }

--- a/apps/editor/src/markdown/plugins/syntaxHighlight.ts
+++ b/apps/editor/src/markdown/plugins/syntaxHighlight.ts
@@ -134,8 +134,8 @@ function cacheIndexToRemoveBackground(doc: ProsemirrorNode, start: MdPos, end: M
       skipLines.push(codeStart[0]);
       codeEnd[0] = Math.min(codeEnd[0], doc.childCount);
 
-      // should subtract `1` to markdown line position
-      // because markdown parser has `1`(not zero) as the start number
+      // should subtract '1' to markdown line position
+      // because markdown parser has '1'(not zero) as the start number
       const startIndex = codeStart[0] - 1;
       const [endIndex] = end;
 

--- a/apps/editor/src/markdown/plugins/syntaxHighlight.ts
+++ b/apps/editor/src/markdown/plugins/syntaxHighlight.ts
@@ -26,7 +26,7 @@ export function syntaxHighlight({ schema, toastMark }: MdContext) {
           const { nodes, removedNodeRange } = result;
 
           if (nodes.length) {
-            markInfo = markInfo.concat(getRemovingMark(newTr, nodes));
+            markInfo = markInfo.concat(getMarkForRemoving(newTr, nodes));
 
             for (const parent of nodes) {
               const walker = parent.walker();
@@ -36,7 +36,7 @@ export function syntaxHighlight({ schema, toastMark }: MdContext) {
                 const { node, entering } = event;
 
                 if (entering) {
-                  markInfo = markInfo.concat(getAddingMark(node, toastMark));
+                  markInfo = markInfo.concat(getMarkForAdding(node, toastMark));
                 }
                 event = walker.next();
               }
@@ -105,14 +105,14 @@ function appendMarkTr(tr: Transaction, schema: Schema, marks: MarkInfo[]) {
   });
 }
 
-function getRemovingMark({ doc }: Transaction, nodes: MdNode[]): MarkInfo[] {
+function getMarkForRemoving({ doc }: Transaction, nodes: MdNode[]) {
   const [start] = nodes[0].sourcepos!;
   const [, end] = last(nodes).sourcepos!;
   const startPos: MdPos = [start[0], start[1]];
   const endPos: MdPos = [end[0], end[1] + 1];
-  const marks = [];
+  const marks: MarkInfo[] = [];
 
-  const skipLines = [];
+  const skipLines: number[] = [];
 
   // remove code block, custom block background
   for (let i = start[0] - 1; i < end[0]; i += 1) {
@@ -131,7 +131,7 @@ function getRemovingMark({ doc }: Transaction, nodes: MdNode[]): MarkInfo[] {
   return marks;
 }
 
-function getAddingMark(node: MdNode, toastMark: ToastMark) {
+function getMarkForAdding(node: MdNode, toastMark: ToastMark) {
   const lineTexts = toastMark.getLineTexts();
   const startPos: MdPos = [getMdStartLine(node), getMdStartCh(node)];
   const endPos: MdPos = [getMdEndLine(node), getMdEndCh(node) + 1];


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
**improve the performance when editing the large content**
* Each time a highlight is applied to a markdown text, it does not calculate the position, but rather takes all the starting positions by line, and then highlight the text using it(mapping start position)
* For background highlighting of code blocks, the background of nodes was removed and re-applied, which resulted in frequent unnecessary style changes. To prevent this, find and change only the nodes that need to remove the background, not the entire nodes.


* before
![2021-03-29 18-01-16 2021-03-29 18_01_29](https://user-images.githubusercontent.com/37766175/112813160-deb94c80-90b8-11eb-94d6-6b57b0967ef9.gif)

* after
![2021-03-29 18-00-19 2021-03-29 18_01_02](https://user-images.githubusercontent.com/37766175/112813214-ed076880-90b8-11eb-85a0-7589a5b84194.gif)




---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
