### PR TITLE
fix: `heading`, `blockquote`, `list`, `hr` command, keymap operation(wrong selection, wrong operation)

### DIFF
--- a/apps/editor/src/__test__/unit/markdown/keymap.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/keymap.spec.ts
@@ -353,6 +353,15 @@ describe('extend list keymap', () => {
 
       expect(getTextContent(mde)).toBe(input);
     });
+
+    it('should delete the row in case of empty bullet list content with next content', () => {
+      mde.setMarkdown('* bullet1\n* \nparagraph');
+      mde.setSelection([2, 3], [2, 3]);
+
+      forceKeymapFn('listItem', 'extendList');
+
+      expect(getTextContent(mde)).toBe('* bullet1\n\nparagraph');
+    });
   });
 
   describe('ordered list', () => {

--- a/apps/editor/src/__test__/unit/markdown/keymap.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/keymap.spec.ts
@@ -1,5 +1,5 @@
 import { source, stripIndent } from 'common-tags';
-import { ToastMark } from '@toast-ui/toastmark';
+import { Sourcepos, ToastMark } from '@toast-ui/toastmark';
 import MarkdownEditor from '@/markdown/mdEditor';
 import EventEmitter from '@/event/eventEmitter';
 import { getTextContent } from './util';
@@ -16,6 +16,10 @@ function forceKeymapFn(type: string, methodName: string, args: any[] = []) {
 }
 
 let mde: MarkdownEditor, em: EventEmitter;
+
+function assertSelection(mdPos: Sourcepos) {
+  expect(mde.getSelection()).toEqual(mdPos);
+}
 
 beforeEach(() => {
   em = new EventEmitter();
@@ -125,6 +129,10 @@ describe('extend block quote keymap', () => {
     forceKeymapFn('blockQuote', 'extendBlockQuote');
 
     expect(getTextContent(mde)).toBe('> block\n> ');
+    assertSelection([
+      [2, 3],
+      [2, 3],
+    ]);
   });
 
   it('should extend the block quote with sliced text', () => {
@@ -134,6 +142,10 @@ describe('extend block quote keymap', () => {
     forceKeymapFn('blockQuote', 'extendBlockQuote');
 
     expect(getTextContent(mde)).toBe('> blo\n> ck');
+    assertSelection([
+      [2, 3],
+      [2, 3],
+    ]);
   });
 
   it('should extend the block quot on multi line selection', () => {
@@ -152,6 +164,24 @@ describe('extend block quote keymap', () => {
     forceKeymapFn('blockQuote', 'extendBlockQuote');
 
     expect(getTextContent(mde)).toBe('> block\n\n');
+  });
+
+  it('should delete the row in case of empty block quote content with next content', () => {
+    mde.setMarkdown('> block\n>\nparagraph');
+    mde.setSelection([2, 2], [2, 2]);
+
+    forceKeymapFn('blockQuote', 'extendBlockQuote');
+
+    expect(getTextContent(mde)).toBe('> block\n\nparagraph');
+  });
+
+  it('should not extend block quote when position is start offset', () => {
+    mde.setMarkdown('> block');
+    mde.setSelection([1, 1], [1, 1]);
+
+    forceKeymapFn('blockQuote', 'extendBlockQuote');
+
+    expect(getTextContent(mde)).toBe('> block');
   });
 });
 
@@ -172,6 +202,10 @@ describe('extend list keymap', () => {
       forceKeymapFn('listItem', 'extendList');
 
       expect(getTextContent(mde)).toBe(result);
+      assertSelection([
+        [2, 3],
+        [2, 3],
+      ]);
     });
 
     it('should extend the bullet list with sliced text', () => {
@@ -189,6 +223,10 @@ describe('extend list keymap', () => {
       forceKeymapFn('listItem', 'extendList');
 
       expect(getTextContent(mde)).toBe(result);
+      assertSelection([
+        [2, 3],
+        [2, 3],
+      ]);
     });
 
     it('should extend the nested bullet list', () => {
@@ -244,6 +282,10 @@ describe('extend list keymap', () => {
       forceKeymapFn('listItem', 'extendList');
 
       expect(getTextContent(mde)).toBe(result);
+      assertSelection([
+        [2, 7],
+        [2, 7],
+      ]);
     });
 
     it('should extend the bullet list on multi line selection', () => {
@@ -329,6 +371,10 @@ describe('extend list keymap', () => {
       forceKeymapFn('listItem', 'extendList');
 
       expect(getTextContent(mde)).toBe(result);
+      assertSelection([
+        [2, 4],
+        [2, 4],
+      ]);
     });
 
     it('should extend the ordered list with sliced text', () => {
@@ -346,6 +392,10 @@ describe('extend list keymap', () => {
       forceKeymapFn('listItem', 'extendList');
 
       expect(getTextContent(mde)).toBe(result);
+      assertSelection([
+        [2, 4],
+        [2, 4],
+      ]);
     });
 
     it('should reorder the list list in the middle of ordered list', () => {
@@ -434,6 +484,10 @@ describe('extend list keymap', () => {
       forceKeymapFn('listItem', 'extendList');
 
       expect(getTextContent(mde)).toBe(result);
+      assertSelection([
+        [2, 8],
+        [2, 8],
+      ]);
     });
 
     it('should extend the ordered list on multi line selection', () => {

--- a/apps/editor/src/__test__/unit/markdown/mdCommand.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/mdCommand.spec.ts
@@ -184,6 +184,19 @@ describe('blockQuote command', () => {
 
     expect(getTextContent(mde)).toBe('blockQuote');
   });
+
+  it('should select last position of the line when adding the blockQuote syntax', () => {
+    mde.setMarkdown('\ntest');
+
+    mde.setSelection([1, 1], [1, 1]);
+    cmd.exec('blockQuote');
+
+    expect(getTextContent(mde)).toBe('> \ntest');
+    expect(mde.getSelection()).toEqual([
+      [1, 3],
+      [1, 3],
+    ]);
+  });
 });
 
 describe('hr command', () => {
@@ -294,6 +307,19 @@ describe('heading command', () => {
     cmd.exec('heading', { level: 2 });
 
     expect(getTextContent(mde)).toBe('## heading1\n## heading2');
+  });
+
+  it('should select last position of the line when adding the heading syntax', () => {
+    mde.setMarkdown('\ntest');
+
+    mde.setSelection([1, 1], [1, 1]);
+    cmd.exec('heading', { level: 1 });
+
+    expect(getTextContent(mde)).toBe('# \ntest');
+    expect(mde.getSelection()).toEqual([
+      [1, 3],
+      [1, 3],
+    ]);
   });
 });
 

--- a/apps/editor/src/__test__/unit/markdown/mdCommand.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/mdCommand.spec.ts
@@ -508,6 +508,28 @@ describe('orderedList command', () => {
 
     expect(getTextContent(mde)).toBe(result);
   });
+
+  it('should change paragraph to ordered list with prev bullet list', () => {
+    const input = source`
+      * bullet1
+
+      ordered1
+      ordered2
+    `;
+    const result = source`
+    * bullet1
+
+    1. ordered1
+    2. ordered2
+    `;
+
+    mde.setMarkdown(input);
+
+    mde.setSelection([3, 2], [4, 2]);
+    cmd.exec('orderedList');
+
+    expect(getTextContent(mde)).toBe(result);
+  });
 });
 
 describe('taskList command', () => {

--- a/apps/editor/src/__test__/unit/markdown/mdCommand.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/mdCommand.spec.ts
@@ -580,8 +580,8 @@ describe('orderedList command', () => {
       1. bullet1
       2. bullet2
       3. bullet3
-         1. bullet4
-         2. bullet5
+         * bullet4
+         * bullet5
       4. bullet6
     `;
 

--- a/apps/editor/src/__test__/unit/markdown/mdCommand.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/mdCommand.spec.ts
@@ -530,6 +530,68 @@ describe('orderedList command', () => {
 
     expect(getTextContent(mde)).toBe(result);
   });
+
+  it('should change bullet list to ordered list partially', () => {
+    const input = source`
+      * bullet1
+      * bullet2
+      * bullet3
+         * bullet4
+         * bullet5
+    `;
+    const firstResult = source`
+      1. bullet1
+      2. bullet2
+      3. bullet3
+         * bullet4
+         * bullet5
+    `;
+    const secondResult = source`
+      1. bullet1
+      2. bullet2
+      3. bullet3
+         1. bullet4
+         2. bullet5
+    `;
+
+    mde.setMarkdown(input);
+
+    mde.setSelection([1, 2], [1, 2]);
+    cmd.exec('orderedList');
+
+    expect(getTextContent(mde)).toBe(firstResult);
+
+    mde.setSelection([4, 2], [4, 2]);
+    cmd.exec('orderedList');
+
+    expect(getTextContent(mde)).toBe(secondResult);
+  });
+
+  it('should change bullet list to ordered list with extended ranges', () => {
+    const input = source`
+      * bullet1
+      * bullet2
+      * bullet3
+         * bullet4
+         * bullet5
+      * bullet6
+    `;
+    const result = source`
+      1. bullet1
+      2. bullet2
+      3. bullet3
+         1. bullet4
+         2. bullet5
+      4. bullet6
+    `;
+
+    mde.setMarkdown(input);
+
+    mde.setSelection([1, 2], [1, 2]);
+    cmd.exec('orderedList');
+
+    expect(getTextContent(mde)).toBe(result);
+  });
 });
 
 describe('taskList command', () => {

--- a/apps/editor/src/helper/manipulation.ts
+++ b/apps/editor/src/helper/manipulation.ts
@@ -48,7 +48,8 @@ export function createText(schema: Schema, text: string, marks?: Mark[]) {
 }
 
 export function createTextSelection(tr: Transaction, from: number, to = from) {
-  const { size } = tr.doc.content;
+  const contentSize = tr.doc.content.size;
+  const size = contentSize > 0 ? contentSize - 1 : 1;
 
   return TextSelection.create(tr.doc, Math.min(from, size), Math.min(to, size));
 }

--- a/apps/editor/src/markdown/helper/list.ts
+++ b/apps/editor/src/markdown/helper/list.ts
@@ -216,7 +216,9 @@ export const otherNodeToList: NodeToList = {
 
     for (let i = startLine - 1; i > 0; i -= 1) {
       const mdNode = toastMark.findFirstNodeAtLine(i)!;
-      const canBeListNode = !!findClosestNode(mdNode, (targetNode) => isListNode(targetNode));
+      const text = getTextByMdLine(doc, i);
+      const canBeListNode =
+        text && !!findClosestNode(mdNode, (targetNode) => isListNode(targetNode));
       const searchResult = reOrderedListGroup.exec(getTextByMdLine(doc, i));
 
       if (!searchResult && !canBeListNode) {

--- a/apps/editor/src/markdown/helper/pos.ts
+++ b/apps/editor/src/markdown/helper/pos.ts
@@ -148,15 +148,16 @@ export function getRangeInfo(selection: Selection) {
   };
 }
 
-export function getNodeOffsetRange(doc: ProsemirrorNode, targetIndex: number) {
+export function getNodeContentOffsetRange(doc: ProsemirrorNode, targetIndex: number) {
   let startOffset = 1;
   let endOffset = 1;
 
   for (let i = 0, offset = 0; i < doc.childCount; i += 1) {
     const { nodeSize } = doc.child(i);
 
+    // calculate content start, end offset(not node offset)
     startOffset = offset + 1;
-    endOffset = offset + nodeSize;
+    endOffset = offset + nodeSize - 1;
 
     if (i === targetIndex) {
       break;

--- a/apps/editor/src/markdown/marks/heading.ts
+++ b/apps/editor/src/markdown/marks/heading.ts
@@ -2,7 +2,7 @@ import { DOMOutputSpecArray, Mark as ProsemirrorMark, ProsemirrorNode } from 'pr
 import { EditorCommand } from '@t/spec';
 import { clsWithMdPrefix } from '@/utils/dom';
 import Mark from '@/spec/mark';
-import { createParagraph, replaceNodes } from '@/helper/manipulation';
+import { createParagraph, createTextSelection, replaceNodes } from '@/helper/manipulation';
 import { getRangeInfo } from '../helper/pos';
 import { getTextContent } from '../helper/query';
 
@@ -67,7 +67,8 @@ export class Heading extends Mark {
       }
 
       if (nodes.length) {
-        dispatch!(replaceNodes(tr, startFromOffset, endToOffset, nodes));
+        replaceNodes(tr, startFromOffset, endToOffset, nodes);
+        dispatch!(tr.setSelection(createTextSelection(tr, tr.mapping.map(endToOffset) - 1)));
         return true;
       }
       return false;

--- a/apps/editor/src/markdown/marks/listItem.ts
+++ b/apps/editor/src/markdown/marks/listItem.ts
@@ -109,7 +109,7 @@ export class ListItem extends Mark {
             : insertNodes(tr, endToOffset, node);
         }
         // should add `2` to selection end position considering start, end block tag position
-        const newSelection = createTextSelection(newTr, endToOffset + listSyntax.length + 2);
+        const newSelection = createTextSelection(newTr, to + listSyntax.length + 2);
 
         dispatch!(newTr.setSelection(newSelection));
       }

--- a/apps/editor/src/markdown/marks/listItem.ts
+++ b/apps/editor/src/markdown/marks/listItem.ts
@@ -25,7 +25,7 @@ import {
   reList,
   ToListContext,
 } from '../helper/list';
-import { getRangeInfo, getNodeOffsetRange } from '../helper/pos';
+import { getRangeInfo, getNodeContentOffsetRange } from '../helper/pos';
 import { getTextContent } from '../helper/query';
 
 type CommandType = 'bullet' | 'ordered' | 'task';
@@ -100,7 +100,7 @@ export class ListItem extends Mark {
         // change ordinal number of backward ordered list
         if (changedResults?.length) {
           // get end offset of the last list
-          const { endOffset } = getNodeOffsetRange(doc, lastIndex!);
+          const { endOffset } = getNodeContentOffsetRange(doc, lastIndex!);
           const nodes = changedResults.map(({ text }) => createParagraph(schema, text));
 
           nodes.unshift(node);
@@ -128,7 +128,7 @@ export class ListItem extends Mark {
       // should add `1` to line for the markdown parser
       // because markdown parser has `1`(not zero) as the start number
       const startLine = rangeInfo.startIndex + 1;
-      const endLine = rangeInfo.endIndex + 1;
+      let endLine = rangeInfo.endIndex + 1;
       let { startFromOffset, endToOffset } = rangeInfo;
 
       let skipLines: number[] = [];
@@ -153,10 +153,11 @@ export class ListItem extends Mark {
         let firstListStartOffset, lastListEndOffset;
 
         if (!isUndefined(firstIndex)) {
-          firstListStartOffset = getNodeOffsetRange(doc, firstIndex).startOffset;
+          firstListStartOffset = getNodeContentOffsetRange(doc, firstIndex).startOffset;
         }
         if (!isUndefined(lastIndex)) {
-          lastListEndOffset = getNodeOffsetRange(doc, lastIndex).endOffset;
+          endLine = Math.max(endLine, lastIndex + 1);
+          lastListEndOffset = getNodeContentOffsetRange(doc, lastIndex).endOffset;
         }
 
         if (changedResults) {
@@ -200,7 +201,7 @@ export class ListItem extends Mark {
           const { checked, padding } = mdNode.listData;
           const stateChar = checked ? ' ' : 'x';
           const [mdPos] = mdNode.sourcepos!;
-          let { startOffset } = getNodeOffsetRange(doc, mdPos[0] - 1);
+          let { startOffset } = getNodeContentOffsetRange(doc, mdPos[0] - 1);
 
           startOffset += mdPos[1] + padding;
 

--- a/apps/editor/src/markdown/marks/listItem.ts
+++ b/apps/editor/src/markdown/marks/listItem.ts
@@ -2,8 +2,6 @@ import { DOMOutputSpecArray, Mark as ProsemirrorMark, ProsemirrorNode } from 'pr
 import { Transaction } from 'prosemirror-state';
 import { Command } from 'prosemirror-commands';
 import { ListItemMdNode, MdNode } from '@toast-ui/toastmark';
-import isNumber from 'tui-code-snippet/type/isNumber';
-import isUndefined from 'tui-code-snippet/type/isUndefined';
 import { EditorCommand, MdSpecContext } from '@t/spec';
 import { clsWithMdPrefix } from '@/utils/dom';
 import Mark from '@/spec/mark';
@@ -123,7 +121,7 @@ export class ListItem extends Mark {
   }
 
   private toList(commandType: CommandType): EditorCommand {
-    return () => ({ doc, tr, selection, schema }, dispatch) => {
+    return () => ({ doc, tr, selection }, dispatch) => {
       const { toastMark } = this.context;
       const rangeInfo = getRangeInfo(selection);
       // should add `1` to line for the markdown parser

--- a/apps/editor/src/markdown/marks/table.ts
+++ b/apps/editor/src/markdown/marks/table.ts
@@ -143,9 +143,7 @@ export class Table extends Mark {
           }
         }
 
-        const pos = Math.min(endFromOffset + chOffset, tr.doc.content.size - 1);
-
-        dispatch!(tr.setSelection(createTextSelection(tr, pos)));
+        dispatch!(tr.setSelection(createTextSelection(tr, endFromOffset + chOffset)));
 
         return true;
       }

--- a/apps/editor/src/markdown/marks/thematicBreak.ts
+++ b/apps/editor/src/markdown/marks/thematicBreak.ts
@@ -2,7 +2,7 @@ import { DOMOutputSpecArray } from 'prosemirror-model';
 import { EditorCommand } from '@t/spec';
 import { clsWithMdPrefix } from '@/utils/dom';
 import Mark from '@/spec/mark';
-import { createParagraph, createTextSelection } from '@/helper/manipulation';
+import { createParagraph, createTextSelection, replaceNodes } from '@/helper/manipulation';
 import { getRangeInfo } from '../helper/pos';
 
 const thematicBreakSyntax = '***';
@@ -32,8 +32,9 @@ export class ThematicBreak extends Mark {
         nodes.push(emptyNode);
       }
 
+      replaceNodes(tr, from, to, nodes, { from: 0, to: 0 });
       // add 3(`***` length) and 3(start, end block tag position)
-      dispatch!(tr.replaceWith(from, to, nodes).setSelection(createTextSelection(tr, from + 6)));
+      dispatch!(tr.setSelection(createTextSelection(tr, from + 6)));
 
       return true;
     };

--- a/apps/editor/src/markdown/nodes/paragraph.ts
+++ b/apps/editor/src/markdown/nodes/paragraph.ts
@@ -13,7 +13,7 @@ import {
   replaceNodes,
 } from '@/helper/manipulation';
 import { reBlockQuote } from '../marks/blockQuote';
-import { getRangeInfo, getNodeOffsetRange } from '../helper/pos';
+import { getRangeInfo, getNodeContentOffsetRange } from '../helper/pos';
 import { getReorderedListInfo, reList, reOrderedListGroup } from '../helper/list';
 import { getTextByMdLine, getTextContent } from '../helper/query';
 
@@ -126,8 +126,8 @@ export class Paragraph extends Node {
 
     endLine = Math.max(endLine, line - 1);
 
-    const { startOffset } = getNodeOffsetRange(doc, startLine - 1);
-    const { endOffset } = getNodeOffsetRange(doc, endLine - 1);
+    const { startOffset } = getNodeContentOffsetRange(doc, startLine - 1);
+    const { endOffset } = getNodeContentOffsetRange(doc, endLine - 1);
     const newTr = replaceNodes(tr, startOffset, endOffset, nodes);
     const newSelection = createTextSelection(newTr, selection.from, selection.to);
 

--- a/apps/editor/src/markdown/plugins/smartTask.ts
+++ b/apps/editor/src/markdown/plugins/smartTask.ts
@@ -3,7 +3,7 @@ import { EditorView } from 'prosemirror-view';
 import { MdPos } from '@toast-ui/toastmark';
 import { MdContext } from '@t/spec';
 import { findClosestNode } from '@/utils/markdown';
-import { getRangeInfo, getNodeOffsetRange } from '../helper/pos';
+import { getRangeInfo, getNodeContentOffsetRange } from '../helper/pos';
 
 const reTaskMarkerKey = /x|backspace/i;
 const reTaskMarker = /^\[(\s*)(x?)(\s*)\](?:\s+)/i;
@@ -34,7 +34,7 @@ export function smartTask({ schema, toastMark }: MdContext) {
                 const [startMdPos] = firstChild.sourcepos!;
                 const [, startSpaces, stateChar, lastSpaces] = matched;
                 const spaces = startSpaces.length + lastSpaces.length;
-                const { startOffset } = getNodeOffsetRange(doc, startMdPos[0] - 1);
+                const { startOffset } = getNodeContentOffsetRange(doc, startMdPos[0] - 1);
                 const startPos = startMdPos[1] + startOffset;
 
                 if (stateChar) {

--- a/apps/editor/src/utils/common.ts
+++ b/apps/editor/src/utils/common.ts
@@ -152,7 +152,7 @@ export function deepCopy<T extends Record<string, any>>(obj: T) {
   }, {} as T);
 }
 
-export function assign(targetObj: Record<string, any>, obj: Record<string, any>) {
+export function assign(targetObj: Record<string, any>, obj: Record<string, any> = {}) {
   Object.keys(obj).forEach((prop) => {
     if (targetObj.hasOwnProperty(prop) && typeof targetObj[prop] === 'object') {
       if (Array.isArray(obj[prop])) {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
The modified operation is described below. Images are not attached for repeated operation or the bug.

#### Heading
* After executing the command, the caret position should be located at the end of the line.
![2021-05-14 10-20-58 2021-05-14 10_21_07](https://user-images.githubusercontent.com/37766175/118206752-1ed46300-b49e-11eb-965c-b38d0b3e86c4.gif)


#### Blockquote
* After executing the command, the caret position should be located at the end of the line.
* After extending the blockquote, the caret position should be located at the start of the line in new block quote.
![2021-05-14 10-22-01 2021-05-14 10_22_18](https://user-images.githubusercontent.com/37766175/118206826-49262080-b49e-11eb-9ffc-36252c4e4eee.gif)
* After extending the blockquote, the unnecessary blank line has been removed.

#### Hr
* After executing the command, the markdown parsing should be well worked.

#### List
* After executing the command, the caret position should be located at the end of the line.
* After extending the list, the below existing contents should not be changed unintentionally.
* After extending the list, the existing list contents  should be changed properly.
![2021-05-14 12-47-26 2021-05-14 12_47_44](https://user-images.githubusercontent.com/37766175/118218562-a4faa480-b4b2-11eb-90e3-88fe669a3be6.gif)
* After extending the list, the caret position should be located at the start of the line in new list.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
