### PR TITLE
Docs: wrong CDN directory structure

### DIFF
--- a/apps/editor/docs/getting-started.md
+++ b/apps/editor/docs/getting-started.md
@@ -51,8 +51,10 @@ The CDN directory has the following structure:
    │     │    ├─ toastui-editor-all.min.js
    │     │    ├─ toastui-editor-viewer.js
    │     │    ├─ toastui-editor-viewer.min.js
-   │     │    ├─ toastui-editor-editor.css
-   │     │    ├─ toastui-editor-editor.min.css
+   │     │    ├─ toastui-editor.js
+   │     │    ├─ toastui-editor.min.js
+   │     │    ├─ toastui-editor.css
+   │     │    ├─ toastui-editor.min.css
    │     │    ├─ toastui-editor-viewer.css
    │     │    └─ toastui-editor-viewer.min.css
    │     ├─ 2.0.0/


### PR DESCRIPTION
The CDN directory structure contained a couple links that were invalid, so I fixed those, and added their corollary JS files.

<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Testing Notes:

1. Make sure the following links work:
   - https://uicdn.toast.com/editor/latest/toastui-editor.js
   - https://uicdn.toast.com/editor/latest/toastui-editor.min.js
   - https://uicdn.toast.com/editor/latest/toastui-editor.css
   - https://uicdn.toast.com/editor/latest/toastui-editor.min.css
  
2. Make sure the following links **don't** work:
   - https://uicdn.toast.com/editor/latest/toastui-editor-editor.css
   - https://uicdn.toast.com/editor/latest/toastui-editor-editor.min.css
