### PR TITLE
fix: cannot show code block content with code highlight plugin in markdown preview

### DIFF
--- a/plugins/code-syntax-highlight/src/__test__/integration/__snapshots__/codeHighlightPlugin.spec.ts.snap
+++ b/plugins/code-syntax-highlight/src/__test__/integration/__snapshots__/codeHighlightPlugin.spec.ts.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`codeSyntaxHighlightPlugin should render codeblock element with no language info in markdown preview 1`] = `
+<pre class="toastui-editor-md-preview-highlight">
+  <code>
+    console.log(123);
+  </code>
+</pre>
+`;
+
 exports[`codeSyntaxHighlightPlugin should render highlighted codeblock element in markdown preview 1`] = `
 <pre class="lang-yaml toastui-editor-md-preview-highlight">
   <code data-language="yaml">

--- a/plugins/code-syntax-highlight/src/__test__/integration/codeHighlightPlugin.spec.ts
+++ b/plugins/code-syntax-highlight/src/__test__/integration/codeHighlightPlugin.spec.ts
@@ -64,4 +64,18 @@ describe('codeSyntaxHighlightPlugin', () => {
 
     expect(wwEditorHTML).toMatchSnapshot();
   });
+
+  it('should render codeblock element with no language info in markdown preview', () => {
+    const markdown = source`
+      \`\`\`
+        console.log(123);
+      \`\`\`
+    `;
+
+    editor.setMarkdown(markdown);
+
+    const previewHTML = getPreviewHTML();
+
+    expect(previewHTML).toMatchSnapshot();
+  });
 });

--- a/plugins/code-syntax-highlight/src/renderers/toHTMLRenderers.ts
+++ b/plugins/code-syntax-highlight/src/renderers/toHTMLRenderers.ts
@@ -16,7 +16,7 @@ export function getHTMLRenderers(prism: PrismJs) {
         codeAttrs['data-backticks'] = fenceLength;
       }
 
-      let content = '';
+      let content = node.literal!;
 
       if (infoWords.length && infoWords[0].length) {
         const [lang] = infoWords;
@@ -26,9 +26,9 @@ export function getHTMLRenderers(prism: PrismJs) {
 
         const registeredLang = prism.languages[lang];
 
-        content = registeredLang
-          ? prism.highlight(node.literal!, registeredLang, lang)
-          : node.literal!;
+        if (registeredLang) {
+          content = prism.highlight(node.literal!, registeredLang, lang);
+        }
       }
 
       return [


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
* fixed that cannot show code block content with code highlight plugin in markdown preview
<img width="719" alt="스크린샷 2021-06-07 오전 11 45 49" src="https://user-images.githubusercontent.com/37766175/120952416-f03c6600-c785-11eb-8d04-46b512400e5d.png">



---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
