### PR TITLE
fix: wysiwyg toolbar state

### DIFF
--- a/apps/editor/src/css/editor.css
+++ b/apps/editor/src/css/editor.css
@@ -389,6 +389,10 @@
   transform: translateX(12px);
 }
 
+.toastui-editor-dropdown-toolbar .scroll-sync {
+  margin: 0 5px;
+}
+
 .toastui-editor-dropdown-toolbar {
   position: absolute;
   height: 46px;

--- a/apps/editor/src/wysiwyg/plugins/toolbarState.ts
+++ b/apps/editor/src/wysiwyg/plugins/toolbarState.ts
@@ -36,12 +36,13 @@ function setListNodeToolbarState(type: ToolbarStateKeys, nodeTypeState: ToolbarS
   });
 }
 
-function getMarkTypeStates(from: ResolvedPos, schema: Schema) {
+function getMarkTypeStates(from: ResolvedPos, to: ResolvedPos, schema: Schema) {
   const markTypeState = {} as ToolbarState;
 
   MARK_TYPES.forEach((type) => {
     const mark = schema.marks[type];
-    const foundMark = mark.isInSet(from.marks());
+    const marksAtPos = from.marksAcross(to);
+    const foundMark = marksAtPos ? !!mark.isInSet(marksAtPos) : false;
 
     if (foundMark) {
       markTypeState[type as ToolbarStateKeys] = true;
@@ -52,7 +53,7 @@ function getMarkTypeStates(from: ResolvedPos, schema: Schema) {
 }
 
 function getToolbarState(selection: Selection, doc: Node, schema: Schema) {
-  const { $from, from, to } = selection;
+  const { $from, $to, from, to } = selection;
   const nodeTypeState = {} as ToolbarState;
   let markTypeState = {} as ToolbarState;
 
@@ -66,7 +67,7 @@ function getToolbarState(selection: Selection, doc: Node, schema: Schema) {
     if (includes(LIST_TYPES, type)) {
       setListNodeToolbarState(type as ToolbarStateKeys, nodeTypeState);
     } else if (type === 'paragraph' || type === 'text') {
-      markTypeState = getMarkTypeStates($from, schema);
+      markTypeState = getMarkTypeStates($from, $to, schema);
     } else {
       nodeTypeState[type as ToolbarStateKeys] = true;
     }

--- a/apps/editor/src/wysiwyg/plugins/toolbarState.ts
+++ b/apps/editor/src/wysiwyg/plugins/toolbarState.ts
@@ -41,8 +41,8 @@ function getMarkTypeStates(from: ResolvedPos, to: ResolvedPos, schema: Schema) {
 
   MARK_TYPES.forEach((type) => {
     const mark = schema.marks[type];
-    const marksAtPos = from.marksAcross(to);
-    const foundMark = marksAtPos ? !!mark.isInSet(marksAtPos) : false;
+    const marksAtPos = from.marksAcross(to) || [];
+    const foundMark = !!mark.isInSet(marksAtPos);
 
     if (foundMark) {
       markTypeState[type as ToolbarStateKeys] = true;

--- a/plugins/code-syntax-highlight/src/nodeViews/languageSelectBox.ts
+++ b/plugins/code-syntax-highlight/src/nodeViews/languageSelectBox.ts
@@ -11,6 +11,7 @@ import type { Emitter } from '@toast-ui/editor';
 export const WRAPPER_CLASS_NAME = 'code-block-language';
 export const INPUT_CLASS_NANE = 'code-block-language-input';
 export const LIST_CLASS_NAME = 'code-block-language-list';
+export const LANG_ATTR = 'data-language';
 
 const CODE_BLOCK_PADDING = 10;
 
@@ -117,7 +118,7 @@ export class LanguageSelectBox {
 
   private onSelectLanguageButtons = (ev: MouseEvent) => {
     const target = ev.target as HTMLElement;
-    const language = target.getAttribute('data-language');
+    const language = target.getAttribute(LANG_ATTR);
 
     if (language) {
       this.selectLanguage(language);
@@ -196,6 +197,7 @@ export class LanguageSelectBox {
 
     if (this.buttons.length) {
       this.currentButton = this.buttons[index];
+      this.input!.value = this.currentButton.getAttribute(LANG_ATTR)!;
       addClass(this.currentButton, 'active');
       this.currentButton.scrollIntoView();
     }
@@ -242,7 +244,7 @@ export class LanguageSelectBox {
     this.prevStoredLanguage = language;
     this.input!.value = language;
 
-    const item = this.buttons.filter((button) => button.getAttribute('data-language') === language);
+    const item = this.buttons.filter((button) => button.getAttribute(LANG_ATTR) === language);
 
     if (item.length) {
       const index = inArray(item[0], this.buttons);


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
* fixed that cannot activate toolbar state in wysiwyg
![image](https://user-images.githubusercontent.com/37766175/121113580-3f999980-c84d-11eb-91f1-99542c3cfc38.png)
* added margin to scroll sync toolbar item
![image](https://user-images.githubusercontent.com/37766175/121113635-58a24a80-c84d-11eb-8bd8-eca51ca1fa66.png)
* fixed code block highlighting plugin operation to selecting the language by keymap



---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
