### PR TITLE
fix: dropdown toolbar button, custom block parsing

### DIFF
--- a/apps/editor/src/__test__/integration/ui/layout.spec.ts
+++ b/apps/editor/src/__test__/integration/ui/layout.spec.ts
@@ -3,7 +3,10 @@ import { render } from '@/ui/vdom/renderer';
 import { VNode } from '@/ui/vdom/vnode';
 import html from '@/ui/vdom/template';
 import EventEmitter from '@/event/eventEmitter';
+import { cls } from '@/utils/dom';
 import '@/i18n/en-us';
+
+const EDITOR_CLS = 'toastui-editor';
 
 function getElement(selector: string) {
   return document.querySelector<HTMLElement>(selector)!;
@@ -14,27 +17,27 @@ function getElements(selector: string) {
 }
 
 function getEditorMain() {
-  return getElement('.toastui-editor-main')!;
+  return getElement(`.${cls('main')}`)!;
 }
 
 function getMdEditor() {
-  return getElement('.toastui-editor-md-container .toastui-editor')!;
+  return getElement(`.${cls('md-container')} .${EDITOR_CLS}`)!;
 }
 
 function getMdPreview() {
-  return getElement('.toastui-editor-md-container .toastui-editor-md-preview')!;
+  return getElement(`.${cls('md-container')} .${cls('md-preview')}`)!;
 }
 
 function getWwEditor() {
-  return getElement('.toastui-editor-ww-container .toastui-editor')!;
+  return getElement(`.${cls('ww-container')} .${EDITOR_CLS}`)!;
 }
 
 function getMdSwitch() {
-  return getElements('.toastui-editor-mode-switch .tab-item')![0];
+  return getElements(`.${cls('mode-switch')} .tab-item`)![0];
 }
 
 function getWwSwitch() {
-  return getElements('.toastui-editor-mode-switch .tab-item')![1];
+  return getElements(`.${cls('mode-switch')} .tab-item`)![1];
 }
 
 function clickMdSwitch() {
@@ -46,11 +49,11 @@ function clickWwSwitch() {
 }
 
 function getMdWriteTab() {
-  return getElement('.toastui-editor-md-tab-container .tab-item')!;
+  return getElement(`.${cls('md-tab-container')} .tab-item`)!;
 }
 
 function getMdPreviewTab() {
-  return document.querySelectorAll<HTMLElement>('.toastui-editor-md-tab-container .tab-item')[1];
+  return document.querySelectorAll<HTMLElement>(`.${cls('md-tab-container')} .tab-item`)[1];
 }
 
 function getScrollSyncWrapper() {
@@ -77,9 +80,9 @@ describe('layout component', () => {
     const mdPreview = document.createElement('div');
     const wwEditor = document.createElement('div');
 
-    mdEditor.className = 'toastui-editor';
-    mdPreview.className = 'toastui-editor-md-preview';
-    wwEditor.className = 'toastui-editor';
+    mdEditor.className = EDITOR_CLS;
+    mdPreview.className = cls('md-preview');
+    wwEditor.className = EDITOR_CLS;
 
     const dummySlot = {
       mdEditor,
@@ -121,7 +124,7 @@ describe('layout component', () => {
   });
 
   it('show/hide editor', () => {
-    const layout = getElement('.toastui-editor-defaultUI');
+    const layout = getElement(`.${cls('defaultUI')}`);
 
     em.emit('hide');
 
@@ -154,13 +157,13 @@ describe('layout component', () => {
 
       em.emit('changeMode', 'wysiwyg');
 
-      expect(editorArea).toHaveClass('toastui-editor-ww-mode');
+      expect(editorArea).toHaveClass(cls('ww-mode'));
       expect(wwSwitch).toHaveClass('active');
       expect(mdSwitch).not.toHaveClass('active');
 
       em.emit('changeMode', 'markdown');
 
-      expect(editorArea).toHaveClass('toastui-editor-md-mode');
+      expect(editorArea).toHaveClass(cls('md-mode'));
       expect(mdSwitch).toHaveClass('active');
       expect(wwSwitch).not.toHaveClass('active');
     });
@@ -183,17 +186,18 @@ describe('layout component', () => {
 
       em.emit('changeMode', 'wysiwyg');
 
-      expect(scrollSyncWrapper).toHaveStyle({ display: 'none' });
+      expect(getElement('.scroll-sync')).toBeNull();
     });
 
     it('should show scrollSync when previewStyle is changed on only markdown mode', () => {
       em.emit('changeMode', 'wysiwyg');
       em.emit('changePreviewStyle', 'vertical');
-      const scrollSyncWrapper = getScrollSyncWrapper();
 
-      expect(scrollSyncWrapper).toHaveStyle({ display: 'none' });
+      expect(getElement('.scroll-sync')).toBeNull();
 
       em.emit('changeMode', 'markdown');
+
+      const scrollSyncWrapper = getScrollSyncWrapper();
 
       expect(scrollSyncWrapper).toHaveStyle({ display: 'inline-block' });
     });
@@ -201,7 +205,7 @@ describe('layout component', () => {
 
   describe('changing preview style', () => {
     it('should hide markdown tab when changePreviewStyle is triggered', () => {
-      const tabSection = getElement('.toastui-editor-md-tab-container')!;
+      const tabSection = getElement(`.${cls('md-tab-container')}`)!;
 
       expect(tabSection).toHaveStyle({ display: 'block' });
 
@@ -211,7 +215,7 @@ describe('layout component', () => {
     });
 
     it('should hide markdown tab when changeMode is triggered', () => {
-      const tabSection = getElement('.toastui-editor-md-tab-container')!;
+      const tabSection = getElement(`.${cls('md-tab-container')}`)!;
 
       expect(tabSection).toHaveStyle({ display: 'block' });
 
@@ -252,12 +256,12 @@ describe('layout component', () => {
       clickMdPreviewTab();
 
       expect(scrollSyncWrapper).toHaveStyle({ display: 'none' });
-      expect(getElement('.toastui-editor-toolbar-icons')).toBeDisabled();
+      expect(getElement(`.${cls('toolbar-icons')}`)).toBeDisabled();
 
       clickMdWriteTab();
 
       expect(scrollSyncWrapper).toHaveStyle({ display: 'none' });
-      expect(getElement('.toastui-editor-toolbar-icons')).not.toBeDisabled();
+      expect(getElement(`.${cls('toolbar-icons')}`)).not.toBeDisabled();
     });
 
     it('should enable the toolbar items when changeMode is triggered', () => {
@@ -265,11 +269,11 @@ describe('layout component', () => {
 
       em.emit('changeMode', 'wysiwyg');
 
-      expect(getElement('.toastui-editor-toolbar-icons')).not.toBeDisabled();
+      expect(getElement(`.${cls('toolbar-icons')}`)).not.toBeDisabled();
 
       em.emit('changeMode', 'markdown');
 
-      expect(getElement('.toastui-editor-toolbar-icons')).not.toBeDisabled();
+      expect(getElement(`.${cls('toolbar-icons')}`)).not.toBeDisabled();
       expect(getMdWriteTab()).toHaveClass('active');
     });
 
@@ -278,13 +282,13 @@ describe('layout component', () => {
 
       em.emit('changePreviewStyle', 'vertical');
 
-      expect(getElement('.toastui-editor-toolbar-icons')).not.toBeDisabled();
+      expect(getElement(`.${cls('toolbar-icons')}`)).not.toBeDisabled();
     });
   });
 
   describe('context menu', () => {
     it('should be displayed when contextmenu event is triggered', () => {
-      const contextMenu = getElement('.toastui-editor-context-menu');
+      const contextMenu = getElement(`.${cls('context-menu')}`);
 
       expect(contextMenu).toHaveStyle({ display: 'none' });
 

--- a/apps/editor/src/__test__/integration/ui/layout.spec.ts
+++ b/apps/editor/src/__test__/integration/ui/layout.spec.ts
@@ -6,7 +6,7 @@ import EventEmitter from '@/event/eventEmitter';
 import { cls } from '@/utils/dom';
 import '@/i18n/en-us';
 
-const EDITOR_CLS = 'toastui-editor';
+const EDITOR_CLASS = 'toastui-editor';
 
 function getElement(selector: string) {
   return document.querySelector<HTMLElement>(selector)!;
@@ -21,7 +21,7 @@ function getEditorMain() {
 }
 
 function getMdEditor() {
-  return getElement(`.${cls('md-container')} .${EDITOR_CLS}`)!;
+  return getElement(`.${cls('md-container')} .${EDITOR_CLASS}`)!;
 }
 
 function getMdPreview() {
@@ -29,7 +29,7 @@ function getMdPreview() {
 }
 
 function getWwEditor() {
-  return getElement(`.${cls('ww-container')} .${EDITOR_CLS}`)!;
+  return getElement(`.${cls('ww-container')} .${EDITOR_CLASS}`)!;
 }
 
 function getMdSwitch() {
@@ -80,9 +80,9 @@ describe('layout component', () => {
     const mdPreview = document.createElement('div');
     const wwEditor = document.createElement('div');
 
-    mdEditor.className = EDITOR_CLS;
+    mdEditor.className = EDITOR_CLASS;
     mdPreview.className = cls('md-preview');
-    wwEditor.className = EDITOR_CLS;
+    wwEditor.className = EDITOR_CLASS;
 
     const dummySlot = {
       mdEditor,

--- a/apps/editor/src/__test__/integration/ui/toolbar.spec.ts
+++ b/apps/editor/src/__test__/integration/ui/toolbar.spec.ts
@@ -4,6 +4,7 @@ import EventEmitter from '@/event/eventEmitter';
 import html from '@/ui/vdom/template';
 import { render } from '@/ui/vdom/renderer';
 import { Toolbar } from '@/ui/components/toolbar/toolbar';
+import { cls } from '@/utils/dom';
 import '@/i18n/en-us';
 
 function getElement(selector: string) {
@@ -131,7 +132,7 @@ describe('default toolbar', () => {
   it('should show tooltip when mouseover on toolbar button', () => {
     dispatchMouseover('.bold');
 
-    const tooltip = getElement('.toastui-editor-tooltip');
+    const tooltip = getElement(`.${cls('tooltip')}`);
 
     expect(tooltip).toHaveStyle({ display: 'block' });
   });
@@ -150,8 +151,8 @@ describe('default toolbar', () => {
   it('should hide the popup when clicking X button on popup', () => {
     dispatchClick('.link');
 
-    const linkPopup = getElement('.toastui-editor-popup-add-link');
-    const closeBtn = getElement('.toastui-editor-popup-add-link .toastui-editor-close-button');
+    const linkPopup = getElement(`.${cls('popup-add-link')}`);
+    const closeBtn = getElement(`.${cls('popup-add-link')} .${cls('close-button')}`);
 
     closeBtn.click();
 
@@ -188,7 +189,7 @@ describe('default toolbar', () => {
     it('should show the popup when clicking heading button', () => {
       dispatchClick('.heading');
 
-      const headingPopup = getElement('.toastui-editor-popup-add-heading');
+      const headingPopup = getElement(`.${cls('popup-add-heading')}`);
 
       expect(headingPopup).toHaveStyle({ display: 'block' });
     });
@@ -199,7 +200,7 @@ describe('default toolbar', () => {
       em.listen('command', spy);
 
       dispatchClick('.heading');
-      dispatchClick('.toastui-editor-popup-add-heading [data-level="2"]');
+      dispatchClick(`.${cls('popup-add-heading [data-level="2"]')}`);
 
       expect(spy).toHaveBeenCalledWith('heading', { level: 2 });
     });
@@ -209,16 +210,16 @@ describe('default toolbar', () => {
     it('should show the popup when clicking link button', () => {
       dispatchClick('.link');
 
-      const linkPopup = getElement('.toastui-editor-popup-add-link');
+      const linkPopup = getElement(`.${cls('popup-add-link')}`);
 
       expect(linkPopup).toHaveStyle({ display: 'block' });
     });
 
     it('should hide popup when clicking Cancel button', () => {
       dispatchClick('.link');
-      dispatchClick('.toastui-editor-popup-add-link .toastui-editor-close-button');
+      dispatchClick(`.${cls('popup-add-link')} .${cls('close-button')}`);
 
-      const linkPopup = getElement('.toastui-editor-popup-add-link');
+      const linkPopup = getElement(`.${cls('popup-add-link')}`);
 
       expect(linkPopup).toHaveStyle({ display: 'none' });
     });
@@ -231,16 +232,16 @@ describe('default toolbar', () => {
       dispatchClick('.link');
 
       const urlText = getElement(
-        '.toastui-editor-popup-add-link #toastuiLinkUrlInput'
+        `.${cls('popup-add-link #toastuiLinkUrlInput')}`
       ) as HTMLInputElement;
       const linkText = getElement(
-        '.toastui-editor-popup-add-link #toastuiLinkTextInput'
+        `.${cls('popup-add-link #toastuiLinkTextInput')}`
       ) as HTMLInputElement;
 
       urlText.value = 'https://ui.toast.com';
       linkText.value = 'toastui';
 
-      dispatchClick('.toastui-editor-popup-add-link .toastui-editor-ok-button');
+      dispatchClick(`.${cls('popup-add-link')} .${cls('ok-button')}`);
 
       expect(spy).toHaveBeenCalledWith('addLink', {
         linkText: 'toastui',
@@ -252,18 +253,18 @@ describe('default toolbar', () => {
       dispatchClick('.link');
 
       const urlText = getElement(
-        '.toastui-editor-popup-add-link #toastuiLinkUrlInput'
+        `.${cls('popup-add-link #toastuiLinkUrlInput')}`
       ) as HTMLInputElement;
       const linkText = getElement(
-        '.toastui-editor-popup-add-link #toastuiLinkTextInput'
+        `.${cls('popup-add-link #toastuiLinkTextInput')}`
       ) as HTMLInputElement;
 
-      dispatchClick('.toastui-editor-popup-add-link .toastui-editor-ok-button');
+      dispatchClick(`.${cls('popup-add-link')} .${cls('ok-button')}`);
 
       expect(urlText).toHaveClass('wrong');
 
       urlText.value = 'https://ui.toast.com';
-      dispatchClick('.toastui-editor-popup-add-link .toastui-editor-ok-button');
+      dispatchClick(`.${cls('popup-add-link')} .${cls('ok-button')}`);
 
       expect(linkText).toHaveClass('wrong');
     });
@@ -273,16 +274,16 @@ describe('default toolbar', () => {
     it('should show the popup when clicking image button', () => {
       dispatchClick('.image');
 
-      const imagePopup = getElement('.toastui-editor-popup-add-image');
+      const imagePopup = getElement(`.${cls('popup-add-image')}`);
 
       expect(imagePopup).toHaveStyle({ display: 'block' });
     });
 
     it('should hide popup when clicking Cancel button', () => {
       dispatchClick('.image');
-      dispatchClick('.toastui-editor-popup-add-image .toastui-editor-close-button');
+      dispatchClick(`.${cls('popup-add-image')} .${cls('close-button')}`);
 
-      const imagePopup = getElement('.toastui-editor-popup-add-image');
+      const imagePopup = getElement(`.${cls('popup-add-image')}`);
 
       expect(imagePopup).toHaveStyle({ display: 'none' });
     });
@@ -290,7 +291,7 @@ describe('default toolbar', () => {
     it('should toggle tab when clicking the file or url tab', () => {
       dispatchClick('.image');
 
-      const fileTabBtn = getElement('.toastui-editor-popup-add-image .active');
+      const fileTabBtn = getElement(`.${cls('popup-add-image .active')}`);
       const urlTabBtn = fileTabBtn.nextSibling as HTMLButtonElement;
 
       urlTabBtn.click();
@@ -311,13 +312,13 @@ describe('default toolbar', () => {
 
       dispatchClick('.image');
 
-      const fileTabBtn = getElement('.toastui-editor-popup-add-image .active');
+      const fileTabBtn = getElement(`.${cls('popup-add-image .active')}`);
       const urlTabBtn = fileTabBtn.nextSibling as HTMLButtonElement;
       const urlText = getElement(
-        '.toastui-editor-popup-add-image #toastuiImageUrlInput'
+        `.${cls('popup-add-image #toastuiImageUrlInput')}`
       ) as HTMLInputElement;
       const descriptionText = getElement(
-        '.toastui-editor-popup-add-image #toastuiAltTextInput'
+        `.${cls('popup-add-image #toastuiAltTextInput')}`
       ) as HTMLInputElement;
 
       urlTabBtn.click();
@@ -325,7 +326,7 @@ describe('default toolbar', () => {
       urlText.value = 'myImageUrl';
       descriptionText.value = 'image';
 
-      dispatchClick('.toastui-editor-popup-add-image .toastui-editor-ok-button');
+      dispatchClick(`.${cls('popup-add-image')} .${cls('ok-button')}`);
 
       expect(spy).toHaveBeenCalledWith('addImage', { altText: 'image', imageUrl: 'myImageUrl' });
     });
@@ -335,7 +336,7 @@ describe('default toolbar', () => {
     it('should show the popup when clicking table button', () => {
       dispatchClick('.table');
 
-      const tablePopup = getElement('.toastui-editor-popup-add-table');
+      const tablePopup = getElement(`.${cls('popup-add-table')}`);
 
       expect(tablePopup).toHaveStyle({ display: 'block' });
     });
@@ -347,8 +348,8 @@ describe('default toolbar', () => {
 
       dispatchClick('.table');
 
-      dispatchMousemove('.toastui-editor-table-selection', 100, 60);
-      dispatchClick('.toastui-editor-table-selection');
+      dispatchMousemove(`.${cls('table-selection')}`, 100, 60);
+      dispatchClick(`.${cls('table-selection')}`);
 
       expect(spy).toHaveBeenCalledWith('addTable', { columnCount: 6, rowCount: 4 });
     });
@@ -436,7 +437,7 @@ describe('custom button toolbar', () => {
   it('should show tooltip when mouseover on toolbar button', () => {
     dispatchMouseover('.my-toolbar');
 
-    const tooltip = getElement('.toastui-editor-tooltip');
+    const tooltip = getElement(`.${cls('tooltip')}`);
 
     expect(tooltip).toHaveStyle({ display: 'block' });
   });
@@ -562,7 +563,7 @@ describe('custom toolbar element', () => {
   it('should show tooltip when mouseover on toolbar button', () => {
     dispatchMouseover('.my-toolbar');
 
-    const tooltip = getElement('.toastui-editor-tooltip');
+    const tooltip = getElement(`.${cls('tooltip')}`);
 
     expect(tooltip).toHaveStyle({ display: 'block' });
   });
@@ -593,7 +594,7 @@ describe('API', () => {
   let ref: Toolbar | null;
 
   function getToolbarItems() {
-    return getElement('.toastui-editor-defaultUI-toolbar').querySelectorAll('button:not(.more)');
+    return getElement(`.${cls('defaultUI-toolbar')}`).querySelectorAll('button:not(.more)');
   }
 
   beforeEach(() => {
@@ -617,7 +618,7 @@ describe('API', () => {
       ` as VNode
     );
     jest
-      .spyOn(getElement('.toastui-editor-defaultUI-toolbar'), 'clientWidth', 'get')
+      .spyOn(getElement(`.${cls('defaultUI-toolbar')}`), 'clientWidth', 'get')
       .mockImplementation(() => 500);
   });
 
@@ -716,7 +717,7 @@ describe('event', () => {
     it('should open popup corresponding to name', () => {
       em.emit('openPopup', 'image');
 
-      const imagePopup = getElement('.toastui-editor-popup-add-image');
+      const imagePopup = getElement(`.${cls('popup-add-image')}`);
 
       expect(imagePopup).toHaveStyle({ display: 'block' });
     });
@@ -727,10 +728,10 @@ describe('event', () => {
       em.emit('openPopup', 'link', initialValues);
 
       const urlText = getElement(
-        '.toastui-editor-popup-add-link #toastuiLinkUrlInput'
+        `.${cls('popup-add-link #toastuiLinkUrlInput')}`
       ) as HTMLInputElement;
       const linkText = getElement(
-        '.toastui-editor-popup-add-link #toastuiLinkTextInput'
+        `.${cls('popup-add-link #toastuiLinkTextInput')}`
       ) as HTMLInputElement;
 
       expect(urlText).toHaveValue('http://test.com');

--- a/apps/editor/src/__test__/integration/widget/widgetNode.spec.ts
+++ b/apps/editor/src/__test__/integration/widget/widgetNode.spec.ts
@@ -1,5 +1,6 @@
 import { oneLineTrim } from 'common-tags';
 import Editor from '@/editorCore';
+import { cls } from '@/utils/dom';
 import { removeDataAttr } from '@/__test__/unit/markdown/util';
 
 describe('widgetNode', () => {
@@ -10,7 +11,7 @@ describe('widgetNode', () => {
     editor: Editor;
 
   function getPreviewHTML() {
-    return removeDataAttr(mdPreview.querySelector('.toastui-editor-contents')!.innerHTML);
+    return removeDataAttr(mdPreview.querySelector(`.${cls('contents')}`)!.innerHTML);
   }
 
   beforeEach(() => {

--- a/apps/editor/src/__test__/unit/editor.spec.ts
+++ b/apps/editor/src/__test__/unit/editor.spec.ts
@@ -9,8 +9,8 @@ import { EditorOptions } from '@t/editor';
 import { createHTMLrenderer } from './markdown/util';
 import { cls } from '@/utils/dom';
 
-const HEADING_CLS = 'toastui-editor-md-heading toastui-editor-md-heading1';
-const DELIM_CLS = 'toastui-editor-md-delimiter';
+const HEADING_CLS = `${cls('md-heading')} ${cls('md-heading1')}`;
+const DELIM_CLS = cls('md-delimiter');
 
 describe('editor', () => {
   let container: HTMLElement,

--- a/apps/editor/src/__test__/unit/editor.spec.ts
+++ b/apps/editor/src/__test__/unit/editor.spec.ts
@@ -7,6 +7,10 @@ import Viewer from '@/Viewer';
 import * as commonUtil from '@/utils/common';
 import { EditorOptions } from '@t/editor';
 import { createHTMLrenderer } from './markdown/util';
+import { cls } from '@/utils/dom';
+
+const HEADING_CLS = 'toastui-editor-md-heading toastui-editor-md-heading1';
+const DELIM_CLS = 'toastui-editor-md-delimiter';
 
 describe('editor', () => {
   let container: HTMLElement,
@@ -17,7 +21,7 @@ describe('editor', () => {
 
   function getPreviewHTML() {
     return mdPreview
-      .querySelector('.toastui-editor-contents')!
+      .querySelector(`.${cls('contents')}`)!
       .innerHTML.replace(/\sdata-nodeid="\d+"|\n/g, '')
       .trim();
   }
@@ -109,7 +113,7 @@ describe('editor', () => {
       editor.setMarkdown('# heading');
 
       expect(mdEditor).toContainHTML(
-        '<div><span class="toastui-editor-md-heading toastui-editor-md-heading1"><span class="toastui-editor-md-delimiter">#</span> heading</span></div>'
+        `<div><span class="${HEADING_CLS}"><span class="${DELIM_CLS}">#</span> heading</span></div>`
       );
       expect(getPreviewHTML()).toBe('<h1>heading</h1>');
     });
@@ -118,7 +122,7 @@ describe('editor', () => {
       editor.setHTML('<h1>heading</h1>');
 
       expect(mdEditor).toContainHTML(
-        '<div><span class="toastui-editor-md-heading toastui-editor-md-heading1"><span class="toastui-editor-md-delimiter">#</span> heading</span></div>'
+        `<div><span class="${HEADING_CLS}"><span class="${DELIM_CLS}">#</span> heading</span></div>`
       );
       expect(getPreviewHTML()).toBe('<h1>heading</h1>');
     });
@@ -128,7 +132,7 @@ describe('editor', () => {
       editor.reset();
 
       expect(mdEditor).not.toContainHTML(
-        '<div><span class="toastui-editor-md-heading toastui-editor-md-heading1"><span class="toastui-editor-md-delimiter">#</span> heading</span></div>'
+        `<div><span class="${HEADING_CLS}"><span class="${DELIM_CLS}">#</span> heading</span></div>`
       );
       expect(getPreviewHTML()).toBe('');
     });
@@ -567,7 +571,7 @@ describe('editor', () => {
 
         createEditor({ el: container, plugins: [plugin] });
 
-        const toolbar = document.querySelector('.toastui-editor-toolbar-icons.color');
+        const toolbar = document.querySelector(`.${cls('toolbar-icons.color')}`);
 
         expect(toolbar).toBeInTheDocument();
       });
@@ -595,7 +599,7 @@ describe('editor', () => {
       it('should hide mode switch if the option value is true', () => {
         createEditor({ el: container, hideModeSwitch: true });
 
-        const modeSwitch = document.querySelector('.toastui-editor-mode-switch');
+        const modeSwitch = document.querySelector(`.${cls('mode-switch')}`);
 
         expect(modeSwitch).not.toBeInTheDocument();
       });

--- a/apps/editor/src/__test__/unit/wysiwyg/keymap.spec.ts
+++ b/apps/editor/src/__test__/unit/wysiwyg/keymap.spec.ts
@@ -6,6 +6,10 @@ import WysiwygEditor from '@/wysiwyg/wwEditor';
 import EventEmitter from '@/event/eventEmitter';
 import { WwToDOMAdaptor } from '@/wysiwyg/adaptor/wwToDOMAdaptor';
 import CellSelection from '@/wysiwyg/plugins/selection/cellSelection';
+import { cls } from '@/utils/dom';
+
+const CELL_SELECTION_CLS = cls('cell-selected');
+const CODE_BLOCK_CLS = cls('ww-code-block');
 
 describe('keymap', () => {
   let wwe: WysiwygEditor, em: EventEmitter;
@@ -284,14 +288,14 @@ describe('keymap', () => {
         <table>
           <thead>
             <tr>
-              <th class="toastui-editor-cell-selected"><p><br></p></th>
-              <th class="toastui-editor-cell-selected"><p><br></p></th>
+              <th class="${CELL_SELECTION_CLS}"><p><br></p></th>
+              <th class="${CELL_SELECTION_CLS}"><p><br></p></th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <td class="toastui-editor-cell-selected"><p><br></p></td>
-              <td class="toastui-editor-cell-selected"><p><br></p></td>
+              <td class="${CELL_SELECTION_CLS}"><p><br></p></td>
+              <td class="${CELL_SELECTION_CLS}"><p><br></p></td>
             </tr>
           </tbody>
         </table>
@@ -386,7 +390,7 @@ describe('keymap', () => {
   describe('code block', () => {
     beforeEach(() => {
       html = oneLineTrim`
-        <div data-language="text" class="toastui-editor-ww-code-block">
+        <div data-language="text" class="${CODE_BLOCK_CLS}">
           <pre>
             <code>foo\nbar\nbaz</code>
           </pre>
@@ -404,7 +408,7 @@ describe('keymap', () => {
 
         const expected = oneLineTrim`
           <p><br></p>
-          <div data-language="text" class="toastui-editor-ww-code-block">
+          <div data-language="text" class="${CODE_BLOCK_CLS}">
             <pre>
               <code>foo\nbar\nbaz</code>
             </pre>
@@ -422,7 +426,7 @@ describe('keymap', () => {
         forceKeymapFn('codeBlock', 'moveCursor', ['down']);
 
         const expected = oneLineTrim`
-          <div data-language="text" class="toastui-editor-ww-code-block">
+          <div data-language="text" class="${CODE_BLOCK_CLS}">
             <pre>
               <code>foo\nbar\nbaz</code>
             </pre>

--- a/apps/editor/src/__test__/unit/wysiwyg/wwCommand.spec.ts
+++ b/apps/editor/src/__test__/unit/wysiwyg/wwCommand.spec.ts
@@ -6,6 +6,9 @@ import WysiwygEditor from '@/wysiwyg/wwEditor';
 import EventEmitter from '@/event/eventEmitter';
 import CommandManager from '@/commands/commandManager';
 import { WwToDOMAdaptor } from '@/wysiwyg/adaptor/wwToDOMAdaptor';
+import { cls } from '@/utils/dom';
+
+const CODE_BLOCK_CLS = cls('ww-code-block');
 
 describe('wysiwyg commands', () => {
   let wwe: WysiwygEditor, em: EventEmitter, cmd: CommandManager;
@@ -167,7 +170,7 @@ describe('wysiwyg commands', () => {
       cmd.exec('codeBlock');
 
       expect(wwe.getHTML()).toBe(oneLineTrim`
-        <div data-language="text" class="toastui-editor-ww-code-block">
+        <div data-language="text" class="${CODE_BLOCK_CLS}">
           <pre>
             <code><br></code>
           </pre>
@@ -182,7 +185,7 @@ describe('wysiwyg commands', () => {
       cmd.exec('codeBlock');
 
       expect(wwe.getHTML()).toBe(oneLineTrim`
-        <div data-language="text" class="toastui-editor-ww-code-block">
+        <div data-language="text" class="${CODE_BLOCK_CLS}">
           <pre>
             <code>foo</code>
           </pre>

--- a/apps/editor/src/__test__/unit/wysiwyg/wwTableCommand.spec.ts
+++ b/apps/editor/src/__test__/unit/wysiwyg/wwTableCommand.spec.ts
@@ -7,6 +7,9 @@ import CellSelection from '@/wysiwyg/plugins/selection/cellSelection';
 
 import { WwToDOMAdaptor } from '@/wysiwyg/adaptor/wwToDOMAdaptor';
 import { TableOffsetMap } from '@/wysiwyg/helper/tableOffsetMap';
+import { cls } from '@/utils/dom';
+
+const CELL_SELECTION_CLS = cls('cell-selected');
 
 describe('wysiwyg table commands', () => {
   let wwe: WysiwygEditor, em: EventEmitter, cmd: CommandManager;
@@ -216,14 +219,14 @@ describe('wysiwyg table commands', () => {
         <table>
           <thead>
             <tr>
-              <th class="toastui-editor-cell-selected"><p>foo</p></th>
-              <th class="toastui-editor-cell-selected"><p>bar</p></th>
+              <th class="${CELL_SELECTION_CLS}"><p>foo</p></th>
+              <th class="${CELL_SELECTION_CLS}"><p>bar</p></th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <td class="toastui-editor-cell-selected"><p>baz</p></td>
-              <td class="toastui-editor-cell-selected"><p>qux</p></td>
+              <td class="${CELL_SELECTION_CLS}"><p>baz</p></td>
+              <td class="${CELL_SELECTION_CLS}"><p>qux</p></td>
             </tr>
             <tr>
               <td><p><br></p></td>
@@ -253,8 +256,8 @@ describe('wysiwyg table commands', () => {
         <table>
           <thead>
             <tr>
-              <th class="toastui-editor-cell-selected"><p>foo</p></th>
-              <th class="toastui-editor-cell-selected"><p>bar</p></th>
+              <th class="${CELL_SELECTION_CLS}"><p>foo</p></th>
+              <th class="${CELL_SELECTION_CLS}"><p>bar</p></th>
             </tr>
           </thead>
           <tbody>
@@ -340,11 +343,11 @@ describe('wysiwyg table commands', () => {
             </tr>
             <tr>
               <td><p>baz</p></td>
-              <td class="toastui-editor-cell-selected"><p>qux</p></td>
+              <td class="${CELL_SELECTION_CLS}"><p>qux</p></td>
             </tr>
             <tr>
               <td><p>quux</p></td>
-              <td class="toastui-editor-cell-selected"><p>quuz</p></td>
+              <td class="${CELL_SELECTION_CLS}"><p>quuz</p></td>
             </tr>
           </tbody>
         </table>
@@ -362,13 +365,13 @@ describe('wysiwyg table commands', () => {
         <table>
           <thead>
             <tr>
-              <th class="toastui-editor-cell-selected"><p>foo</p></th>
+              <th class="${CELL_SELECTION_CLS}"><p>foo</p></th>
               <th><p>bar</p></th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <td class="toastui-editor-cell-selected"><p>baz</p></td>
+              <td class="${CELL_SELECTION_CLS}"><p>baz</p></td>
               <td><p>qux</p></td>
             </tr>
             <tr>
@@ -456,17 +459,17 @@ describe('wysiwyg table commands', () => {
           <thead>
             <tr>
               <th><p>foo</p></th>
-              <th class="toastui-editor-cell-selected"><p>bar</p></th>
+              <th class="${CELL_SELECTION_CLS}"><p>bar</p></th>
             </tr>
           </thead>
           <tbody>
             <tr>
               <td><p>baz</p></td>
-              <td class="toastui-editor-cell-selected"><p>qux</p></td>
+              <td class="${CELL_SELECTION_CLS}"><p>qux</p></td>
             </tr>
             <tr>
               <td><p>quux</p></td>
-              <td class="toastui-editor-cell-selected"><p>quuz</p></td>
+              <td class="${CELL_SELECTION_CLS}"><p>quuz</p></td>
             </tr>
             <tr>
               <td><p>corge</p></td>
@@ -494,15 +497,15 @@ describe('wysiwyg table commands', () => {
           </thead>
           <tbody>
             <tr>
-              <td class="toastui-editor-cell-selected"><p>baz</p></td>
+              <td class="${CELL_SELECTION_CLS}"><p>baz</p></td>
               <td><p>qux</p></td>
             </tr>
             <tr>
-              <td class="toastui-editor-cell-selected"><p>quux</p></td>
+              <td class="${CELL_SELECTION_CLS}"><p>quux</p></td>
               <td><p>quuz</p></td>
             </tr>
             <tr>
-              <td class="toastui-editor-cell-selected"><p>corge</p></td>
+              <td class="${CELL_SELECTION_CLS}"><p>corge</p></td>
               <td><p><br></p></td>
             </tr>
           </tbody>
@@ -566,8 +569,8 @@ describe('wysiwyg table commands', () => {
         <table>
           <thead>
             <tr>
-              <th class="toastui-editor-cell-selected"><p>foo</p></th>
-              <th class="toastui-editor-cell-selected"><p>bar</p></th>
+              <th class="${CELL_SELECTION_CLS}"><p>foo</p></th>
+              <th class="${CELL_SELECTION_CLS}"><p>bar</p></th>
               <th><p><br></p></th>
               <th><p><br></p></th>
               <th><p>baz</p></th>
@@ -575,8 +578,8 @@ describe('wysiwyg table commands', () => {
           </thead>
           <tbody>
             <tr>
-              <td class="toastui-editor-cell-selected"><p>qux</p></td>
-              <td class="toastui-editor-cell-selected"><p>quux</p></td>
+              <td class="${CELL_SELECTION_CLS}"><p>qux</p></td>
+              <td class="${CELL_SELECTION_CLS}"><p>quux</p></td>
               <td><p><br></p></td>
               <td><p><br></p></td>
               <td><p>quuz</p></td>
@@ -652,8 +655,8 @@ describe('wysiwyg table commands', () => {
               <th><p>foo</p></th>
               <th><p><br></p></th>
               <th><p><br></p></th>
-              <th class="toastui-editor-cell-selected"><p>bar</p></th>
-              <th class="toastui-editor-cell-selected"><p>baz</p></th>
+              <th class="${CELL_SELECTION_CLS}"><p>bar</p></th>
+              <th class="${CELL_SELECTION_CLS}"><p>baz</p></th>
             </tr>
           </thead>
           <tbody>
@@ -661,15 +664,15 @@ describe('wysiwyg table commands', () => {
               <td><p>qux</p></td>
               <td><p><br></p></td>
               <td><p><br></p></td>
-              <td class="toastui-editor-cell-selected"><p>quux</p></td>
-              <td class="toastui-editor-cell-selected"><p>quuz</p></td>
+              <td class="${CELL_SELECTION_CLS}"><p>quux</p></td>
+              <td class="${CELL_SELECTION_CLS}"><p>quuz</p></td>
             </tr>
             <tr>
               <td><p>corge</p></td>
               <td><p><br></p></td>
               <td><p><br></p></td>
-              <td class="toastui-editor-cell-selected"><p>grault</p></td>
-              <td class="toastui-editor-cell-selected"><p><br></p></td>
+              <td class="${CELL_SELECTION_CLS}"><p>grault</p></td>
+              <td class="${CELL_SELECTION_CLS}"><p><br></p></td>
             </tr>
           </tbody>
         </table>
@@ -752,16 +755,16 @@ describe('wysiwyg table commands', () => {
         <table>
           <thead>
             <tr>
-              <th class="toastui-editor-cell-selected"><p>foo</p></th>
-              <th class="toastui-editor-cell-selected"><p>bar</p></th>
-              <th class="toastui-editor-cell-selected"><p>baz</p></th>
+              <th class="${CELL_SELECTION_CLS}"><p>foo</p></th>
+              <th class="${CELL_SELECTION_CLS}"><p>bar</p></th>
+              <th class="${CELL_SELECTION_CLS}"><p>baz</p></th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <td class="toastui-editor-cell-selected"><p>qux</p></td>
-              <td class="toastui-editor-cell-selected"><p>quux</p></td>
-              <td class="toastui-editor-cell-selected"><p>quuz</p></td>
+              <td class="${CELL_SELECTION_CLS}"><p>qux</p></td>
+              <td class="${CELL_SELECTION_CLS}"><p>quux</p></td>
+              <td class="${CELL_SELECTION_CLS}"><p>quuz</p></td>
             </tr>
             <tr>
               <td><p>corge</p></td>
@@ -912,8 +915,8 @@ describe('wysiwyg table commands', () => {
           </thead>
           <tbody>
             <tr>
-              <td align="left" class="toastui-editor-cell-selected"><p>baz</p></td>
-              <td align="left" class="toastui-editor-cell-selected"><p>qux</p></td>
+              <td align="left" class="${CELL_SELECTION_CLS}"><p>baz</p></td>
+              <td align="left" class="${CELL_SELECTION_CLS}"><p>qux</p></td>
             </tr>
             <tr>
               <td align="left"><p>quux</p></td>
@@ -933,8 +936,8 @@ describe('wysiwyg table commands', () => {
         <table>
           <thead>
             <tr>
-              <th align="right" class="toastui-editor-cell-selected"><p>foo</p></th>
-              <th align="right" class="toastui-editor-cell-selected"><p>bar</p></th>
+              <th align="right" class="${CELL_SELECTION_CLS}"><p>foo</p></th>
+              <th align="right" class="${CELL_SELECTION_CLS}"><p>bar</p></th>
             </tr>
           </thead>
           <tbody>

--- a/apps/editor/src/ui/components/toolbar/dropdownToolbarButton.ts
+++ b/apps/editor/src/ui/components/toolbar/dropdownToolbarButton.ts
@@ -77,7 +77,8 @@ class DropdownToolbarButtonComp extends Component<Props, State> {
   render() {
     const { showDropdown, dropdownPos } = this.state;
     const { disabled, item, items, hideTooltip } = this.props;
-    const groupStyle = items.length ? null : { display: 'none' };
+    const visibleItems = items.filter((dropdownItem) => !dropdownItem.hidden);
+    const groupStyle = visibleItems.length ? null : { display: 'none' };
     const dropdownStyle = showDropdown ? null : { display: 'none' };
 
     return html`
@@ -96,13 +97,13 @@ class DropdownToolbarButtonComp extends Component<Props, State> {
           style=${{ ...dropdownStyle, ...dropdownPos }}
           ref=${(el: HTMLElement) => (this.refs.dropdownEl = el)}
         >
-          ${items.length
-            ? items.map(
+          ${visibleItems.length
+            ? visibleItems.map(
                 (group, index) => html`
                   <${ToolbarGroup}
                     group=${group}
-                    hiddenDivider=${index === items.length - 1 ||
-                    (items as ToolbarButtonInfo[])[index + 1]?.hidden}
+                    hiddenDivider=${index === visibleItems.length - 1 ||
+                    (visibleItems as ToolbarButtonInfo[])[index + 1]?.hidden}
                     ...${this.props}
                   />
                 `

--- a/docs/ko/plugin.md
+++ b/docs/ko/plugin.md
@@ -6,7 +6,7 @@ TOAST UI Editor(이하 '에디터'라고 명시)는 기본으로 지원하지 �
 | --- | --- | --- |
 | [`chart`](https://github.com/nhn/tui.editor/tree/master/plugins/chart) | [`@toast-ui/editor-plugin-chart`](https://www.npmjs.com/package/@toast-ui/editor-plugin-chart) | 차트를 렌더링하기 위한 플러그인 |
 | [`code-syntax-highlight`](https://github.com/nhn/tui.editor/tree/master/plugins/code-syntax-highlight) | [`@toast-ui/editor-plugin-code-syntax-highlight`](https://www.npmjs.com/package/@toast-ui/editor-plugin-code-syntax-highlight) | 코드 하이라이팅을 위한 플러그인 |
-| [`plugin-color-syntax`](https://github.com/nhn/tui.editor/tree/master/plugins/color-syntax) | [`@toast-ui/editor-plugin-color-syntax`](https://www.npmjs.com/package/@toast-ui/editor-plugin-color-syntax) | 컬러피커 사용을 위한 플러그인 |
+| [`color-syntax`](https://github.com/nhn/tui.editor/tree/master/plugins/color-syntax) | [`@toast-ui/editor-plugin-color-syntax`](https://www.npmjs.com/package/@toast-ui/editor-plugin-color-syntax) | 컬러피커 사용을 위한 플러그인 |
 | [`table-merged-cell`](https://github.com/nhn/tui.editor/tree/master/plugins/table-merged-cell) | [`@toast-ui/editor-plugin-table-merged-cell`](https://www.npmjs.com/package/@toast-ui/editor-plugin-table-merged-cell) | 병합 테이블 셀을 사용하기 위한 플러그인 |
 | [`uml`](https://github.com/nhn/tui.editor/tree/master/plugins/uml) | [`@toast-ui/editor-plugin-uml`](https://www.npmjs.com/package/@toast-ui/editor-plugin-uml) | UML 사용을 위한 플러그인 |
 

--- a/libs/toastmark/src/__test__/toastmark.spec.ts
+++ b/libs/toastmark/src/__test__/toastmark.spec.ts
@@ -38,7 +38,7 @@ function assertResultNodes(doc: ToastMark, nodes: Node[], startIdx = 0) {
 }
 
 describe('findNodeAtPosition()', () => {
-  it('returns a node at the given position', () => {
+  it('should return a node at the given position', () => {
     const doc = new ToastMark('# Hello *World*\n\n- Item 1\n- Item **2**');
 
     expect(doc.findNodeAtPosition([1, 1])).toMatchObject({
@@ -88,7 +88,7 @@ describe('findNodeAtPosition()', () => {
     expect(doc.findNodeAtPosition([5, 1])).toBeNull();
   });
 
-  it('returns null if matched node does not exist', () => {
+  it('should return null if matched node does not exist', () => {
     const doc = new ToastMark('# Hello\n\nWorld');
 
     // position in between two node (blank line)
@@ -110,7 +110,7 @@ describe('findFirstNodeAtLine()', () => {
     'Paragraph',
   ].join('\n');
 
-  it('returns the first node at the given line', () => {
+  it('should return the first node at the given line', () => {
     const doc = new ToastMark(markdown);
 
     expect(doc.findFirstNodeAtLine(1)).toMatchObject({ type: 'heading' });
@@ -134,7 +134,7 @@ describe('findFirstNodeAtLine()', () => {
     expect(doc.findFirstNodeAtLine(8)).toMatchObject({ type: 'paragraph' });
   });
 
-  it('returns null if nothing mathces', () => {
+  it('should return null if nothing mathces', () => {
     const doc = new ToastMark('\n\n');
 
     expect(doc.findFirstNodeAtLine(0)).toBeNull();
@@ -146,7 +146,7 @@ describe('findFirstNodeAtLine()', () => {
 
 describe('editText()', () => {
   describe('single paragraph', () => {
-    it('insert character within a line', () => {
+    it('should insert character within a line', () => {
       const doc = new ToastMark('Hello World');
       const result = doc.editMarkdown([1, 6], [1, 6], ',')[0];
 
@@ -154,7 +154,7 @@ describe('editText()', () => {
       assertResultNodes(doc, result.nodes);
     });
 
-    it('remove entire text', () => {
+    it('should remove entire text', () => {
       const doc = new ToastMark('Hello World');
       const result = doc.editMarkdown([1, 1], [1, 12], '')[0];
 
@@ -162,7 +162,7 @@ describe('editText()', () => {
       assertResultNodes(doc, result.nodes);
     });
 
-    it('remove preceding newline', () => {
+    it('should remove preceding newline', () => {
       const doc = new ToastMark('\nHello World');
       const result = doc.editMarkdown([1, 1], [2, 1], '')[0];
 
@@ -170,7 +170,7 @@ describe('editText()', () => {
       assertResultNodes(doc, result.nodes);
     });
 
-    it('remove last newline', () => {
+    it('should remove last newline', () => {
       const doc = new ToastMark('Hello World\n');
       const result = doc.editMarkdown([1, 12], [2, 1], '')[0];
 
@@ -178,7 +178,7 @@ describe('editText()', () => {
       assertResultNodes(doc, result.nodes);
     });
 
-    it('insert characters and newlines', () => {
+    it('should insert characters and newlines', () => {
       const doc = new ToastMark('Hello World');
       const result = doc.editMarkdown([1, 6], [1, 7], '!\n\nMy ')[0];
 
@@ -186,7 +186,7 @@ describe('editText()', () => {
       assertResultNodes(doc, result.nodes);
     });
 
-    it('replace multiline text with characters', () => {
+    it('should replace multiline text with characters', () => {
       const doc = new ToastMark('Hello\nMy\nWorld');
       const result = doc.editMarkdown([1, 5], [3, 3], 'ooo Wooo')[0];
 
@@ -194,7 +194,7 @@ describe('editText()', () => {
       assertResultNodes(doc, result.nodes);
     });
 
-    it('prepend characters', () => {
+    it('should prepend characters', () => {
       const doc = new ToastMark('Hello World');
       const result = doc.editMarkdown([1, 1], [1, 1], 'Hi, ')[0];
 
@@ -202,7 +202,7 @@ describe('editText()', () => {
       assertResultNodes(doc, result.nodes);
     });
 
-    it('append character', () => {
+    it('should append character', () => {
       const doc = new ToastMark('Hello World');
       const result = doc.editMarkdown([1, 12], [1, 12], '!!')[0];
 
@@ -210,7 +210,7 @@ describe('editText()', () => {
       assertResultNodes(doc, result.nodes);
     });
 
-    it('prepend newlines', () => {
+    it('should prepend newlines', () => {
       const doc = new ToastMark('Hello World');
       const result = doc.editMarkdown([1, 1], [1, 1], '\n\n\n')[0];
 
@@ -218,7 +218,7 @@ describe('editText()', () => {
       assertResultNodes(doc, result.nodes);
     });
 
-    it('prepend characters (unmatched position)', () => {
+    it('should prepend characters (unmatched position)', () => {
       const doc = new ToastMark('  Hello World');
       const result = doc.editMarkdown([1, 1], [1, 1], 'Hi,')[0];
 
@@ -226,7 +226,7 @@ describe('editText()', () => {
       assertResultNodes(doc, result.nodes);
     });
 
-    it('insert newlines into preceding empty line of first paragraph', () => {
+    it('should insert newlines into preceding empty line of first paragraph', () => {
       const doc = new ToastMark('\nHello World');
       const result = doc.editMarkdown([1, 1], [1, 1], '\n')[0];
 
@@ -234,7 +234,7 @@ describe('editText()', () => {
       assertResultNodes(doc, result.nodes);
     });
 
-    it('append characters with newline', () => {
+    it('should append characters with newline', () => {
       const doc = new ToastMark('Hello World\n');
       const result = doc.editMarkdown([2, 1], [2, 1], '\nHi')[0];
 
@@ -242,7 +242,7 @@ describe('editText()', () => {
       assertResultNodes(doc, result.nodes);
     });
 
-    it('remove lines with top blank line', () => {
+    it('should remove lines with top blank line', () => {
       const doc = new ToastMark('\n\nabove linebreak\n\nHello World');
       const result = doc.editMarkdown([1, 1], [5, 12], '')[0];
 
@@ -250,7 +250,7 @@ describe('editText()', () => {
       assertResultNodes(doc, result.nodes);
     });
 
-    it('parse the table with including prev line', () => {
+    it('should parse the table with including prev line', () => {
       const doc = new ToastMark('| a | b\n--| ---\n c');
       const result = doc.editMarkdown([3, 1], [3, 3], '|c|')[0];
 
@@ -260,7 +260,7 @@ describe('editText()', () => {
   });
 
   describe('multiple paragraph', () => {
-    it('insert paragraphs within multiple paragraphs', () => {
+    it('should insert paragraphs within multiple paragraphs', () => {
       const doc = new ToastMark('Hello\n\nMy\n\nWorld');
       const result = doc.editMarkdown([1, 6], [5, 1], ',\n\nMy ')[0];
 
@@ -268,7 +268,7 @@ describe('editText()', () => {
       assertResultNodes(doc, result.nodes);
     });
 
-    it('replace multiple paragraphs with a heading', () => {
+    it('should replace multiple paragraphs with a heading', () => {
       const doc = new ToastMark('Hello\n\nMy\n\nWorld');
       const result = doc.editMarkdown([1, 1], [5, 1], '# Hello ')[0];
 
@@ -276,7 +276,7 @@ describe('editText()', () => {
       assertResultNodes(doc, result.nodes);
     });
 
-    it('remove last block with newlines', () => {
+    it('should remove last block with newlines', () => {
       const doc = new ToastMark('Hello\n\nWorld\n');
       const result = doc.editMarkdown([3, 1], [4, 1], '')[0];
 
@@ -284,7 +284,7 @@ describe('editText()', () => {
       assertResultNodes(doc, result.nodes);
     });
 
-    it('insert a characters in between paragraphs', () => {
+    it('should insert a characters in between paragraphs', () => {
       const doc = new ToastMark('Hello\n\nWorld');
       const result = doc.editMarkdown([2, 1], [2, 1], 'My')[0];
 
@@ -300,7 +300,7 @@ describe('editText()', () => {
       assertResultNodes(doc, result.nodes);
     });
 
-    it('update to fenced code blocks to the end of the document', () => {
+    it('should update to fenced code blocks to the end of the document', () => {
       const doc = new ToastMark('``\nHello\n\nMy World');
       const result = doc.editMarkdown([1, 3], [1, 3], '`')[0];
 
@@ -308,7 +308,7 @@ describe('editText()', () => {
       assertResultNodes(doc, result.nodes);
     });
 
-    it('update to custom block to the end of the document', () => {
+    it('should update to custom block to the end of the document', () => {
       const doc = new ToastMark('$\nHello\n\nMy World');
       const result = doc.editMarkdown([1, 2], [1, 2], '$custom')[0];
 

--- a/libs/toastmark/src/__test__/toastmark.spec.ts
+++ b/libs/toastmark/src/__test__/toastmark.spec.ts
@@ -307,6 +307,14 @@ describe('editText()', () => {
       assertParseResult(doc, ['```', 'Hello', '', 'My World']);
       assertResultNodes(doc, result.nodes);
     });
+
+    it('update to custom block to the end of the document', () => {
+      const doc = new ToastMark('$\nHello\n\nMy World');
+      const result = doc.editMarkdown([1, 2], [1, 2], '$custom')[0];
+
+      assertParseResult(doc, ['$$custom', 'Hello', '', 'My World']);
+      assertResultNodes(doc, result.nodes);
+    });
   });
 
   describe('list item', () => {

--- a/libs/toastmark/src/commonmark/custom/__test__/customBlock.spec.ts
+++ b/libs/toastmark/src/commonmark/custom/__test__/customBlock.spec.ts
@@ -88,4 +88,24 @@ describe('customBlock', () => {
     const html = renderer.render(root);
     expect(html).toBe(`${output}\n`);
   });
+
+  it('should be rendered regardless of the white space', () => {
+    const input = source`
+      $$  myCustom
+      my custom block
+
+      should be parsed
+      $$
+    `;
+    const output = source`
+      <div class="myCustom-block">my custom block
+
+      should be parsed
+      </div>
+    `;
+
+    const root = reader.parse(input);
+    const html = renderer.render(root);
+    expect(html).toBe(`${output}\n`);
+  });
 });

--- a/libs/toastmark/src/commonmark/custom/customBlockHandler.ts
+++ b/libs/toastmark/src/commonmark/custom/customBlockHandler.ts
@@ -1,4 +1,5 @@
 import { Process, BlockHandler } from '../blockHandlers';
+import { isSpaceOrTab, peek } from '../blockHelper';
 import { unescapeString } from '../common';
 import { CustomBlockNode, BlockNode } from '../node';
 
@@ -13,6 +14,12 @@ export const customBlock: BlockHandler = {
       parser.lastLineLength = match[0].length;
       parser.finalize(container as BlockNode, parser.lineNumber);
       return Process.Finished;
+    }
+    // skip optional spaces of custom block offset
+    let i = container.offset;
+    while (i > 0 && isSpaceOrTab(peek(line, parser.offset))) {
+      parser.advanceOffset(1, true);
+      i--;
     }
     return Process.Go;
   },

--- a/libs/toastmark/src/commonmark/custom/customBlockStart.ts
+++ b/libs/toastmark/src/commonmark/custom/customBlockStart.ts
@@ -1,8 +1,8 @@
 import { BlockStart, Matched } from '../blockStarts';
 import { CustomBlockNode } from '../node';
 
-const reCustomBlock = /^(\$\$)([a-zA-Z])+/;
-const reCanBeCustomInline = /^(\$\$)([a-zA-Z])+.*(\$\$)/;
+const reCustomBlock = /^(\$\$)(\s*[a-zA-Z])+/;
+const reCanBeCustomInline = /^(\$\$)(\s*[a-zA-Z])+.*(\$\$)/;
 
 export const customBlock: BlockStart = (parser) => {
   let match;

--- a/libs/toastmark/src/html/baseConvertors.ts
+++ b/libs/toastmark/src/html/baseConvertors.ts
@@ -190,8 +190,8 @@ export const baseConvertors: HTMLConvertorMap = {
   },
 
   customBlock(node, context, convertors) {
-    const info = (node as CustomBlockNode).info!;
-    const customConvertor = convertors![info.toLowerCase()];
+    const info = (node as CustomBlockNode).info!.trim().toLowerCase();
+    const customConvertor = convertors![info];
 
     if (customConvertor) {
       try {
@@ -223,7 +223,7 @@ export const baseConvertors: HTMLConvertorMap = {
   },
 
   customInline(node, context, convertors) {
-    const info = (node as CustomBlockNode).info!;
+    const info = (node as CustomBlockNode).info!.trim().toLowerCase();
     const customConvertor = convertors![info];
 
     if (customConvertor) {

--- a/libs/toastmark/src/toastmark.ts
+++ b/libs/toastmark/src/toastmark.ts
@@ -18,6 +18,7 @@ import {
   RefDefNode,
   isTable,
   isCodeBlock,
+  isCustomBlock,
 } from './commonmark/node';
 import {
   removeNextUntil,
@@ -201,10 +202,11 @@ export class ToastMark implements ToastMarkParser {
     let nextNode = endNode ? endNode.next : this.root.firstChild;
     const { lastChild } = root;
     const isOpenedLastChildCodeBlock = lastChild && isCodeBlock(lastChild) && lastChild.open;
+    const isOpenedLastChildCustomBlock = lastChild && isCustomBlock(lastChild) && lastChild.open;
     const isLastChildList = lastChild && isList(lastChild);
 
     while (
-      (isOpenedLastChildCodeBlock && nextNode) ||
+      ((isOpenedLastChildCodeBlock || isOpenedLastChildCustomBlock) && nextNode) ||
       (isLastChildList && nextNode && (nextNode.type === 'list' || nextNode.sourcepos![0][1] >= 2))
     ) {
       const newEndLine = this.extendEndLine(nextNode.sourcepos![1][0]);


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
* fixed that show unneccesary more button in toolbar
![스크린샷 2021-06-08 오후 4 18 33](https://user-images.githubusercontent.com/37766175/121140764-315f7380-c875-11eb-9806-0e688a3699d8.png)
* fixed parsing bug with custom block
![image](https://user-images.githubusercontent.com/37766175/121140883-5227c900-c875-11eb-9c52-e5b822c4cfb8.png)



---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
