### PR TITLE
fix: keep the position when list item is removed

### DIFF
--- a/apps/editor/src/__test__/unit/wysiwyg/keymap.spec.ts
+++ b/apps/editor/src/__test__/unit/wysiwyg/keymap.spec.ts
@@ -1,6 +1,12 @@
 import { oneLineTrim } from 'common-tags';
 
 import { DOMParser } from 'prosemirror-model';
+import {
+  chainCommands,
+  deleteSelection,
+  joinBackward,
+  selectNodeBackward,
+} from 'prosemirror-commands';
 
 import WysiwygEditor from '@/wysiwyg/wwEditor';
 import EventEmitter from '@/event/eventEmitter';
@@ -436,6 +442,67 @@ describe('keymap', () => {
 
         expect(wwe.getHTML()).toBe(expected);
       });
+    });
+  });
+
+  describe('list item', () => {
+    function forceBackspaceKeymap() {
+      const { view } = wwe;
+      const { state, dispatch } = view;
+
+      chainCommands(deleteSelection, joinBackward, selectNodeBackward)(state, dispatch, view);
+    }
+
+    it('should remove list item and lift up to previous list item by backspcae keymap ', () => {
+      html = oneLineTrim`
+        <ul>
+          <li>item1</li>
+          <li></li>
+        </ul>
+      `;
+
+      setContent(html);
+      wwe.setSelection(9, 10); // in second list item
+
+      forceBackspaceKeymap();
+      forceKeymapFn('listItem', 'liftToPrevListItem');
+
+      const expected = oneLineTrim`
+        <ul>
+          <li><p>item1</p></li>
+        </ul>
+      `;
+
+      expect(wwe.getHTML()).toBe(expected);
+    });
+
+    it('should remove list item and lift up to parent list item by backspcae keymap ', () => {
+      html = oneLineTrim`
+        <ul>
+          <li>item1</li>
+          <li>
+            item2
+            <ul>
+              <li></li>
+            </ul>
+          </li>
+        </ul>
+      `;
+
+      setContent(html);
+      wwe.setSelection(19, 20); // in nested last child list item
+
+      forceBackspaceKeymap();
+      forceKeymapFn('listItem', 'liftToPrevListItem');
+
+      const expected = oneLineTrim`
+        <ul>
+          <li><p>item1</p></li>
+          <li><p>item2</p></li>
+        </ul>
+      `;
+
+      expect(wwe.getHTML()).toBe(expected);
     });
   });
 });

--- a/apps/editor/src/__test__/unit/wysiwyg/keymap.spec.ts
+++ b/apps/editor/src/__test__/unit/wysiwyg/keymap.spec.ts
@@ -453,7 +453,7 @@ describe('keymap', () => {
       chainCommands(deleteSelection, joinBackward, selectNodeBackward)(state, dispatch, view);
     }
 
-    it('should remove list item and lift up to previous list item by backspcae keymap ', () => {
+    it('should remove list item and lift up to previous list item by backspace keymap ', () => {
       html = oneLineTrim`
         <ul>
           <li>item1</li>
@@ -476,7 +476,7 @@ describe('keymap', () => {
       expect(wwe.getHTML()).toBe(expected);
     });
 
-    it('should remove list item and lift up to parent list item by backspcae keymap ', () => {
+    it('should remove list item and lift up to parent list item by backspace keymap ', () => {
       html = oneLineTrim`
         <ul>
           <li>item1</li>


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
* fixed that keep the position when list item is removed
**as-is**
![2021-06-11 16-12-07 2021-06-11 16_12_20](https://user-images.githubusercontent.com/37766175/121646091-e9885880-cacf-11eb-9ab0-8e5a0f3a559f.gif)
**to-be**
![2021-06-11 16-12-41 2021-06-11 16_12_52](https://user-images.githubusercontent.com/37766175/121646138-f3aa5700-cacf-11eb-8c9e-c292d6d6b5b6.gif)


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
