### PR TITLE
docs : Small typo fix

### DIFF
--- a/docs/en/custom-html-renderer.md
+++ b/docs/en/custom-html-renderer.md
@@ -18,7 +18,7 @@ const editor = new Editor({
       return {
         type: context.entering ? 'openTag' : 'closeTag',
         tagName: 'div',
-        classNames: [`heading-'${node.level}`]
+        classNames: [`heading-${node.level}`]
       };
     },
     text(node, context) {
@@ -50,7 +50,7 @@ World
 The final HTML content will be like below.
 
 ```html
-<div class="heading2">HEADING</div>
+<div class="heading-2">HEADING</div>
 <p>Hello<br /><br />World</p>
 ```
 


### PR DESCRIPTION
### Description

Missing a **-** in the resulting html
had an extra **'** in the provided js config.

