### PR TITLE
fix: the default `addImageBlobHook` is called even though it should have been deleted by `hooks` option

### DIFF
--- a/apps/editor/src/__test__/unit/editor.spec.ts
+++ b/apps/editor/src/__test__/unit/editor.spec.ts
@@ -1,13 +1,15 @@
 import '@/i18n/en-us';
 import { oneLineTrim, stripIndents } from 'common-tags';
+import { Emitter } from '@t/event';
+import { EditorOptions } from '@t/editor';
 import type { OpenTagToken } from '@toast-ui/toastmark';
 import i18n from '@/i18n/i18n';
 import Editor from '@/editor';
 import Viewer from '@/Viewer';
 import * as commonUtil from '@/utils/common';
-import { EditorOptions } from '@t/editor';
 import { createHTMLrenderer } from './markdown/util';
 import { cls } from '@/utils/dom';
+import * as imageHelper from '@/helper/image';
 
 const HEADING_CLS = `${cls('md-heading')} ${cls('md-heading1')}`;
 const DELIM_CLS = cls('md-delimiter');
@@ -238,6 +240,20 @@ describe('editor', () => {
 
       expect(spy).toHaveBeenCalledWith({ prop: 'prop' }, state, dispatch, view);
       expect(spy).toHaveBeenCalled();
+    });
+
+    it('the event registered by addHook() API should be triggered only once', () => {
+      const spy = jest.fn();
+      const { eventEmitter } = editor;
+
+      eventEmitter.addEventType('custom');
+
+      editor.addHook('custom', spy);
+      editor.addHook('custom', spy);
+
+      eventEmitter.emit('custom');
+
+      expect(spy).toHaveBeenCalledTimes(1);
     });
 
     describe('insertText()', () => {
@@ -808,6 +824,38 @@ describe('editor', () => {
         `;
 
         expect(wwEditor.innerHTML).toContain(result);
+      });
+    });
+
+    describe('hooks option', () => {
+      const defaultImageBlobHookSpy = jest.fn();
+
+      function mockDefaultImageBlobHook() {
+        defaultImageBlobHookSpy.mockReset();
+
+        jest
+          .spyOn(imageHelper, 'addDefaultImageBlobHook')
+          .mockImplementation((emitter: Emitter) => {
+            emitter.listen('addImageBlobHook', defaultImageBlobHookSpy);
+          });
+      }
+
+      it('should remove default `addImageBlobHook` event handler after registering hook', () => {
+        const spy = jest.fn();
+
+        mockDefaultImageBlobHook();
+
+        createEditor({
+          el: container,
+          hooks: {
+            addImageBlobHook: spy,
+          },
+        });
+
+        editor.eventEmitter.emit('addImageBlobHook');
+
+        expect(spy).toHaveBeenCalled();
+        expect(defaultImageBlobHookSpy).not.toHaveBeenCalled();
       });
     });
   });

--- a/apps/editor/src/__test__/unit/editor.spec.ts
+++ b/apps/editor/src/__test__/unit/editor.spec.ts
@@ -242,7 +242,7 @@ describe('editor', () => {
       expect(spy).toHaveBeenCalled();
     });
 
-    it('the event registered by addHook() API should be triggered only once', () => {
+    it('should be triggered only once when the event registered by addHook()', () => {
       const spy = jest.fn();
       const { eventEmitter } = editor;
 

--- a/apps/editor/src/__test__/unit/markdown/mdEditor.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/mdEditor.spec.ts
@@ -11,6 +11,8 @@ function getEditorHTML(editor: MarkdownEditor) {
   return editor.view.dom.innerHTML;
 }
 
+jest.useFakeTimers();
+
 describe('MarkdownEditor', () => {
   let mde: MarkdownEditor, em: EventEmitter, el: HTMLElement;
 
@@ -22,6 +24,8 @@ describe('MarkdownEditor', () => {
   });
 
   afterEach(() => {
+    jest.clearAllTimers();
+
     mde.destroy();
     document.body.removeChild(el);
   });
@@ -53,6 +57,9 @@ describe('MarkdownEditor', () => {
   it('setSelection API', () => {
     mde.setMarkdown('# myText');
     mde.setSelection([1, 1], [1, 2]);
+
+    // run setTimeout function when focusing the editor
+    jest.runAllTimers();
 
     expect(getSelectedText()).toBe('#');
   });
@@ -88,6 +95,9 @@ describe('MarkdownEditor', () => {
 
   it('focus API', () => {
     mde.focus();
+
+    // run setTimeout function when focusing the editor
+    jest.runAllTimers();
 
     expect(document.activeElement).toEqual(mde.view.dom);
   });

--- a/apps/editor/src/__test__/unit/markdown/mdPreview.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/mdPreview.spec.ts
@@ -9,6 +9,8 @@ function getHTML(preview: MarkdownPreview) {
   return removeDataAttr(preview.getHTML());
 }
 
+jest.useFakeTimers();
+
 describe('Preview', () => {
   let eventEmitter: EventEmitter, preview: MarkdownPreview;
 
@@ -104,6 +106,7 @@ describe('preview highlight', () => {
   }
 
   afterEach(() => {
+    jest.clearAllTimers();
     document.body.removeChild(editorEl);
     editor.destroy();
     preview.destroy();
@@ -202,6 +205,9 @@ describe('preview highlight', () => {
 
     setMarkdown('# Heading');
     setCursor([1, 1]);
+
+    // run setTimeout function when focusing the editor
+    jest.runAllTimers();
 
     expect(getHighlightedCount()).toBe(1);
 

--- a/apps/editor/src/__test__/unit/wysiwyg/wwEditor.spec.ts
+++ b/apps/editor/src/__test__/unit/wysiwyg/wwEditor.spec.ts
@@ -9,6 +9,8 @@ import { createHTMLSchemaMap } from '@/wysiwyg/nodes/html';
 import { sanitizeHTML } from '@/sanitizer/htmlSanitizer';
 import { createHTMLrenderer } from '../markdown/util';
 
+jest.useFakeTimers();
+
 describe('WysiwygEditor', () => {
   let wwe: WysiwygEditor, em: EventEmitter, el: HTMLElement;
 
@@ -34,6 +36,7 @@ describe('WysiwygEditor', () => {
   });
 
   afterEach(() => {
+    jest.clearAllTimers();
     if (Object.keys(wwe).length) {
       wwe.destroy();
     }
@@ -49,6 +52,9 @@ describe('WysiwygEditor', () => {
 
     it(`focus() enable editor's dom selection state`, () => {
       wwe.focus();
+
+      // run setTimeout function when focusing the editor
+      jest.runAllTimers();
 
       expect(document.activeElement).toEqual(wwe.view.dom);
     });

--- a/apps/editor/src/editorCore.ts
+++ b/apps/editor/src/editorCore.ts
@@ -197,14 +197,6 @@ class ToastUIEditorCore {
       sanitizer: customHTMLSanitizer || sanitizeHTML,
     };
     const wwToDOMAdaptor = new WwToDOMAdaptor(linkAttributes, rendererOptions.customHTMLRenderer);
-
-    if (this.options.hooks) {
-      forEachOwnProperties(this.options.hooks, (fn, key) => this.addHook(key, fn));
-    }
-
-    if (this.options.events) {
-      forEachOwnProperties(this.options.events, (fn, key) => this.on(key, fn));
-    }
     const htmlSchemaMap = createHTMLSchemaMap(
       rendererOptions.customHTMLRenderer,
       rendererOptions.sanitizer,
@@ -279,6 +271,14 @@ class ToastUIEditorCore {
     this.scrollSync = new ScrollSync(this.mdEditor, this.preview, this.eventEmitter);
     this.addInitEvent();
     this.addInitCommand(mdCommands, wwCommands);
+
+    if (this.options.hooks) {
+      forEachOwnProperties(this.options.hooks, (fn, key) => this.addHook(key, fn));
+    }
+
+    if (this.options.events) {
+      forEachOwnProperties(this.options.events, (fn, key) => this.on(key, fn));
+    }
 
     this.eventEmitter.emit('load', this);
     this.moveCursorToStart();
@@ -685,6 +685,7 @@ class ToastUIEditorCore {
       this.mdEditor.setMarkdown(this.convertor.toMarkdownText(wwNode), !withoutFocus);
     }
 
+    this.eventEmitter.emit('removePopupWidget');
     this.eventEmitter.emit('changeMode', mode);
 
     if (!withoutFocus) {

--- a/apps/editor/src/event/eventEmitter.ts
+++ b/apps/editor/src/event/eventEmitter.ts
@@ -21,6 +21,7 @@ const eventTypeList: EventTypes[] = [
   'toggleScrollSync',
   'mixinTableOffsetMapPrototype',
   'setFocusedNode',
+  'removePopupWidget',
   // provide event for user
   'openPopup',
   'closePopup',

--- a/apps/editor/src/plugins/popupWidget.ts
+++ b/apps/editor/src/plugins/popupWidget.ts
@@ -20,6 +20,7 @@ class PopupWidget {
   constructor(eventEmitter: Emitter) {
     this.eventEmitter = eventEmitter;
     this.eventEmitter.listen('blur', this.removeWidget);
+    this.eventEmitter.listen('removePopupWidget', this.removeWidget);
   }
 
   private removeWidget = () => {

--- a/apps/editor/types/event.d.ts
+++ b/apps/editor/types/event.d.ts
@@ -36,6 +36,7 @@ export type EventTypes =
   | 'toggleScrollSync'
   | 'mixinTableOffsetMapPrototype'
   | 'setFocusedNode'
+  | 'removePopupWidget'
   // provide event for user
   | 'openPopup'
   | 'closePopup'


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
* fixed that the default `addImageBlobHook` is called even though it should have been deleted by `hooks` option.
* added `removeWidgetPopup` internal event.
* related issue(#1588)


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
