### PR TITLE
fix: `getHTML` API trigger change event

### DIFF
--- a/apps/editor/src/__test__/unit/editor.spec.ts
+++ b/apps/editor/src/__test__/unit/editor.spec.ts
@@ -70,19 +70,31 @@ describe('editor', () => {
       expect(wwEditor).toContainHTML(expected);
     });
 
-    it('getHTML()', () => {
-      editor.setMarkdown('# heading\n* bullet');
+    describe('getHTML()', () => {
+      it('basic', () => {
+        editor.setMarkdown('# heading\n* bullet');
 
-      const result = stripIndents`
-        <h1>heading</h1>
-        <ul>
-          <li>
-            <p>bullet</p>
-          </li>
-        </ul>
-      `;
+        const result = stripIndents`
+          <h1>heading</h1>
+          <ul>
+            <li>
+              <p>bullet</p>
+            </li>
+          </ul>
+        `;
 
-      expect(editor.getHTML()).toBe(result);
+        expect(editor.getHTML()).toBe(result);
+      });
+
+      it('should not trigger change event when the mode is wysiwyg', () => {
+        const spy = jest.fn();
+
+        editor.changeMode('wysiwyg');
+        editor.on('change', spy);
+        editor.getHTML();
+
+        expect(spy).not.toHaveBeenCalled();
+      });
     });
 
     it('changeMode()', () => {

--- a/apps/editor/src/__test__/unit/eventEmitter.spec.ts
+++ b/apps/editor/src/__test__/unit/eventEmitter.spec.ts
@@ -201,4 +201,34 @@ describe('eventEmitter', () => {
       expect(handlerBeRemoved).not.toHaveBeenCalled();
     });
   });
+
+  describe('hold event', () => {
+    let handler: jest.Mock;
+
+    beforeEach(() => {
+      handler = jest.fn();
+
+      emitter.addEventType('myEvent');
+
+      emitter.listen('myEvent', handler);
+    });
+
+    it('should not call the holding event', () => {
+      emitter.holdEventInvoke(() => {
+        emitter.emit('myEvent');
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('should call the event after holding the event', () => {
+      emitter.holdEventInvoke(() => {
+        emitter.emit('myEvent');
+      });
+
+      emitter.emit('myEvent');
+
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/apps/editor/src/__test__/unit/eventEmitter.spec.ts
+++ b/apps/editor/src/__test__/unit/eventEmitter.spec.ts
@@ -205,6 +205,14 @@ describe('eventEmitter', () => {
   describe('hold event', () => {
     let handler: jest.Mock;
 
+    function triggerEvent(apiName: 'emit' | 'emitReduce') {
+      if (apiName === 'emit') {
+        emitter.emit('myEvent');
+      } else {
+        emitter.emitReduce('myEvent', 0);
+      }
+    }
+
     beforeEach(() => {
       handler = jest.fn();
 
@@ -213,22 +221,24 @@ describe('eventEmitter', () => {
       emitter.listen('myEvent', handler);
     });
 
-    it('should not call the holding event', () => {
-      emitter.holdEventInvoke(() => {
-        emitter.emit('myEvent');
+    (['emit', 'emitReduce'] as const).forEach((apiName) => {
+      it(`should not call the holding event with ${apiName} API`, () => {
+        emitter.holdEventInvoke(() => {
+          triggerEvent(apiName);
+        });
+
+        expect(handler).not.toHaveBeenCalled();
       });
 
-      expect(handler).not.toHaveBeenCalled();
-    });
+      it(`should call the event after holding the event with ${apiName} API`, () => {
+        emitter.holdEventInvoke(() => {
+          triggerEvent(apiName);
+        });
 
-    it('should call the event after holding the event', () => {
-      emitter.holdEventInvoke(() => {
-        emitter.emit('myEvent');
+        triggerEvent(apiName);
+
+        expect(handler).toHaveBeenCalledTimes(1);
       });
-
-      emitter.emit('myEvent');
-
-      expect(handler).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/editor/src/__test__/unit/eventEmitter.spec.ts
+++ b/apps/editor/src/__test__/unit/eventEmitter.spec.ts
@@ -223,17 +223,13 @@ describe('eventEmitter', () => {
 
     (['emit', 'emitReduce'] as const).forEach((apiName) => {
       it(`should not call the holding event with ${apiName} API`, () => {
-        emitter.holdEventInvoke(() => {
-          triggerEvent(apiName);
-        });
+        emitter.holdEventInvoke(() => triggerEvent(apiName));
 
         expect(handler).not.toHaveBeenCalled();
       });
 
       it(`should call the event after holding the event with ${apiName} API`, () => {
-        emitter.holdEventInvoke(() => {
-          triggerEvent(apiName);
-        });
+        emitter.holdEventInvoke(() => triggerEvent(apiName));
 
         triggerEvent(apiName);
 

--- a/apps/editor/src/editorCore.ts
+++ b/apps/editor/src/editorCore.ts
@@ -475,9 +475,11 @@ class ToastUIEditorCore {
    * @returns {string} html string
    */
   getHTML() {
-    if (this.isWysiwygMode()) {
-      this.mdEditor.setMarkdown(this.convertor.toMarkdownText(this.wwEditor.getModel()));
-    }
+    this.eventEmitter.holdEventInvoke(() => {
+      if (this.isWysiwygMode()) {
+        this.mdEditor.setMarkdown(this.convertor.toMarkdownText(this.wwEditor.getModel()));
+      }
+    });
 
     const mdNode = this.toastMark.getRootNode();
     const mdRenderer = this.preview.getRenderer();

--- a/apps/editor/src/event/eventEmitter.ts
+++ b/apps/editor/src/event/eventEmitter.ts
@@ -47,11 +47,14 @@ class EventEmitter implements Emitter {
 
   private eventTypes: Record<string, string>;
 
+  private hold: boolean;
+
   constructor() {
     this.events = new Map();
     this.eventTypes = eventTypeList.reduce((types, type) => {
       return { ...types, type };
     }, {});
+    this.hold = false;
 
     eventTypeList.forEach((eventType) => {
       this.addEventType(eventType);
@@ -90,7 +93,7 @@ class EventEmitter implements Emitter {
     const eventHandlers = this.events.get(typeInfo.type);
     const results: any[] = [];
 
-    if (eventHandlers) {
+    if (!this.hold && eventHandlers) {
       eventHandlers.forEach((handler) => {
         const result = handler(...args);
 
@@ -112,7 +115,7 @@ class EventEmitter implements Emitter {
   emitReduce(type: string, source: any, ...args: any[]) {
     const eventHandlers = this.events.get(type);
 
-    if (eventHandlers) {
+    if (!this.hold && eventHandlers) {
       eventHandlers.forEach((handler) => {
         const result = handler(source, ...args);
 
@@ -228,6 +231,12 @@ class EventEmitter implements Emitter {
 
   getEvents() {
     return this.events;
+  }
+
+  holdEventInvoke(fn: Function) {
+    this.hold = true;
+    fn();
+    this.hold = false;
   }
 }
 

--- a/apps/editor/src/ui/components/toolbar/imagePopupBody.ts
+++ b/apps/editor/src/ui/components/toolbar/imagePopupBody.ts
@@ -143,7 +143,11 @@ export class ImagePopupBody extends Component<Props, State> {
           >
             ${file ? file.name : i18n.get('No file')}
           </span>
-          <button type="button" class="${cls('file-select-button')}" onClick=${this.showFileSelectBox}>
+          <button
+            type="button"
+            class="${cls('file-select-button')}"
+            onClick=${this.showFileSelectBox}
+          >
             ${i18n.get('Choose a file')}
           </button>
           <input

--- a/apps/editor/types/event.d.ts
+++ b/apps/editor/types/event.d.ts
@@ -12,6 +12,7 @@ export interface Emitter {
   addEventType(type: string): void;
   removeEventHandler(type: string, handler?: Handler): void;
   getEvents(): Mapable<string, Handler[] | undefined>;
+  holdEventInvoke(fn: Function): void;
 }
 
 export interface EmitterConstructor {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
* fixed that `getHTML` API trigger change event.
* related issue(#1587)


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
