### PR TITLE
fix: cannot parse the `br` tag when calling `setHTML` API

### DIFF
--- a/apps/editor/src/__test__/unit/editor.spec.ts
+++ b/apps/editor/src/__test__/unit/editor.spec.ts
@@ -132,7 +132,7 @@ describe('editor', () => {
       expect(getPreviewHTML()).toBe('<h1>heading</h1>');
     });
 
-    describe('setHTML(', () => {
+    describe('setHTML()', () => {
       it('basic', () => {
         editor.setHTML('<h1>heading</h1>');
 

--- a/apps/editor/src/__test__/unit/editor.spec.ts
+++ b/apps/editor/src/__test__/unit/editor.spec.ts
@@ -132,13 +132,22 @@ describe('editor', () => {
       expect(getPreviewHTML()).toBe('<h1>heading</h1>');
     });
 
-    it('setHTML()', () => {
-      editor.setHTML('<h1>heading</h1>');
+    describe('setHTML(', () => {
+      it('basic', () => {
+        editor.setHTML('<h1>heading</h1>');
 
-      expect(mdEditor).toContainHTML(
-        `<div><span class="${HEADING_CLS}"><span class="${DELIM_CLS}">#</span> heading</span></div>`
-      );
-      expect(getPreviewHTML()).toBe('<h1>heading</h1>');
+        expect(mdEditor).toContainHTML(
+          `<div><span class="${HEADING_CLS}"><span class="${DELIM_CLS}">#</span> heading</span></div>`
+        );
+        expect(getPreviewHTML()).toBe('<h1>heading</h1>');
+      });
+
+      it('should parse the br tag as the empty block to separate between blocks', () => {
+        editor.setHTML('<p>a<br/>b</p>');
+
+        expect(mdEditor).toContainHTML('<div>a</div><div>b</div>');
+        expect(getPreviewHTML()).toBe('<p>a<br>b</p>');
+      });
     });
 
     it('reset()', () => {

--- a/apps/editor/src/convertors/toWysiwyg/htmlToWwConvertors.ts
+++ b/apps/editor/src/convertors/toWysiwyg/htmlToWwConvertors.ts
@@ -1,31 +1,13 @@
 import { MdNode } from '@toast-ui/toastmark';
 import { sanitizeXSSAttributeValue } from '@/sanitizer/htmlSanitizer';
-import { includes } from '@/utils/common';
 
 import {
   HTMLToWwConvertorMap,
   FlattenHTMLToWwConvertorMap,
   ToWwConvertorState,
 } from '@t/convertor';
-
-const TAG_NAME = '[A-Za-z][A-Za-z0-9-]*';
-const ATTRIBUTE_NAME = '[a-zA-Z_:][a-zA-Z0-9:._-]*';
-const UNQUOTED_VALUE = '[^"\'=<>`\\x00-\\x20]+';
-
-const SINGLE_QUOTED_VALUE = "'[^']*'";
-const DOUBLE_QUOTED_VALUE = '"[^"]*"';
-
-const ATTRIBUTE_VALUE = `(?:${UNQUOTED_VALUE}|${SINGLE_QUOTED_VALUE}|${DOUBLE_QUOTED_VALUE})`;
-const ATTRIBUTE_VALUE_SPEC = `${'(?:\\s*=\\s*'}${ATTRIBUTE_VALUE})`;
-
-export const ATTRIBUTE = `${'(?:\\s+'}${ATTRIBUTE_NAME}${ATTRIBUTE_VALUE_SPEC}?)`;
-
-const OPEN_TAG = `<(${TAG_NAME})(${ATTRIBUTE})*\\s*/?>`;
-const CLOSE_TAG = `</(${TAG_NAME})\\s*[>]`;
-
-const HTML_TAG = `(?:${OPEN_TAG}|${CLOSE_TAG})`;
-
-export const reHTMLTag = new RegExp(`^${HTML_TAG}`, 'i');
+import { includes } from '@/utils/common';
+import { reHTMLTag } from '@/utils/constants';
 
 export function getTextWithoutTrailingNewline(text: string) {
   return text[text.length - 1] === '\n' ? text.slice(0, text.length - 1) : text;

--- a/apps/editor/src/convertors/toWysiwyg/toWwConvertors.ts
+++ b/apps/editor/src/convertors/toWysiwyg/toWwConvertors.ts
@@ -17,7 +17,6 @@ import toArray from 'tui-code-snippet/collection/toArray';
 import { isElemNode } from '@/utils/dom';
 
 import {
-  reHTMLTag,
   htmlToWwConvertors,
   getTextWithoutTrailingNewline,
   isInlineNode,
@@ -28,6 +27,7 @@ import { ToWwConvertorMap } from '@t/convertor';
 import { createWidgetContent, getWidgetContent } from '@/widget/rules';
 import { getChildrenHTML, getHTMLAttrsByHTMLString } from '@/wysiwyg/nodes/html';
 import { includes } from '@/utils/common';
+import { reHTMLTag } from '@/utils/constants';
 
 function isBRTag(node: MdNode) {
   return node.type === 'htmlInline' && /<br ?\/?>/.test(node.literal!);

--- a/apps/editor/src/editorCore.ts
+++ b/apps/editor/src/editorCore.ts
@@ -38,7 +38,7 @@ import { WwToDOMAdaptor } from './wysiwyg/adaptor/wwToDOMAdaptor';
 import { ScrollSync } from './markdown/scroll/scrollSync';
 import { addDefaultImageBlobHook } from './helper/image';
 import { setWidgetRules } from './widget/rules';
-import { cls } from './utils/dom';
+import { cls, replaceBRWithEmptyBlock } from './utils/dom';
 import { sanitizeHTML } from './sanitizer/htmlSanitizer';
 import { createHTMLSchemaMap } from './wysiwyg/nodes/html';
 import { getHTMLRenderConvertors } from './markdown/htmlRenderConvertors';
@@ -448,7 +448,8 @@ class ToastUIEditorCore {
   setHTML(html = '', cursorToEnd = true) {
     const container = document.createElement('div');
 
-    container.innerHTML = html;
+    // the `br` tag should be replaced with empty block to separate between blocks
+    container.innerHTML = replaceBRWithEmptyBlock(html);
     const wwNode = DOMParser.fromSchema(this.wwEditor.schema).parse(container);
 
     if (this.isMarkdownMode()) {

--- a/apps/editor/src/markdown/htmlRenderConvertors.ts
+++ b/apps/editor/src/markdown/htmlRenderConvertors.ts
@@ -12,10 +12,10 @@ import {
 } from '@t/toastmark';
 import { LinkAttributes, CustomHTMLRenderer } from '@t/editor';
 import { HTMLMdNode } from '@t/markdown';
-import { reHTMLTag } from '@/convertors/toWysiwyg/htmlToWwConvertors';
 import { getWidgetContent, widgetToDOM } from '@/widget/rules';
 import { getChildrenHTML, getHTMLAttrsByHTMLString } from '@/wysiwyg/nodes/html';
 import { includes } from '@/utils/common';
+import { reHTMLTag } from '@/utils/constants';
 
 type TokenAttrs = Record<string, any>;
 

--- a/apps/editor/src/utils/constants.ts
+++ b/apps/editor/src/utils/constants.ts
@@ -10,8 +10,8 @@ const ATTRIBUTE_VALUE_SPEC = `${'(?:\\s*=\\s*'}${ATTRIBUTE_VALUE})`;
 
 export const ATTRIBUTE = `${'(?:\\s+'}${ATTRIBUTE_NAME}${ATTRIBUTE_VALUE_SPEC}?)`;
 
-const OPEN_TAG = `<(${TAG_NAME})(${ATTRIBUTE})*\\s*/?>`;
-const CLOSE_TAG = `</(${TAG_NAME})\\s*[>]`;
+export const OPEN_TAG = `<(${TAG_NAME})(${ATTRIBUTE})*\\s*/?>`;
+export const CLOSE_TAG = `</(${TAG_NAME})\\s*[>]`;
 
 export const HTML_TAG = `(?:${OPEN_TAG}|${CLOSE_TAG})`;
 

--- a/apps/editor/src/utils/constants.ts
+++ b/apps/editor/src/utils/constants.ts
@@ -1,0 +1,18 @@
+const TAG_NAME = '[A-Za-z][A-Za-z0-9-]*';
+const ATTRIBUTE_NAME = '[a-zA-Z_:][a-zA-Z0-9:._-]*';
+const UNQUOTED_VALUE = '[^"\'=<>`\\x00-\\x20]+';
+
+const SINGLE_QUOTED_VALUE = "'[^']*'";
+const DOUBLE_QUOTED_VALUE = '"[^"]*"';
+
+const ATTRIBUTE_VALUE = `(?:${UNQUOTED_VALUE}|${SINGLE_QUOTED_VALUE}|${DOUBLE_QUOTED_VALUE})`;
+const ATTRIBUTE_VALUE_SPEC = `${'(?:\\s*=\\s*'}${ATTRIBUTE_VALUE})`;
+
+export const ATTRIBUTE = `${'(?:\\s+'}${ATTRIBUTE_NAME}${ATTRIBUTE_VALUE_SPEC}?)`;
+
+const OPEN_TAG = `<(${TAG_NAME})(${ATTRIBUTE})*\\s*/?>`;
+const CLOSE_TAG = `</(${TAG_NAME})\\s*[>]`;
+
+export const HTML_TAG = `(?:${OPEN_TAG}|${CLOSE_TAG})`;
+
+export const reHTMLTag = new RegExp(`^${HTML_TAG}`, 'i');

--- a/apps/editor/src/utils/dom.ts
+++ b/apps/editor/src/utils/dom.ts
@@ -239,8 +239,6 @@ export function setAttributes(attributes: Record<string, any>, element: HTMLElem
 
 export function replaceBRWithEmptyBlock(html: string) {
   const reBr = /<br\s*\/*>/i;
-  const alternativeTagListForBr: string[] = [];
-
   const reHTMLTag = new RegExp(HTML_TAG, 'ig');
   const htmlTagMatched = html.match(reHTMLTag);
 
@@ -258,12 +256,9 @@ export function replaceBRWithEmptyBlock(html: string) {
           alternativeTag = `</${tagName}><${tagName}>`;
         }
       }
-      alternativeTagListForBr.push(alternativeTag);
+      html = html.replace(reBr, alternativeTag);
     }
   });
 
-  return alternativeTagListForBr.reduce(
-    (acc, alternativeTag) => (acc = acc.replace(reBr, alternativeTag)),
-    html
-  );
+  return html;
 }

--- a/apps/editor/src/utils/dom.ts
+++ b/apps/editor/src/utils/dom.ts
@@ -6,6 +6,7 @@ import hasClass from 'tui-code-snippet/domUtil/hasClass';
 import addClass from 'tui-code-snippet/domUtil/addClass';
 import removeClass from 'tui-code-snippet/domUtil/removeClass';
 import matches from 'tui-code-snippet/domUtil/matches';
+import { HTML_TAG, OPEN_TAG } from './constants';
 
 export function isPositionInBox(style: CSSStyleDeclaration, offsetX: number, offsetY: number) {
   const left = parseInt(style.left, 10);
@@ -234,4 +235,35 @@ export function setAttributes(attributes: Record<string, any>, element: HTMLElem
       element.removeAttribute(attrName);
     }
   });
+}
+
+export function replaceBRWithEmptyBlock(html: string) {
+  const reBr = /<br\s*\/*>/i;
+  const alternativeTagListForBr: string[] = [];
+
+  const reHTMLTag = new RegExp(HTML_TAG, 'ig');
+  const htmlTagMatched = html.match(reHTMLTag);
+
+  htmlTagMatched?.forEach((htmlTag, index) => {
+    if (reBr.test(htmlTag)) {
+      let alternativeTag = '';
+
+      if (index) {
+        const prevTag = htmlTagMatched[index - 1];
+        const openTagMatched = prevTag.match(OPEN_TAG);
+
+        if (openTagMatched) {
+          const [, tagName] = openTagMatched;
+
+          alternativeTag = `</${tagName}><${tagName}>`;
+        }
+      }
+      alternativeTagListForBr.push(alternativeTag);
+    }
+  });
+
+  return alternativeTagListForBr.reduce(
+    (acc, alternativeTag) => (acc = acc.replace(reBr, alternativeTag)),
+    html
+  );
 }

--- a/apps/editor/src/wysiwyg/nodes/html.ts
+++ b/apps/editor/src/wysiwyg/nodes/html.ts
@@ -9,8 +9,8 @@ import { HTMLConvertorMap, MdNode } from '@toast-ui/toastmark';
 import toArray from 'tui-code-snippet/collection/toArray';
 import { Sanitizer, HTMLSchemaMap } from '@t/editor';
 import { ToDOMAdaptor } from '@t/convertor';
-import { ATTRIBUTE, reHTMLTag } from '@/convertors/toWysiwyg/htmlToWwConvertors';
 import { registerTagWhitelistIfPossible } from '@/sanitizer/htmlSanitizer';
+import { reHTMLTag, ATTRIBUTE } from '@/utils/constants';
 
 export function getChildrenHTML(node: MdNode, typeName: string) {
   return node


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
* fixed that the `br` tag cannot be parsed when calling `setHTML` API.
* related issue(#1582)


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
