### PR TITLE
fix: broken `customHTMLRenderer` option type in editorCore

### DIFF
--- a/apps/editor/src/markdown/mdPreview.ts
+++ b/apps/editor/src/markdown/mdPreview.ts
@@ -3,10 +3,10 @@ import addClass from 'tui-code-snippet/domUtil/addClass';
 import removeClass from 'tui-code-snippet/domUtil/removeClass';
 import on from 'tui-code-snippet/domEvent/on';
 import css from 'tui-code-snippet/domUtil/css';
-import { EditResult, HTMLConvertorMap, MdNode, MdPos, Renderer } from '@toast-ui/toastmark';
+import { EditResult, MdNode, MdPos, Renderer } from '@toast-ui/toastmark';
 
 import { Emitter } from '@t/event';
-import { LinkAttributes } from '@t/editor';
+import { CustomHTMLRenderer, LinkAttributes } from '@t/editor';
 import { cls, createElementWith, removeNode, toggleClass } from '@/utils/dom';
 import { getHTMLRenderConvertors } from '@/markdown/htmlRenderConvertors';
 import { isInlineNode, findClosestNode, getMdStartCh } from '@/utils/markdown';
@@ -32,7 +32,7 @@ type Sanitizer = (html: string) => string;
 
 interface Options {
   linkAttributes: LinkAttributes | null;
-  customHTMLRenderer: HTMLConvertorMap;
+  customHTMLRenderer: CustomHTMLRenderer;
   isViewer: boolean;
   highlight?: boolean;
   sanitizer: Sanitizer;

--- a/apps/editor/src/wysiwyg/adaptor/wwToDOMAdaptor.ts
+++ b/apps/editor/src/wysiwyg/adaptor/wwToDOMAdaptor.ts
@@ -14,7 +14,7 @@ import isArray from 'tui-code-snippet/type/isArray';
 import { getHTMLRenderConvertors } from '@/markdown/htmlRenderConvertors';
 import { ToDOMAdaptor } from '@t/convertor';
 import { includes, last } from '@/utils/common';
-import { LinkAttributes } from '@t/editor';
+import { CustomHTMLRenderer, LinkAttributes } from '@t/editor';
 import { setAttributes } from '@/utils/dom';
 import { createMdLikeNode, isContainer, isPmNode } from './mdLikeNode';
 
@@ -65,7 +65,7 @@ export class WwToDOMAdaptor implements ToDOMAdaptor {
 
   convertors: HTMLConvertorMap;
 
-  constructor(linkAttributes: LinkAttributes | null, customRenderer: HTMLConvertorMap) {
+  constructor(linkAttributes: LinkAttributes | null, customRenderer: CustomHTMLRenderer) {
     const convertors = getHTMLRenderConvertors(linkAttributes, customRenderer);
     const customHTMLConvertor = { ...customRenderer.htmlBlock, ...customRenderer.htmlInline };
 

--- a/apps/editor/src/wysiwyg/nodes/html.ts
+++ b/apps/editor/src/wysiwyg/nodes/html.ts
@@ -5,9 +5,9 @@ import {
   NodeSpec,
   MarkSpec,
 } from 'prosemirror-model';
-import { HTMLConvertorMap, MdNode } from '@toast-ui/toastmark';
+import { MdNode } from '@toast-ui/toastmark';
 import toArray from 'tui-code-snippet/collection/toArray';
-import { Sanitizer, HTMLSchemaMap } from '@t/editor';
+import { Sanitizer, HTMLSchemaMap, CustomHTMLRenderer } from '@t/editor';
 import { ToDOMAdaptor } from '@t/convertor';
 import { registerTagWhitelistIfPossible } from '@/sanitizer/htmlSanitizer';
 import { reHTMLTag, ATTRIBUTE } from '@/utils/constants';
@@ -117,7 +117,7 @@ const schemaFactory = {
 };
 
 export function createHTMLSchemaMap(
-  convertorMap: HTMLConvertorMap,
+  convertorMap: CustomHTMLRenderer,
   sanitizeHTML: Sanitizer,
   wwToDOMAdaptor: ToDOMAdaptor
 ): HTMLSchemaMap {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
* fixed broken `customHTMLRenderer` option type in `editorCore.ts`


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
