### PR TITLE
fix: dom structure

### DIFF
--- a/apps/editor/src/css/contents.css
+++ b/apps/editor/src/css/contents.css
@@ -2,7 +2,8 @@
   z-index basis
   -1: pseudo element
   20 - preview, wysiwyg
-  30 - wysiwyg code block language editor, tooltip, popup, context menu
+  30 - wysiwyg code block language editor, popup, context menu
+  40 - tooltip
 */
 .ProseMirror {
   font-family: 'Open Sans', 'Helvetica Neue', 'Helvetica', 'Arial', '나눔바른고딕',

--- a/apps/editor/src/css/editor.css
+++ b/apps/editor/src/css/editor.css
@@ -31,13 +31,6 @@
   clear: both;
 }
 
-.toastui-editor-md-container {
-  position: absolute;
-  line-height: 1;
-  color: #222;
-  width: 100%;
-  height: inherit;
-}
 
 .toastui-editor-main {
   min-height: 0px;
@@ -109,6 +102,8 @@
   height: 100%;
   width: 1px;
   background-color: #ebedf2;
+  position: absolute;
+  left: 50%;
 }
 
 .toastui-editor-main .toastui-editor-md-vertical-style .toastui-editor-md-splitter {
@@ -122,9 +117,21 @@
   background-color: #fff;
 }
 
+.auto-height .toastui-editor-main-container {
+  position: relative;
+}
+
+.toastui-editor-main-container {
+  position: absolute;
+  line-height: 1;
+  color: #222;
+  width: 100%;
+  height: inherit;
+}
+
 .toastui-editor-ww-container > .toastui-editor {
   height: inherit;
-  position: absolute;
+  position: relative;
   width: 100%;
 }
 
@@ -747,7 +754,7 @@
 .toastui-editor-tooltip {
   position: absolute;
   background-color: #444;
-  z-index: 30;
+  z-index: 40;
   padding: 4px 7px;
   font-size: 12px;
   border-radius: 3px;

--- a/apps/editor/src/ui/components/layout.ts
+++ b/apps/editor/src/ui/components/layout.ts
@@ -83,16 +83,18 @@ export class Layout extends Component<Props, State> {
           class="${cls('main')} ${editorTypeClassName}"
           ref=${(el: HTMLElement) => (this.refs.editorSection = el)}
         >
-          <div
-            class="${cls('md-container')} ${previewClassName}"
-            ref=${(el: HTMLElement) => (this.refs.mdContainer = el)}
-          >
-            <div class="${cls('md-splitter')}"></div>
+          <div class=${cls('main-container')}>
+            <div
+              class="${cls('md-container')} ${previewClassName}"
+              ref=${(el: HTMLElement) => (this.refs.mdContainer = el)}
+            >
+              <div class="${cls('md-splitter')}"></div>
+            </div>
+            <div
+              class="${cls('ww-container')}"
+              ref=${(el: HTMLElement) => (this.refs.wwContainer = el)}
+            />
           </div>
-          <div
-            class="${cls('ww-container')}"
-            ref=${(el: HTMLElement) => (this.refs.wwContainer = el)}
-          />
         </div>
         ${!hideModeSwitch &&
         html`<${Switch} eventEmitter=${eventEmitter} editorType=${editorType} />`}

--- a/apps/editor/src/ui/components/layout.ts
+++ b/apps/editor/src/ui/components/layout.ts
@@ -83,7 +83,7 @@ export class Layout extends Component<Props, State> {
           class="${cls('main')} ${editorTypeClassName}"
           ref=${(el: HTMLElement) => (this.refs.editorSection = el)}
         >
-          <div class=${cls('main-container')}>
+          <div class="${cls('main-container')}">
             <div
               class="${cls('md-container')} ${previewClassName}"
               ref=${(el: HTMLElement) => (this.refs.mdContainer = el)}


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
* fixed that `resizeObserver` is triggered unnecessarily in flex-container(`display: flex`)
![2021-08-17 08-59-50 2021-08-17 09_00_19](https://user-images.githubusercontent.com/37766175/129643559-cb200e1c-b0b2-4b74-b3ae-ebd12e747d4d.gif)
* fixed that editor container DOM structure


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
