### PR TITLE
feat: add an 'autofocus' option that can disable initial focus (close #1730)

### DIFF
--- a/apps/editor/src/base.ts
+++ b/apps/editor/src/base.ts
@@ -168,21 +168,25 @@ export default abstract class EditorBase implements Base {
     });
   }
 
-  moveCursorToStart() {
+  moveCursorToStart(focus: boolean) {
     const { tr } = this.view.state;
 
     this.view.dispatch(tr.setSelection(createTextSelection(tr, 1)).scrollIntoView());
-    this.focus();
+    if (focus) {
+      this.focus();
+    }
   }
 
-  moveCursorToEnd() {
+  moveCursorToEnd(focus: boolean) {
     const { tr } = this.view.state;
 
     this.view.dispatch(
       tr.setSelection(createTextSelection(tr, tr.doc.content.size - 1)).scrollIntoView()
     );
 
-    this.focus();
+    if (focus) {
+      this.focus();
+    }
   }
 
   setScrollTop(top: number) {

--- a/apps/editor/src/editorCore.ts
+++ b/apps/editor/src/editorCore.ts
@@ -82,6 +82,7 @@ import { getHTMLRenderConvertors } from './markdown/htmlRenderConvertors';
  *     @param {boolean} [options.frontMatter=false] - whether use the front matter
  *     @param {Array.<object>} [options.widgetRules=[]] - The rules for replacing the text with widget node
  *     @param {string} [options.theme] - The theme to style the editor with. The default is included in toastui-editor.css.
+ *     @param {autofocus} [options.autofocus=true] - automatically focus the editor on creation.
  */
 class ToastUIEditorCore {
   private initialHtml: string;
@@ -148,6 +149,7 @@ class ToastUIEditorCore {
         frontMatter: false,
         widgetRules: [],
         theme: 'light',
+        autofocus: true,
       },
       options
     );
@@ -281,7 +283,7 @@ class ToastUIEditorCore {
     }
 
     this.eventEmitter.emit('load', this);
-    this.moveCursorToStart();
+    this.moveCursorToStart(this.options.autofocus);
   }
 
   private addInitEvent() {
@@ -413,15 +415,15 @@ class ToastUIEditorCore {
   /**
    * Set cursor position to end
    */
-  moveCursorToEnd() {
-    this.getCurrentModeEditor().moveCursorToEnd();
+  moveCursorToEnd(focus = true) {
+    this.getCurrentModeEditor().moveCursorToEnd(focus);
   }
 
   /**
    * Set cursor position to start
    */
-  moveCursorToStart() {
-    this.getCurrentModeEditor().moveCursorToStart();
+  moveCursorToStart(focus = true) {
+    this.getCurrentModeEditor().moveCursorToStart(focus);
   }
 
   /**

--- a/apps/editor/src/markdown/mdEditor.ts
+++ b/apps/editor/src/markdown/mdEditor.ts
@@ -331,7 +331,7 @@ export default class MdEditor extends EditorBase {
     this.view.dispatch(tr.replaceWith(0, doc.content.size, nodes));
 
     if (cursorToEnd) {
-      this.moveCursorToEnd();
+      this.moveCursorToEnd(true);
     }
   }
 

--- a/apps/editor/src/wysiwyg/wwEditor.ts
+++ b/apps/editor/src/wysiwyg/wwEditor.ts
@@ -255,7 +255,7 @@ export default class WysiwygEditor extends EditorBase {
     this.view.dispatch(tr.replaceWith(0, doc.content.size, newDoc));
 
     if (cursorToEnd) {
-      this.moveCursorToEnd();
+      this.moveCursorToEnd(true);
     }
   }
 

--- a/apps/editor/types/editor.d.ts
+++ b/apps/editor/types/editor.d.ts
@@ -158,6 +158,7 @@ export interface EditorOptions {
   frontMatter?: boolean;
   widgetRules?: WidgetRule[];
   theme?: string;
+  autofocus?: boolean;
 }
 
 interface Slots {
@@ -193,9 +194,9 @@ export class EditorCore {
 
   blur(): void;
 
-  moveCursorToEnd(): void;
+  moveCursorToEnd(focus?: boolean): void;
 
-  moveCursorToStart(): void;
+  moveCursorToStart(focus?: boolean): void;
 
   setMarkdown(markdown: string, cursorToEnd?: boolean): void;
 
@@ -312,9 +313,9 @@ export interface Base {
 
   destroy(): void;
 
-  moveCursorToStart(): void;
+  moveCursorToStart(focus?: boolean): void;
 
-  moveCursorToEnd(): void;
+  moveCursorToEnd(focus?: boolean): void;
 
   setScrollTop(top: number): void;
 


### PR DESCRIPTION
Without this option, the editor always catches the focus on initialization, making it possibly incompatible with other elements on the page that also need the focus at startup.

The patch is really simple, I am not sure what test I could have written.

Fixes #1730