### PR TITLE
fix: the editor cannot apply empty string attributes to wysiwyg node

### DIFF
--- a/apps/editor/src/__test__/unit/editor.spec.ts
+++ b/apps/editor/src/__test__/unit/editor.spec.ts
@@ -864,6 +864,25 @@ describe('editor', () => {
 
         expect(wwEditor.innerHTML).toContain(result);
       });
+
+      it('should keep the html block attributes with an empty string after changing the mode', () => {
+        createEditor({
+          el: container,
+          initialValue: '<iframe width="" height="" src=""></iframe>\n\ntest',
+          previewHighlight: false,
+          // add iframe html block renderer
+          customHTMLRenderer: createHTMLrenderer(),
+        });
+
+        editor.changeMode('wysiwyg');
+
+        const result = oneLineTrim`
+          <iframe width="" height="" src="" class="html-block"></iframe>
+          <p>test</p>
+        `;
+
+        expect(wwEditor.innerHTML).toContain(result);
+      });
     });
 
     describe('hooks option', () => {

--- a/apps/editor/src/__test__/unit/editor.spec.ts
+++ b/apps/editor/src/__test__/unit/editor.spec.ts
@@ -865,10 +865,10 @@ describe('editor', () => {
         expect(wwEditor.innerHTML).toContain(result);
       });
 
-      it('should keep the html block attributes with an empty string after changing the mode', () => {
+      it('should keep the html attributes with an empty string after changing the mode', () => {
         createEditor({
           el: container,
-          initialValue: '<iframe width="" height="" src=""></iframe>\n\ntest',
+          initialValue: '<iframe width="" height="" src=""></iframe>',
           previewHighlight: false,
           // add iframe html block renderer
           customHTMLRenderer: createHTMLrenderer(),
@@ -878,7 +878,6 @@ describe('editor', () => {
 
         const result = oneLineTrim`
           <iframe width="" height="" src="" class="html-block"></iframe>
-          <p>test</p>
         `;
 
         expect(wwEditor.innerHTML).toContain(result);

--- a/apps/editor/src/sanitizer/htmlSanitizer.ts
+++ b/apps/editor/src/sanitizer/htmlSanitizer.ts
@@ -16,7 +16,7 @@ const reHTMLAttr = new RegExp(
     'ismap|lang|language|nohref|nowrap|rel|rev|rows|rules|' +
     'scope|scrolling|shape|size|span|start|summary|tabindex|target|title|type|' +
     'valign|value|vspace|width|checked|mathvariant|encoding|id|name|' +
-    'background|cite|href|longdesc|src|usemap|xlink:href|data-+|checked|style)',
+    'background|cite|href|longdesc|src|usemap|xlink:href|data-+|checked|style|controls)',
   'g'
 );
 

--- a/apps/editor/src/utils/common.ts
+++ b/apps/editor/src/utils/common.ts
@@ -108,7 +108,7 @@ export function quote(text: string) {
   return result[0] + text + result[1];
 }
 
-function isNil(value: unknown): value is null | undefined {
+export function isNil(value: unknown): value is null | undefined {
   return isNull(value) || isUndefined(value);
 }
 

--- a/apps/editor/src/utils/dom.ts
+++ b/apps/editor/src/utils/dom.ts
@@ -229,11 +229,7 @@ export function prependNode(node: Element, appended: string | ArrayLike<Element>
 
 export function setAttributes(attributes: Record<string, any>, element: HTMLElement) {
   Object.keys(attributes).forEach((attrName) => {
-    if (attributes[attrName]) {
-      element.setAttribute(attrName, attributes[attrName]);
-    } else {
-      element.removeAttribute(attrName);
-    }
+    element.setAttribute(attrName, attributes[attrName]);
   });
 }
 

--- a/apps/editor/src/utils/dom.ts
+++ b/apps/editor/src/utils/dom.ts
@@ -7,6 +7,7 @@ import addClass from 'tui-code-snippet/domUtil/addClass';
 import removeClass from 'tui-code-snippet/domUtil/removeClass';
 import matches from 'tui-code-snippet/domUtil/matches';
 import { HTML_TAG, OPEN_TAG } from './constants';
+import { isNil } from './common';
 
 export function isPositionInBox(style: CSSStyleDeclaration, offsetX: number, offsetY: number) {
   const left = parseInt(style.left, 10);
@@ -229,7 +230,11 @@ export function prependNode(node: Element, appended: string | ArrayLike<Element>
 
 export function setAttributes(attributes: Record<string, any>, element: HTMLElement) {
   Object.keys(attributes).forEach((attrName) => {
-    element.setAttribute(attrName, attributes[attrName]);
+    if (isNil(attributes[attrName])) {
+      element.removeAttribute(attrName);
+    } else {
+      element.setAttribute(attrName, attributes[attrName]);
+    }
   });
 }
 


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
* fixed that the editor cannot apply empty string attributes to wysiwyg node
* related issue(#1710)
* TODO: should add DOMPurify for proper sanitizing


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
