### PR TITLE
fix: fail to convert  list having blockQuote with spaces to wysiwyg

### DIFF
--- a/apps/editor/src/__test__/unit/convertor.spec.ts
+++ b/apps/editor/src/__test__/unit/convertor.spec.ts
@@ -316,6 +316,29 @@ describe('Convertor', () => {
       assertConverting(markdown, expected);
     });
 
+    it('block nodes in list', () => {
+      const markdown = source`
+        1. foo
+
+            \`\`\`
+            bar
+            \`\`\`
+        
+            > bam
+      `;
+      const expected = source`
+        1. foo
+
+            \`\`\`
+            bar
+            \`\`\`
+        
+            > bam
+      `;
+
+      assertConverting(markdown, expected);
+    });
+
     it('soft break', () => {
       const markdown = source`
         foo

--- a/apps/editor/src/wysiwyg/nodes/bulletList.ts
+++ b/apps/editor/src/wysiwyg/nodes/bulletList.ts
@@ -19,7 +19,7 @@ export class BulletList extends NodeSchema {
   get schema() {
     return {
       content: 'listItem+',
-      group: 'block listGroup',
+      group: 'block',
       attrs: {
         rawHTML: { default: null },
         ...getDefaultCustomAttrs(),

--- a/apps/editor/src/wysiwyg/nodes/listItem.ts
+++ b/apps/editor/src/wysiwyg/nodes/listItem.ts
@@ -11,7 +11,8 @@ export class ListItem extends NodeSchema {
 
   get schema() {
     return {
-      content: 'paragraph listGroup*',
+      content: 'paragraph block*',
+      selectable: false,
       attrs: {
         task: { default: false },
         checked: { default: false },

--- a/apps/editor/src/wysiwyg/nodes/orderedList.ts
+++ b/apps/editor/src/wysiwyg/nodes/orderedList.ts
@@ -15,7 +15,7 @@ export class OrderedList extends NodeSchema {
   get schema() {
     return {
       content: 'listItem+',
-      group: 'block listGroup',
+      group: 'block',
       attrs: {
         order: { default: 1 },
         rawHTML: { default: null },

--- a/apps/editor/src/wysiwyg/nodes/paragraph.ts
+++ b/apps/editor/src/wysiwyg/nodes/paragraph.ts
@@ -11,7 +11,7 @@ export class Paragraph extends NodeSchema {
   get schema() {
     return {
       content: 'inline*',
-      group: 'block listGroup',
+      group: 'block',
       attrs: {
         ...getDefaultCustomAttrs(),
       },


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
**as-is**
![2021-09-06 12-32-29 2021-09-06 12_32_38](https://user-images.githubusercontent.com/37766175/132157016-6302d6fd-e82b-40c9-9261-c07228204a9d.gif)

**to-be**
![2021-09-06 12-31-51 2021-09-06 12_32_01](https://user-images.githubusercontent.com/37766175/132156971-ddb1708b-904e-43cc-83dd-e38c0ccb53af.gif)
* fixed that the editor fails to convert  list having blockQuote with spaces to wysiwyg
* related issue(#1756)


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
