### PR TITLE
fix: i18n cannot be applied to color-syntax-plugin

### DIFF
--- a/apps/editor/src/editorCore.ts
+++ b/apps/editor/src/editorCore.ts
@@ -169,6 +169,9 @@ class ToastUIEditorCore {
     this.mode = initialEditType || 'markdown';
     this.mdPreviewStyle = this.options.previewStyle;
 
+    this.i18n = i18n;
+    this.i18n.setCode(this.options.language);
+
     this.eventEmitter = new EventEmitter();
 
     setWidgetRules(widgetRules);
@@ -204,9 +207,6 @@ class ToastUIEditorCore {
       rendererOptions.sanitizer,
       wwToDOMAdaptor
     );
-
-    this.i18n = i18n;
-    this.i18n.setCode(this.options.language);
 
     this.toastMark = new ToastMark('', {
       disallowedHtmlBlockTags: ['br', 'img'],

--- a/plugins/color-syntax/src/i18n/langs.ts
+++ b/plugins/color-syntax/src/i18n/langs.ts
@@ -80,9 +80,11 @@ export function addLangs(i18n: I18n) {
   i18n.setLanguage(['uk', 'uk-UA'], {
     'Text color': 'Колір тексту',
   });
+
   i18n.setLanguage('zh-CN', {
     'Text color': '文字颜色',
   });
+
   i18n.setLanguage('zh-TW', {
     'Text color': '文字顏色',
   });

--- a/plugins/color-syntax/src/i18n/langs.ts
+++ b/plugins/color-syntax/src/i18n/langs.ts
@@ -1,0 +1,89 @@
+import type { I18n } from '@toast-ui/editor';
+
+export function addLangs(i18n: I18n) {
+  i18n.setLanguage('ar', {
+    'Text color': 'لون النص',
+  });
+
+  i18n.setLanguage(['cs', 'cs-CZ'], {
+    'Text color': 'Barva textu',
+  });
+
+  i18n.setLanguage(['de', 'de-DE'], {
+    'Text color': 'Textfarbe',
+  });
+
+  i18n.setLanguage(['en', 'en-US'], {
+    'Text color': 'Text color',
+  });
+
+  i18n.setLanguage(['es', 'es-ES'], {
+    'Text color': 'Color del texto',
+  });
+
+  i18n.setLanguage(['fi', 'fi-FI'], {
+    'Text color': 'Tekstin väri',
+  });
+
+  i18n.setLanguage(['fr', 'fr-FR'], {
+    'Text color': 'Couleur du texte',
+  });
+
+  i18n.setLanguage(['gl', 'gl-ES'], {
+    'Text color': 'Cor do texto',
+  });
+
+  i18n.setLanguage(['hr', 'hr-HR'], {
+    'Text color': 'Boja teksta',
+  });
+
+  i18n.setLanguage(['it', 'it-IT'], {
+    'Text color': 'Colore del testo',
+  });
+
+  i18n.setLanguage(['ja', 'ja-JP'], {
+    'Text color': '文字色相',
+  });
+
+  i18n.setLanguage(['ko', 'ko-KR'], {
+    'Text color': '글자 색상',
+  });
+
+  i18n.setLanguage(['nb', 'nb-NO'], {
+    'Text color': 'Tekstfarge',
+  });
+
+  i18n.setLanguage(['nl', 'nl-NL'], {
+    'Text color': 'Tekstkleur',
+  });
+
+  i18n.setLanguage(['pl', 'pl-PL'], {
+    'Text color': 'Kolor tekstu',
+  });
+
+  i18n.setLanguage(['pt', 'pt-BR'], {
+    'Text color': 'Cor do texto',
+  });
+
+  i18n.setLanguage(['ru', 'ru-RU'], {
+    'Text color': 'Цвет текста',
+  });
+
+  i18n.setLanguage(['sv', 'sv-SE'], {
+    'Text color': 'Textfärg',
+  });
+
+  i18n.setLanguage(['tr', 'tr-TR'], {
+    'Text color': 'Metin rengi',
+  });
+
+  i18n.setLanguage(['uk', 'uk-UA'], {
+    'Text color': 'Колір тексту',
+  });
+  i18n.setLanguage('zh-CN', {
+    'Text color': '文字颜色',
+  });
+  i18n.setLanguage('zh-TW', {
+    'Text color': '文字顏色',
+  });
+}

--- a/plugins/color-syntax/src/index.ts
+++ b/plugins/color-syntax/src/index.ts
@@ -1,8 +1,9 @@
 import ColorPicker from 'tui-color-picker';
 import type { Context } from '@toast-ui/toastmark';
-import type { PluginContext, PluginInfo, HTMLMdNode } from '@toast-ui/editor';
+import type { PluginContext, PluginInfo, HTMLMdNode, I18n } from '@toast-ui/editor';
 import type { Transaction, Selection, TextSelection } from 'prosemirror-state';
 import { PluginOptions } from '@t/index';
+import { addLangs } from './i18n/langs';
 
 import './css/plugin.css';
 
@@ -17,10 +18,10 @@ function createApplyButton(text: string) {
   return button;
 }
 
-function createToolbarItemOption(colorPickerContainer: HTMLDivElement) {
+function createToolbarItemOption(colorPickerContainer: HTMLDivElement, i18n: I18n) {
   return {
     name: 'color',
-    tooltip: 'Text color',
+    tooltip: i18n.get('Text color'),
     className: `${PREFIX}toolbar-icons color`,
     popup: {
       className: `${PREFIX}popup-color`,
@@ -72,6 +73,8 @@ export default function colorSyntaxPlugin(
   const container = document.createElement('div');
   const colorPickerOption: ColorPickerOption = { container, usageStatistics };
 
+  addLangs(i18n);
+
   if (preset) {
     colorPickerOption.preset = preset;
   }
@@ -99,7 +102,7 @@ export default function colorSyntaxPlugin(
   colorPicker.slider.toggle(true);
   container.appendChild(button);
 
-  const toolbarItem = createToolbarItemOption(container);
+  const toolbarItem = createToolbarItemOption(container, i18n);
 
   return {
     markdownCommands: {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
* fixed that i18n cannot be applied to color-syntax-plugin
* related issue(#1774)


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
