### PR TITLE
feat: Added a `focus` parameter to the `setMarkdown` and `setHTML` functions

### DIFF
--- a/apps/editor/src/editorCore.ts
+++ b/apps/editor/src/editorCore.ts
@@ -256,7 +256,7 @@ class ToastUIEditorCore {
     }
 
     if (!this.options.initialValue) {
-      this.setHTML(this.initialHTML, false);
+      this.setHTML(this.initialHTML, false, this.options.autofocus);
     }
 
     this.commandManager = new CommandManager(
@@ -449,7 +449,7 @@ class ToastUIEditorCore {
    * @param {string} html - html syntax text
    * @param {boolean} [cursorToEnd=true] - move cursor to contents end
    */
-  setHTML(html = '', cursorToEnd = true) {
+  setHTML(html = '', cursorToEnd = true, focus = true) {
     const container = document.createElement('div');
 
     // the `br` tag should be replaced with empty block to separate between blocks
@@ -457,7 +457,7 @@ class ToastUIEditorCore {
     const wwNode = DOMParser.fromSchema(this.wwEditor.schema).parse(container);
 
     if (this.isMarkdownMode()) {
-      this.mdEditor.setMarkdown(this.convertor.toMarkdownText(wwNode), cursorToEnd);
+      this.mdEditor.setMarkdown(this.convertor.toMarkdownText(wwNode), cursorToEnd, focus);
     } else {
       this.wwEditor.setModel(wwNode, cursorToEnd);
     }

--- a/apps/editor/src/editorCore.ts
+++ b/apps/editor/src/editorCore.ts
@@ -249,7 +249,7 @@ class ToastUIEditorCore {
 
     this.setHeight(this.options.height);
 
-    this.setMarkdown(this.options.initialValue, false);
+    this.setMarkdown(this.options.initialValue, false, this.options.autofocus);
 
     if (this.options.placeholder) {
       this.setPlaceholder(this.options.placeholder);
@@ -433,8 +433,8 @@ class ToastUIEditorCore {
    * @param {string} markdown - markdown syntax text.
    * @param {boolean} [cursorToEnd=true] - move cursor to contents end
    */
-  setMarkdown(markdown = '', cursorToEnd = true) {
-    this.mdEditor.setMarkdown(markdown, cursorToEnd);
+  setMarkdown(markdown = '', cursorToEnd = true, focus = true) {
+    this.mdEditor.setMarkdown(markdown, cursorToEnd, focus);
 
     if (this.isWysiwygMode()) {
       const mdNode = this.toastMark.getRootNode();

--- a/apps/editor/src/markdown/mdEditor.ts
+++ b/apps/editor/src/markdown/mdEditor.ts
@@ -322,7 +322,7 @@ export default class MdEditor extends EditorBase {
     return getEditorToMdPos(this.view.state.tr.doc, from, to);
   }
 
-  setMarkdown(markdown: string, cursorToEnd = true) {
+  setMarkdown(markdown: string, cursorToEnd = true, focus = true) {
     const lineTexts = markdown.split(reLineEnding);
     const { tr, doc, schema } = this.view.state;
     const nodes = lineTexts.map((lineText) =>
@@ -332,7 +332,7 @@ export default class MdEditor extends EditorBase {
     this.view.dispatch(tr.replaceWith(0, doc.content.size, nodes));
 
     if (cursorToEnd) {
-      this.moveCursorToEnd(true);
+      this.moveCursorToEnd(focus);
     }
   }
 

--- a/apps/editor/types/editor.d.ts
+++ b/apps/editor/types/editor.d.ts
@@ -201,7 +201,7 @@ export class EditorCore {
 
   setMarkdown(markdown: string, cursorToEnd?: boolean, focus?: boolean): void;
 
-  setHTML(html: string, cursorToEnd?: boolean): void;
+  setHTML(html: string, cursorToEnd?: boolean, focus?: boolean): void;
 
   getMarkdown(): string;
 

--- a/apps/editor/types/editor.d.ts
+++ b/apps/editor/types/editor.d.ts
@@ -199,7 +199,7 @@ export class EditorCore {
 
   moveCursorToStart(focus?: boolean): void;
 
-  setMarkdown(markdown: string, cursorToEnd?: boolean): void;
+  setMarkdown(markdown: string, cursorToEnd?: boolean, focus?: boolean): void;
 
   setHTML(html: string, cursorToEnd?: boolean): void;
 


### PR DESCRIPTION
#1772 introduced a `focus` parameter to the `moveCursorToEnd` function.

Now I encounter the need to not take the focus when setting markdown in the editor, hence I added a `focus` parameter to the `setMarkdown` and `setHTML` functions, defaulted to `true`, that is passed to `moveCursorToEnd`.

The `autofocus` parameter introduced in #1772 is also passed to `setMarkdown` or `setHTML` during the editor constructor to ensure cursor is not taken by the editor if `autofocus` is `false`. I think this may help with #1945 and #1802, because without this patch, if the editor is initialized with data it still takes the focus.

I am not really sure how to test this so I did not write any, but please let me know if you think this is important.

ping @js87zz