### PR TITLE
fix: heading state remains when changed to paragraph in WYSIWYG

### DIFF
--- a/apps/editor/src/__test__/unit/wysiwyg/wwCommand.spec.ts
+++ b/apps/editor/src/__test__/unit/wysiwyg/wwCommand.spec.ts
@@ -85,6 +85,15 @@ describe('wysiwyg commands', () => {
 
       expect(wwe.getHTML()).toBe('<h6>foo</h6>');
     });
+
+    it('should change heading element to paragraph with level 0', () => {
+      setTextToEditor('foo');
+
+      cmd.exec('selectAll');
+      cmd.exec('heading', { level: 0 });
+
+      expect(wwe.getHTML()).toBe('foo');
+    });
   });
 
   describe('hr command', () => {

--- a/apps/editor/src/wysiwyg/nodes/heading.ts
+++ b/apps/editor/src/wysiwyg/nodes/heading.ts
@@ -48,7 +48,10 @@ export class Heading extends NodeSchema {
   }
 
   commands(): EditorCommand {
-    return (payload) => (state, dispatch) =>
-      setBlockType(state.schema.nodes.heading, payload)(state, dispatch);
+    return (payload) => (state, dispatch) => {
+      const nodeType = state.schema.nodes[payload!.level ? 'heading' : 'paragraph'];
+
+      return setBlockType(nodeType, payload)(state, dispatch);
+    };
   }
 }


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
* related issue(#1971)


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
