### PR TITLE
fix: wrong wysiwyg table offset

### DIFF
--- a/apps/editor/src/convertors/toWysiwyg/toWwConvertors.ts
+++ b/apps/editor/src/convertors/toWysiwyg/toWwConvertors.ts
@@ -233,40 +233,34 @@ const toWwConvertors: ToWwConvertorMap = {
   },
 
   tableCell(state, node, { entering }) {
-    const { tableHeadCell, tableBodyCell, paragraph } = state.schema.nodes;
-    const tablePart = node.parent!.parent!;
-    const cell = tablePart.type === 'tableHead' ? tableHeadCell : tableBodyCell;
-    const hasParaNode = (childNode: MdNode | null) =>
-      childNode && (isInlineNode(childNode) || isCustomHTMLInlineNode(state, childNode));
+    if (!(node as TableCellMdNode).ignored) {
+      const hasParaNode = (childNode: MdNode | null) =>
+        childNode && (isInlineNode(childNode) || isCustomHTMLInlineNode(state, childNode));
 
-    if (entering) {
-      let attrs: Record<string, string | number> | null = null;
+      if (entering) {
+        const { tableHeadCell, tableBodyCell, paragraph } = state.schema.nodes;
+        const tablePart = node.parent!.parent!;
+        const cell = tablePart.type === 'tableHead' ? tableHeadCell : tableBodyCell;
 
-      if (!(node as TableCellMdNode).ignored) {
         const table = tablePart.parent as TableMdNode;
-        const { startIdx } = node as TableCellMdNode;
+        const { align } = table.columns[(node as TableCellMdNode).startIdx] || {};
+        const attrs: Record<string, string | number> = { ...(node as TableCellMdNode).attrs };
 
-        if (table.columns.length > startIdx) {
-          const { align } = table.columns[startIdx];
-
-          attrs = (node as TableCellMdNode).attrs ?? {};
-
-          if (align) {
-            attrs.align = align;
-          }
+        if (align) {
+          attrs.align = align;
         }
-      }
 
-      state.openNode(cell, attrs);
+        state.openNode(cell, attrs);
 
-      if (hasParaNode(node.firstChild)) {
-        state.openNode(paragraph);
-      }
-    } else {
-      if (hasParaNode(node.lastChild)) {
+        if (hasParaNode(node.firstChild)) {
+          state.openNode(paragraph);
+        }
+      } else {
+        if (hasParaNode(node.lastChild)) {
+          state.closeNode();
+        }
         state.closeNode();
       }
-      state.closeNode();
     }
   },
 

--- a/apps/editor/src/wysiwyg/helper/tableOffsetMap.ts
+++ b/apps/editor/src/wysiwyg/helper/tableOffsetMap.ts
@@ -152,7 +152,10 @@ export class TableOffsetMap {
   getNodeAndPos(rowIdx: number, colIdx: number) {
     const cellInfo = this.rowInfo[rowIdx][colIdx];
 
-    return { node: this.table.nodeAt(cellInfo.offset - 1)!, pos: cellInfo.offset };
+    return {
+      node: this.table.nodeAt(cellInfo.offset - this.tableStartOffset)!,
+      pos: cellInfo.offset,
+    };
   }
 
   extendedRowspan(rowIdx: number, colIdx: number) {

--- a/plugins/table-merged-cell/src/__test__/integration/markdown/mergedTablePreview.spec.ts
+++ b/plugins/table-merged-cell/src/__test__/integration/markdown/mergedTablePreview.spec.ts
@@ -243,7 +243,7 @@ describe('markdown merged table plugin', () => {
         <td>cell3-3</td>
         </tr>
         <tr>
-        <td colspan="3" rowspan="2">cell4-1</td>
+        <td rowspan="2" colspan="3">cell4-1</td>
         <td>cell4-2</td>
         </tr>
         <tr>
@@ -291,7 +291,7 @@ describe('markdown merged table plugin', () => {
         <td>cell3-3</td>
         </tr>
         <tr>
-        <td colspan="3" rowspan="2">cell4-1</td>
+        <td rowspan="2" colspan="3">cell4-1</td>
         <td>cell4-2</td>
         </tr>
         <tr>
@@ -352,7 +352,7 @@ describe('markdown merged table plugin', () => {
         <td>cell3-5</td>
         </tr>
         <tr>
-        <td colspan="3" rowspan="2">mergedCell4-1</td>
+        <td rowspan="2" colspan="3">mergedCell4-1</td>
         <td>cell4-2</td>
         <td>cell4-3</td>
         <td>cell4-4</td>
@@ -399,7 +399,7 @@ describe('markdown merged table plugin', () => {
         <tr>
         <td colspan="2">mergedCell1-1</td>
         <td>cell1-2</td>
-        <td colspan="2" rowspan="5">mergedCell1-3</td>
+        <td rowspan="5" colspan="2">mergedCell1-3</td>
         <td>cell1-4</td>
         <td>cell1-5</td>
         </tr>
@@ -416,7 +416,7 @@ describe('markdown merged table plugin', () => {
         <td></td>
         </tr>
         <tr>
-        <td colspan="3" rowspan="2">mergedCell4-1</td>
+        <td rowspan="2" colspan="3">mergedCell4-1</td>
         <td>cell4-2</td>
         <td></td>
         </tr>
@@ -451,7 +451,7 @@ describe('markdown merged table plugin', () => {
         <tr>
         <td colspan="2">mergedCell1-1</td>
         <td>cell1-2</td>
-        <td colspan="2" rowspan="5">mergedCell1-3</td>
+        <td rowspan="5" colspan="2">mergedCell1-3</td>
         </tr>
         <tr>
         <td rowspan="2">mergedCell2-1</td>
@@ -498,7 +498,7 @@ describe('markdown merged table plugin', () => {
         <tr>
         <td colspan="2">mergedCell1-1</td>
         <td rowspan="3">mergedCell1-2</td>
-        <td colspan="2" rowspan="5">mergedCell1-3</td>
+        <td rowspan="5" colspan="2">mergedCell1-3</td>
         </tr>
         <tr>
         <td rowspan="2">mergedCell2-1</td>
@@ -556,7 +556,7 @@ describe('markdown merged table plugin', () => {
         <td>cell3-3</td>
         </tr>
         <tr>
-        <td colspan="3" rowspan="2">foo"bar"<span style="color: red;">baz</span></td>
+        <td rowspan="2" colspan="3">foo"bar"<span style="color: red;">baz</span></td>
         <td>cell4-2</td>
         </tr>
         <tr>

--- a/plugins/table-merged-cell/src/wysiwyg/tableOffsetMapMixin.ts
+++ b/plugins/table-merged-cell/src/wysiwyg/tableOffsetMapMixin.ts
@@ -47,7 +47,7 @@ export const offsetMapMixin = {
       const cellInfo = this.rowInfo[rowIdx][startSpanIdx];
 
       return {
-        node: this.table.nodeAt(cellInfo.offset - 1)!,
+        node: this.table.nodeAt(cellInfo.offset - this.tableStartOffset)!,
         pos: cellInfo.offset,
         startSpanIdx,
         count: colspanMap[startSpanIdx].count,
@@ -64,7 +64,7 @@ export const offsetMapMixin = {
       const cellInfo = this.rowInfo[startSpanIdx][colIdx];
 
       return {
-        node: this.table.nodeAt(cellInfo.offset - 1)!,
+        node: this.table.nodeAt(cellInfo.offset - this.tableStartOffset)!,
         pos: cellInfo.offset,
         startSpanIdx,
         count: this.rowInfo[startSpanIdx].rowspanMap[colIdx].count,


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
The wysiwyg table cannot be removed properly due to wrong wysiwyg table offset

* as-is
![2022-02-04 11-03-58 2022-02-04 11_04_12](https://user-images.githubusercontent.com/37766175/152460396-06d8f805-e679-44b8-9980-7490cb173a66.gif)

* to-be
![2022-02-04 14-54-30 2022-02-04 14_54_40](https://user-images.githubusercontent.com/37766175/152479736-94597c9f-2525-4b11-8b49-afc8e8070f7a.gif)




---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
