### PR TITLE
fix: fixed pasteImageOnlyBug for kind string, type image/svg+xml

### DIFF
--- a/apps/editor/src/helper/image.ts
+++ b/apps/editor/src/helper/image.ts
@@ -24,7 +24,7 @@ export function emitImageBlobHook(eventEmitter: Emitter, blob: File, type: strin
 }
 
 export function pasteImageOnly(items: DataTransferItemList) {
-  const images = toArray(items).filter(({ type }) => type.indexOf('image') !== -1);
+  const images = toArray(items).filter(({ kind, type }) => 'file' === kind && type.indexOf('image') !== -1);
 
   if (images.length === 1) {
     const [item] = images;

--- a/apps/editor/src/helper/image.ts
+++ b/apps/editor/src/helper/image.ts
@@ -24,7 +24,7 @@ export function emitImageBlobHook(eventEmitter: Emitter, blob: File, type: strin
 }
 
 export function pasteImageOnly(items: DataTransferItemList) {
-  const images = toArray(items).filter(({ kind, type }) => 'file' === kind && type.indexOf('image') !== -1);
+  const images = toArray(items).filter(({ kind, type }) => kind === 'file' && type.indexOf('image') !== -1);
 
   if (images.length === 1) {
     const [item] = images;

--- a/apps/editor/src/helper/image.ts
+++ b/apps/editor/src/helper/image.ts
@@ -24,7 +24,8 @@ export function emitImageBlobHook(eventEmitter: Emitter, blob: File, type: strin
 }
 
 export function pasteImageOnly(items: DataTransferItemList) {
-  const images = toArray(items).filter(({ kind, type }) => kind === 'file' && type.indexOf('image') !== -1);
+  const images = toArray(items).filter(
+    ({ kind, type }) => kind === 'file' && type.indexOf('image') !== -1);
 
   if (images.length === 1) {
     const [item] = images;

--- a/apps/editor/src/helper/image.ts
+++ b/apps/editor/src/helper/image.ts
@@ -25,7 +25,8 @@ export function emitImageBlobHook(eventEmitter: Emitter, blob: File, type: strin
 
 export function pasteImageOnly(items: DataTransferItemList) {
   const images = toArray(items).filter(
-    ({ kind, type }) => kind === 'file' && type.indexOf('image') !== -1);
+    ({ kind, type }) => kind === 'file' && type.indexOf('image') !== -1
+  );
 
   if (images.length === 1) {
     const [item] = images;


### PR DESCRIPTION


### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description
When copying an image from ms word (select the image, ctrl+c) and pasting it, the pasted data is the following:
 - {kind: 'string', type: 'image/svg+xml'}
 - {kind: 'file', type: 'image/png'}

this leads to a bug in the editor since the pasteImageOnly function only checks the `type` regardless of the `kind`.  It will also never return a good value for kind string, type image/* since the getAsFile() method returns null on kind string.