### PR TITLE
Fix: HTML Escape not Correct #2381

### DIFF
--- a/apps/editor/src/utils/common.ts
+++ b/apps/editor/src/utils/common.ts
@@ -8,7 +8,7 @@ import { LinkAttributeNames, LinkAttributes } from '@t/editor';
 export const isMac = /Mac/.test(navigator.platform);
 const reSpaceMoreThanOne = /[\u0020]+/g;
 const reEscapeChars = /[>(){}[\]+-.!#|]/g;
-const reEscapeHTML = /<([a-zA-Z_][a-zA-Z0-9\-._]*)(\s|[^\\/>])*\/?>|<(\/)([a-zA-Z_][a-zA-Z0-9\-._]*)\s*\/?>|<!--[^-]+-->|<([a-zA-Z_][a-zA-Z0-9\-.:/]*)>/g;
+const reEscapeHTML = /<([a-zA-Z_][a-zA-Z0-9\-._]*)(\s|[^\\>])*\/?>|<(\/)([a-zA-Z_][a-zA-Z0-9\-._]*)\s*\/?>|<!--[^-]+-->|<([a-zA-Z_][a-zA-Z0-9\-.:/]*)>/g;
 const reEscapeBackSlash = /\\[!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~\\]/g;
 const reEscapePairedChars = /[*_~`]/g;
 const reMdImageSyntax = /!\[.*\]\(.*\)/g;


### PR DESCRIPTION
https://github.com/nhn/tui.editor/issues/2381

<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  fix: HTML Escape Not Correct (fix #2381)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  fix: A bug fix
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL

  fix: #2381
-->

### Please check if the PR fulfills these requirements
- [x ] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or ~has a description of the breaking change~

### Description



---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
