### PR TITLE
fix: focus with colorsyntax on multi instances (fix #2413)

### DIFF
--- a/plugins/color-syntax/src/__test__/integration/colorSyntaxPlugin.spec.ts
+++ b/plugins/color-syntax/src/__test__/integration/colorSyntaxPlugin.spec.ts
@@ -248,4 +248,42 @@ describe('colorSyntax', () => {
       assertWwEditorHTML(expected);
     });
   });
+
+  describe('multi instances', () => {
+    let container2: HTMLElement, editor2: Editor;
+
+    beforeEach(() => {
+      container2 = document.createElement('div');
+      document.body.appendChild(container2);
+    });
+
+    afterEach(() => {
+      editor2.destroy();
+      document.body.removeChild(container2);
+    });
+    it.only('should focus to correct editor when using color syntax plugin', () => {
+      editor = new Editor({
+        el: container,
+        previewStyle: 'vertical',
+        height: '100px',
+        initialEditType: 'markdown',
+        plugins: [colorSyntaxPlugin],
+      });
+
+      editor2 = new Editor({
+        el: container2,
+        previewStyle: 'vertical',
+        height: '100px',
+        initialEditType: 'markdown',
+        plugins: [colorSyntaxPlugin],
+      });
+
+      editor2.exec('selectAll');
+      editor2.exec('color', { selectedColor: '#f0f' });
+
+      expect(document.activeElement).toBe(
+        container2.querySelector('.toastui-editor-md-container .ProseMirror')
+      );
+    });
+  });
 });

--- a/plugins/color-syntax/src/__test__/integration/colorSyntaxPlugin.spec.ts
+++ b/plugins/color-syntax/src/__test__/integration/colorSyntaxPlugin.spec.ts
@@ -282,9 +282,7 @@ describe('colorSyntax', () => {
       editor2.exec('selectAll');
       editor2.exec('color', { selectedColor: '#f0f' });
 
-      expect(document.activeElement).toBe(
-        container2.querySelector('.toastui-editor-md-container .ProseMirror')
-      );
+      expect(container2).toContainElement(document.activeElement as HTMLElement);
     });
   });
 });

--- a/plugins/color-syntax/src/__test__/integration/colorSyntaxPlugin.spec.ts
+++ b/plugins/color-syntax/src/__test__/integration/colorSyntaxPlugin.spec.ts
@@ -261,7 +261,8 @@ describe('colorSyntax', () => {
       editor2.destroy();
       document.body.removeChild(container2);
     });
-    it.only('should focus to correct editor when using color syntax plugin', () => {
+
+    it('should focus to correct editor when using color syntax plugin', () => {
       editor = new Editor({
         el: container,
         previewStyle: 'vertical',

--- a/plugins/color-syntax/src/index.ts
+++ b/plugins/color-syntax/src/index.ts
@@ -6,6 +6,7 @@ import { PluginOptions } from '@t/index';
 import { addLangs } from './i18n/langs';
 
 import './css/plugin.css';
+import { findParentByClassName } from './utils/dom';
 
 const PREFIX = 'toastui-editor-';
 
@@ -48,12 +49,19 @@ function createSelection(
     : SelectionClass.create(doc, mappedFrom, mappedTo);
 }
 
+function getCurrentEditorEl(colorPickerEl: HTMLElement, containerClassName: string) {
+  const editorDefaultEl = findParentByClassName(colorPickerEl, `${PREFIX}defaultUI`)!;
+
+  return editorDefaultEl.querySelector<HTMLElement>(`.${containerClassName} .ProseMirror`)!;
+}
+
 interface ColorPickerOption {
   container: HTMLDivElement;
   preset?: Array<string>;
   usageStatistics: boolean;
 }
 
+let containerClassName: string;
 let currentEditorEl: HTMLElement;
 
 // @TODO: add custom syntax for plugin
@@ -83,14 +91,14 @@ export default function colorSyntaxPlugin(
   const button = createApplyButton(i18n.get('OK'));
 
   eventEmitter.listen('focus', (editType) => {
-    const containerClassName = `${PREFIX}${editType === 'markdown' ? 'md' : 'ww'}-container`;
-
-    currentEditorEl = document.querySelector<HTMLElement>(`.${containerClassName} .ProseMirror`)!;
+    containerClassName = `${PREFIX}${editType === 'markdown' ? 'md' : 'ww'}-container`;
   });
 
   container.addEventListener('click', (ev) => {
     if ((ev.target as HTMLElement).getAttribute('type') === 'button') {
       const selectedColor = colorPicker.getColor();
+
+      currentEditorEl = getCurrentEditorEl(container, containerClassName);
 
       eventEmitter.emit('command', 'color', { selectedColor });
       eventEmitter.emit('closePopup');

--- a/plugins/color-syntax/src/utils/dom.ts
+++ b/plugins/color-syntax/src/utils/dom.ts
@@ -1,0 +1,13 @@
+function hasClass(element: HTMLElement, className: string) {
+  return element.classList.contains(className);
+}
+
+export function findParentByClassName(el: HTMLElement, className: string) {
+  let currentEl: HTMLElement | null = el;
+
+  while (currentEl && !hasClass(currentEl, className)) {
+    currentEl = currentEl.parentElement;
+  }
+
+  return currentEl;
+}


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description

* Fixed that set focus to the first editor when using the color syntax plugin in multi-instance.
  * Changed to find the editing area element in the parent element (Editor Container element) of the dropdown element of the current color syntax plugin.
  * The process of finding an edit area element has been changed to before moving focus into the editor, rather than when the editor has focus set.

**As-Is**
![](https://user-images.githubusercontent.com/41339744/162920092-d33602aa-f3bf-458d-8c15-ef5334c3c38b.gif)


**To-Be**
![](https://user-images.githubusercontent.com/41339744/162920134-c0d5b736-13af-477c-8f8a-1727086ac099.gif)

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
