### PR TITLE
feat: Add WYSIWYG keymap to change to task list

### DIFF
--- a/apps/editor/src/__test__/unit/wysiwyg/keymap.spec.ts
+++ b/apps/editor/src/__test__/unit/wysiwyg/keymap.spec.ts
@@ -533,5 +533,47 @@ describe('keymap', () => {
 
       expect(wwe.getHTML()).toBe(expected);
     });
+
+    it('should convert list from bullet to task', () => {
+      html = oneLineTrim`
+        <ul>
+          <li>item</li>
+        </ul>
+      `;
+
+      setContent(html);
+      wwe.setSelection(2); // in list item
+
+      forceKeymapFn('bulletList', 'toTaskList');
+
+      const expected = oneLineTrim`
+        <ul>
+          <li class="task-list-item" data-task="true"><p>item</p></li>
+        </ul>
+      `;
+
+      expect(wwe.getHTML()).toBe(expected);
+    });
+
+    it('should convert list from task to bullet', () => {
+      html = oneLineTrim`
+        <ul>
+          <li class="task-list-item" data-task="true"><p>item</p></li>
+        </ul>
+      `;
+
+      setContent(html);
+      wwe.setSelection(2); // in list item
+
+      forceKeymapFn('bulletList', 'toBulletList');
+
+      const expected = oneLineTrim`
+        <ul>
+          <li><p>item</p></li>
+        </ul>
+      `;
+
+      expect(wwe.getHTML()).toBe(expected);
+    });
   });
 });

--- a/apps/editor/src/wysiwyg/command/list.ts
+++ b/apps/editor/src/wysiwyg/command/list.ts
@@ -162,7 +162,7 @@ function getBeforeLineListItem(doc: ProsemirrorNode, offset: number) {
   return findListItem(endListItemPos);
 }
 
-function toggleTaskListItems(tr: Transaction, { $from, $to }: NodeRange) {
+function changeListTypeToTask(tr: Transaction, { $from, $to }: NodeRange) {
   const startListItem = findListItem($from);
   let endListItem = findListItem($to);
 
@@ -185,7 +185,7 @@ function toggleTaskListItems(tr: Transaction, { $from, $to }: NodeRange) {
   return tr;
 }
 
-function changeListType(tr: Transaction, { $from, $to }: NodeRange, list: NodeType) {
+function changeListTypeTo(tr: Transaction, { $from, $to }: NodeRange, list: NodeType) {
   const startListItem = findListItem($from);
   let endListItem = findListItem($to);
 
@@ -216,14 +216,14 @@ function changeListType(tr: Transaction, { $from, $to }: NodeRange, list: NodeTy
   return tr;
 }
 
-export function changeList(list: NodeType): Command {
+export function changeListTo(list: NodeType): Command {
   return ({ selection, tr }, dispatch) => {
     const { $from, $to } = selection;
     const range = $from.blockRange($to);
 
     if (range) {
       const newTr = isInListNode($from)
-        ? changeListType(tr, range, list)
+        ? changeListTypeTo(tr, range, list)
         : changeToList(tr, range, list);
 
       dispatch!(newTr);
@@ -235,14 +235,14 @@ export function changeList(list: NodeType): Command {
   };
 }
 
-export function toggleTask(): Command {
+export function changeListToTask(): Command {
   return ({ selection, tr, schema }, dispatch) => {
     const { $from, $to } = selection;
     const range = $from.blockRange($to);
 
     if (range) {
       const newTr = isInListNode($from)
-        ? toggleTaskListItems(tr, range)
+        ? changeListTypeToTask(tr, range)
         : changeToList(tr, range, schema.nodes.bulletList, { task: true });
 
       dispatch!(newTr);

--- a/apps/editor/src/wysiwyg/nodes/bulletList.ts
+++ b/apps/editor/src/wysiwyg/nodes/bulletList.ts
@@ -7,7 +7,7 @@ import {
   getCustomAttrs,
   getDefaultCustomAttrs,
 } from '@/wysiwyg/helper/node';
-import { changeList, toggleTask } from '@/wysiwyg/command/list';
+import { changeListTo, changeListToTask } from '@/wysiwyg/command/list';
 
 import { Command } from 'prosemirror-commands';
 
@@ -31,24 +31,31 @@ export class BulletList extends NodeSchema {
     };
   }
 
-  private changeList(): Command {
-    return (state, dispatch) => changeList(state.schema.nodes.bulletList)(state, dispatch);
+  private toBulletList(): Command {
+    return (state, dispatch) => changeListTo(state.schema.nodes.bulletList)(state, dispatch);
+  }
+
+  private toTaskList(): Command {
+    return changeListToTask();
   }
 
   commands() {
     return {
-      bulletList: this.changeList,
-      taskList: toggleTask,
+      bulletList: this.toBulletList,
+      taskList: changeListToTask,
     };
   }
 
   keymaps() {
-    const bulletListCommand = this.changeList();
+    const bulletListCommand = this.toBulletList();
+    const taskListCommand = this.toTaskList();
     const { indent, outdent } = getWwCommands();
 
     return {
       'Mod-u': bulletListCommand,
       'Mod-U': bulletListCommand,
+      'alt-t': taskListCommand,
+      'alt-T': taskListCommand,
       Tab: indent(),
       'Shift-Tab': outdent(),
     };

--- a/apps/editor/src/wysiwyg/nodes/orderedList.ts
+++ b/apps/editor/src/wysiwyg/nodes/orderedList.ts
@@ -2,7 +2,7 @@ import { Node as ProsemirrorNode, DOMOutputSpecArray } from 'prosemirror-model';
 
 import NodeSchema from '@/spec/node';
 import { getWwCommands } from '@/commands/wwCommands';
-import { changeList } from '@/wysiwyg/command/list';
+import { changeListTo } from '@/wysiwyg/command/list';
 
 import { EditorCommand } from '@t/spec';
 import { getDefaultCustomAttrs, getCustomAttrs } from '@/wysiwyg/helper/node';
@@ -46,7 +46,7 @@ export class OrderedList extends NodeSchema {
   }
 
   commands(): EditorCommand {
-    return () => (state, dispatch) => changeList(state.schema.nodes.orderedList)(state, dispatch);
+    return () => (state, dispatch) => changeListTo(state.schema.nodes.orderedList)(state, dispatch);
   }
 
   keymaps() {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description
This keymap already exists on the Markdown view. The command also already exists, so I've just registered it as it's done on Markdown and added tests.

I also propose to change some function names to make it more similar to what's in Markdown, and because "toggle" in some other places in the code means toggling between [ ] to [x].

This will make it easier to understand when this toggling command and keymap is added to WYSIWYG as well (which I would like to propose in a separate Pull Request).