### PR TITLE
fix: convert by using HTML tag when it is not between spaces

### DIFF
--- a/apps/editor/src/convertors/toMarkdown/toMdConvertorState.ts
+++ b/apps/editor/src/convertors/toMarkdown/toMdConvertorState.ts
@@ -10,6 +10,7 @@ import {
   FirstDelimFn,
   InfoForPosSync,
 } from '@t/convertor';
+import { DEFAULT_TEXT_NOT_START_OR_END_WITH_SPACE } from '@/utils/constants';
 
 export default class ToMdConvertorState {
   private readonly nodeTypeConvertors: ToMdNodeTypeConvertorMap;
@@ -53,10 +54,12 @@ export default class ToMdConvertorState {
     const { content } = parent;
 
     const isFrontNodeEndWithSpace =
-      index === 0 || isEndWithSpace(content.child(index - 1).text ?? 'a');
+      index === 0 ||
+      isEndWithSpace(content.child(index - 1).text ?? DEFAULT_TEXT_NOT_START_OR_END_WITH_SPACE);
 
     const isRearNodeStartWithSpace =
-      index >= content.childCount - 1 || isStartWithSpace(content.child(index + 1).text ?? 'a');
+      index >= content.childCount - 1 ||
+      isStartWithSpace(content.child(index + 1).text ?? DEFAULT_TEXT_NOT_START_OR_END_WITH_SPACE);
 
     return isFrontNodeEndWithSpace && isRearNodeStartWithSpace;
   }

--- a/apps/editor/src/convertors/toMarkdown/toMdConvertorState.ts
+++ b/apps/editor/src/convertors/toMarkdown/toMdConvertorState.ts
@@ -49,30 +49,14 @@ export default class ToMdConvertorState {
     return /(^|\n)$/.test(this.result);
   }
 
-  private isBeteewnSpaces(parent: Node, index: number) {
+  private isBetweenSpaces(parent: Node, index: number) {
     const { content } = parent;
-    // const frontText = content.child(index - 1).text;
-    // const rearText = content.child(index + 1).text;
 
     const isFrontNodeEndWithSpace =
       index === 0 || isEndWithSpace(content.child(index - 1).text ?? 'a');
 
-    if (index !== 0) {
-      console.log(index, isFrontNodeEndWithSpace);
-    }
-
     const isRearNodeStartWithSpace =
       index >= content.childCount - 1 || isStartWithSpace(content.child(index + 1).text ?? 'a');
-
-    if (index - 1 >= 0 && index + 1 <= content.childCount - 1) {
-      console.log(
-        isEndWithSpace(content.child(index - 1).text ?? 'a'),
-        isStartWithSpace(content.child(index + 1).text ?? 'a'),
-        isFrontNodeEndWithSpace,
-        isRearNodeStartWithSpace,
-        content
-      );
-    }
 
     return isFrontNodeEndWithSpace && isRearNodeStartWithSpace;
   }
@@ -81,10 +65,7 @@ export default class ToMdConvertorState {
     const convertor = this.getMarkConvertor(mark);
 
     if (convertor) {
-      if (mark.type.name === 'strong') {
-        // debugger;
-      }
-      const betweenSpace = this.isBeteewnSpaces(parent, entering ? index : index - 1);
+      const betweenSpace = this.isBetweenSpaces(parent, entering ? index : index - 1);
 
       const { delim, rawHTML } = convertor({ node: mark, parent, index }, entering, betweenSpace);
 

--- a/apps/editor/src/convertors/toMarkdown/toMdConvertors.ts
+++ b/apps/editor/src/convertors/toMarkdown/toMdConvertors.ts
@@ -210,11 +210,9 @@ export const toMdConvertors: ToMdConvertorMap = {
 
   strong({ node }, { entering }, betweenSpace) {
     const { rawHTML } = node.attrs;
-    let delim;
+    let delim = '**';
 
-    if (betweenSpace) {
-      delim = '**';
-    } else {
+    if (!betweenSpace) {
       delim = entering ? '<strong>' : '</strong>';
     }
 
@@ -226,11 +224,9 @@ export const toMdConvertors: ToMdConvertorMap = {
 
   emph({ node }, { entering }, betweenSpace) {
     const { rawHTML } = node.attrs;
-    let delim;
+    let delim = '*';
 
-    if (betweenSpace) {
-      delim = '*';
-    } else {
+    if (!betweenSpace) {
       delim = entering ? '<em>' : '</em>';
     }
 
@@ -242,11 +238,9 @@ export const toMdConvertors: ToMdConvertorMap = {
 
   strike({ node }, { entering }, betweenSpace) {
     const { rawHTML } = node.attrs;
-    let delim;
+    let delim = '~~';
 
-    if (betweenSpace) {
-      delim = '~~';
-    } else {
+    if (!betweenSpace) {
       delim = entering ? '<del>' : '</del>';
     }
 

--- a/apps/editor/src/convertors/toMarkdown/toMdConvertors.ts
+++ b/apps/editor/src/convertors/toMarkdown/toMdConvertors.ts
@@ -208,11 +208,18 @@ export const toMdConvertors: ToMdConvertorMap = {
     };
   },
 
-  strong({ node }, { entering }) {
+  strong({ node }, { entering }, betweenSpace) {
     const { rawHTML } = node.attrs;
+    let delim;
+
+    if (betweenSpace) {
+      delim = '**';
+    } else {
+      delim = entering ? '<strong>' : '</strong>';
+    }
 
     return {
-      delim: '**',
+      delim,
       rawHTML: entering ? getOpenRawHTML(rawHTML) : getCloseRawHTML(rawHTML),
     };
   },
@@ -353,7 +360,7 @@ function createMarkTypeConvertors(convertors: ToMdConvertorMap) {
   const markTypes = Object.keys(markTypeOptions) as WwMarkType[];
 
   markTypes.forEach((type) => {
-    markTypeConvertors[type] = (nodeInfo, entering) => {
+    markTypeConvertors[type] = (nodeInfo, entering, betweenSpace) => {
       const markOption = markTypeOptions[type];
       const convertor = convertors[type];
 
@@ -362,7 +369,9 @@ function createMarkTypeConvertors(convertors: ToMdConvertorMap) {
       // When calling the converter without using `delim` and `rawHTML` values,
       // the converter is called without parameters.
       const runConvertor = convertor && nodeInfo && !isUndefined(entering);
-      const params = runConvertor ? convertor!(nodeInfo as MarkInfo, { entering }) : {};
+      const params = runConvertor
+        ? convertor!(nodeInfo as MarkInfo, { entering }, betweenSpace)
+        : {};
 
       return { ...params, ...markOption };
     };

--- a/apps/editor/src/convertors/toMarkdown/toMdConvertors.ts
+++ b/apps/editor/src/convertors/toMarkdown/toMdConvertors.ts
@@ -224,20 +224,34 @@ export const toMdConvertors: ToMdConvertorMap = {
     };
   },
 
-  emph({ node }, { entering }) {
+  emph({ node }, { entering }, betweenSpace) {
     const { rawHTML } = node.attrs;
+    let delim;
+
+    if (betweenSpace) {
+      delim = '*';
+    } else {
+      delim = entering ? '<em>' : '</em>';
+    }
 
     return {
-      delim: '*',
+      delim,
       rawHTML: entering ? getOpenRawHTML(rawHTML) : getCloseRawHTML(rawHTML),
     };
   },
 
-  strike({ node }, { entering }) {
+  strike({ node }, { entering }, betweenSpace) {
     const { rawHTML } = node.attrs;
+    let delim;
+
+    if (betweenSpace) {
+      delim = '~~';
+    } else {
+      delim = entering ? '<del>' : '</del>';
+    }
 
     return {
-      delim: '~~',
+      delim,
       rawHTML: entering ? getOpenRawHTML(rawHTML) : getCloseRawHTML(rawHTML),
     };
   },

--- a/apps/editor/src/utils/common.ts
+++ b/apps/editor/src/utils/common.ts
@@ -13,8 +13,6 @@ const reEscapeBackSlash = /\\[!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~\\]/g;
 const reEscapePairedChars = /[*_~`]/g;
 const reMdImageSyntax = /!\[.*\]\(.*\)/g;
 const reEscapedCharInLinkSyntax = /[[\]]/g; //
-const reEndWithSpace = /(\S*)\s$/g;
-const reStartWithSpace = /^\s(\S*)/g;
 
 const XMLSPECIAL = '[&<>"]';
 const reXmlSpecial = new RegExp(XMLSPECIAL, 'g');
@@ -261,9 +259,13 @@ export function getSortedNumPair(valueA: number, valueB: number) {
 }
 
 export function isStartWithSpace(text: string) {
+  const reStartWithSpace = /^\s(\S*)/g;
+
   return reStartWithSpace.test(text);
 }
 
 export function isEndWithSpace(text: string) {
+  const reEndWithSpace = /(\S*)\s$/g;
+
   return reEndWithSpace.test(text);
 }

--- a/apps/editor/src/utils/common.ts
+++ b/apps/editor/src/utils/common.ts
@@ -13,6 +13,8 @@ const reEscapeBackSlash = /\\[!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~\\]/g;
 const reEscapePairedChars = /[*_~`]/g;
 const reMdImageSyntax = /!\[.*\]\(.*\)/g;
 const reEscapedCharInLinkSyntax = /[[\]]/g; //
+const reEndWithSpace = /(\S*)\s$/g;
+const reStartWithSpace = /^\s(\S*)/g;
 
 const XMLSPECIAL = '[&<>"]';
 const reXmlSpecial = new RegExp(XMLSPECIAL, 'g');
@@ -256,4 +258,12 @@ export function assign(targetObj: Record<string, any>, obj: Record<string, any> 
 
 export function getSortedNumPair(valueA: number, valueB: number) {
   return valueA > valueB ? [valueB, valueA] : [valueA, valueB];
+}
+
+export function isStartWithSpace(text: string) {
+  return reStartWithSpace.test(text);
+}
+
+export function isEndWithSpace(text: string) {
+  return reEndWithSpace.test(text);
 }

--- a/apps/editor/src/utils/constants.ts
+++ b/apps/editor/src/utils/constants.ts
@@ -20,3 +20,5 @@ export const reBR = /<br\s*\/*>/i;
 export const reHTMLComment = /<! ---->|<!--(?:-?[^>-])(?:-?[^-])*-->/;
 
 export const ALTERNATIVE_TAG_FOR_BR = '</p><p>';
+
+export const DEFAULT_TEXT_NOT_START_OR_END_WITH_SPACE = 'a';

--- a/apps/editor/types/convertor.d.ts
+++ b/apps/editor/types/convertor.d.ts
@@ -111,7 +111,8 @@ export type ToMdNodeTypeConvertorMap = Partial<Record<WwNodeType, ToMdNodeTypeCo
 
 type ToMdMarkTypeConvertor = (
   nodeInfo?: MarkInfo,
-  entering?: boolean
+  entering?: boolean,
+  betweenSpace?: boolean
 ) => ToMdConvertorReturnValues & ToMdMarkTypeOption;
 
 export type ToMdMarkTypeConvertorMap = Partial<Record<WwMarkType, ToMdMarkTypeConvertor>>;
@@ -124,7 +125,8 @@ interface ToMdConvertorContext {
 
 type ToMdConvertor = (
   nodeInfo: NodeInfo | MarkInfo,
-  context: ToMdConvertorContext
+  context: ToMdConvertorContext,
+  betweenSpace?: boolean
 ) => ToMdConvertorReturnValues;
 
 export type ToMdConvertorMap = Partial<Record<WwNodeType | MdNodeType, ToMdConvertor>>;


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description

* Fix the converter to match the spec difference between WYSIWYG and Markdown.
  * Following [markdown spec (Rule 5)](https://spec.commonmark.org/0.30/#Rule_5), the markdown like `**"text"**a` is not parsed.
  * But in WYSIWIG, It is possible that typing content like <strong>"test"</strong>a.
  * So, to match both, when typing it in WYSIWIG and converting to markdown, It will be converted by using an HTML tag, not a markdown delimiter.

**Typing content in WYSIWYG**
<img width="710" src="https://user-images.githubusercontent.com/41339744/174962482-3943a4b6-b224-491c-848a-85d579131bbc.png">


**As-Is**
<img width="710" src="https://user-images.githubusercontent.com/41339744/174962517-0cfdc8dc-793a-4348-923b-f92d1116ea48.png">

**To-Be**
<img width="710" src="https://user-images.githubusercontent.com/41339744/174962549-d3abab42-f28f-4507-b755-26c8c00ff8c0.png">


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
