### PR TITLE
feat: support custom inline renderer

### DIFF
--- a/apps/editor/src/__test__/unit/markdown/__snapshots__/syntaxHighlight.spec.ts.snap
+++ b/apps/editor/src/__test__/unit/markdown/__snapshots__/syntaxHighlight.spec.ts.snap
@@ -150,6 +150,23 @@ exports[`markdown editor syntax highlight custom block 1`] = `
 </div>
 `;
 
+exports[`markdown editor syntax highlight custom inline 1`] = `
+<div>
+  <span class="toastui-editor-md-custom-inline">
+    <span class="toastui-editor-md-delimiter">
+      $$
+    </span>
+    <span class="toastui-editor-md-meta">
+      custom
+    </span>
+    my custom element
+    <span class="toastui-editor-md-delimiter">
+      $$
+    </span>
+  </span>
+</div>
+`;
+
 exports[`markdown editor syntax highlight emph 1`] = `
 <div>
   <span class="toastui-editor-md-delimiter">

--- a/apps/editor/src/__test__/unit/markdown/syntaxHighlight.spec.ts
+++ b/apps/editor/src/__test__/unit/markdown/syntaxHighlight.spec.ts
@@ -186,4 +186,12 @@ describe('markdown editor syntax highlight', () => {
 
     expect(html).toMatchSnapshot();
   });
+
+  it('custom inline', () => {
+    mde.setMarkdown('$$custom my custom element$$');
+
+    const html = getEditorHTML(mde);
+
+    expect(html).toMatchSnapshot();
+  });
 });

--- a/apps/editor/src/convertors/toMarkdown/toMdConvertors.ts
+++ b/apps/editor/src/convertors/toMarkdown/toMdConvertors.ts
@@ -196,6 +196,15 @@ export const toMdConvertors: ToMdConvertorMap = {
     };
   },
 
+  customInline({ node }) {
+    const { attrs, textContent } = node as ProsemirrorNode;
+
+    return {
+      delim: [`$$${attrs.info}`, '$$'],
+      text: textContent,
+    };
+  },
+
   frontMatter({ node }) {
     return {
       text: (node as ProsemirrorNode).textContent,

--- a/apps/editor/src/convertors/toMarkdown/toMdNodeTypeWriters.ts
+++ b/apps/editor/src/convertors/toMarkdown/toMdNodeTypeWriters.ts
@@ -239,6 +239,16 @@ export const nodeTypeWriters: ToMdNodeTypeWriterMap = {
     state.write(text);
   },
 
+  customInline(state, _, { delim, text }) {
+    const [openDelim, closeDelim] = delim as string[];
+
+    state.write(openDelim);
+    if (text) {
+      state.write(` ${text}`);
+    }
+    state.write(closeDelim);
+  },
+
   html(state, { node }, { text }) {
     state.write(text);
 

--- a/apps/editor/src/convertors/toWysiwyg/toWwConvertors.ts
+++ b/apps/editor/src/convertors/toWysiwyg/toWwConvertors.ts
@@ -361,25 +361,21 @@ const toWwConvertors: ToWwConvertorMap = {
   },
 
   customInline(state, node, { entering, skipChildren }) {
-    const { info, firstChild } = node as CustomInlineMdNode;
     const { schema } = state;
+    const { customInline, widget } = schema.nodes;
+
+    const { info, firstChild } = node as CustomInlineMdNode;
+
+    skipChildren();
 
     if (info.indexOf('widget') !== -1 && entering) {
       const content = getWidgetContent(node as CustomInlineMdNode);
 
-      skipChildren();
-
-      state.addNode(schema.nodes.widget, { info }, [
-        schema.text(createWidgetContent(info, content)),
-      ]);
+      state.addNode(widget, { info }, [schema.text(createWidgetContent(info, content))]);
     } else {
-      let text = '$$';
-
-      if (entering) {
-        text += firstChild ? `${info} ` : info;
-      }
-
-      state.addText(text);
+      state.openNode(customInline, { info });
+      state.addText(getTextWithoutTrailingNewline(firstChild?.literal || ''));
+      state.closeNode();
     }
   },
 };

--- a/apps/editor/src/convertors/toWysiwyg/toWwConvertors.ts
+++ b/apps/editor/src/convertors/toWysiwyg/toWwConvertors.ts
@@ -374,7 +374,7 @@ const toWwConvertors: ToWwConvertorMap = {
       state.addNode(widget, { info }, [schema.text(createWidgetContent(info, content))]);
     } else {
       state.openNode(customInline, { info });
-      state.addText(getTextWithoutTrailingNewline(firstChild?.literal || ''));
+      state.addText(getTextWithoutTrailingNewline(firstChild?.literal ?? ''));
       state.closeNode();
     }
   },

--- a/apps/editor/src/css/md-syntax-highlighting.css
+++ b/apps/editor/src/css/md-syntax-highlighting.css
@@ -121,12 +121,18 @@
 .toastui-editor-md-custom-block {
   color: #452d6b;
 }
+.toastui-editor-md-custom-inline {
+  color: #452d6b;
+  background-color: #f9f7fd;
+}
 .toastui-editor-md-custom-block-line-background {
   background-color: #f9f7fd;
 }
-.toastui-editor-md-custom-block .toastui-editor-md-delimiter {
+.toastui-editor-md-custom-block .toastui-editor-md-delimiter,
+.toastui-editor-md-custom-inline .toastui-editor-md-delimiter {
   color: #b8b3c0;
 }
-.toastui-editor-md-custom-block .toastui-editor-md-meta {
+.toastui-editor-md-custom-block .toastui-editor-md-meta,
+.toastui-editor-md-custom-inline .toastui-editor-md-meta {
   color: #5200d0;
 }

--- a/apps/editor/src/markdown/marks/customInline.ts
+++ b/apps/editor/src/markdown/marks/customInline.ts
@@ -1,0 +1,17 @@
+import { DOMOutputSpecArray } from 'prosemirror-model';
+import { clsWithMdPrefix } from '@/utils/dom';
+import Mark from '@/spec/mark';
+
+export class CustomInline extends Mark {
+  get name() {
+    return 'customInline';
+  }
+
+  get schema() {
+    return {
+      toDOM(): DOMOutputSpecArray {
+        return ['span', { class: clsWithMdPrefix('custom-inline') }, 0];
+      },
+    };
+  }
+}

--- a/apps/editor/src/markdown/mdEditor.ts
+++ b/apps/editor/src/markdown/mdEditor.ts
@@ -38,6 +38,7 @@ import { smartTask } from './plugins/smartTask';
 import { createNodesWithWidget, unwrapWidgetSyntax } from '@/widget/rules';
 import { Widget, widgetNodeView } from '@/widget/widgetNode';
 import { PluginProp } from '@t/plugin';
+import { CustomInline } from './marks/customInline';
 
 interface WindowWithClipboard extends Window {
   clipboardData?: DataTransfer | null;
@@ -148,6 +149,7 @@ export default class MdEditor extends EditorBase {
       new BlockQuote(),
       new CodeBlock(),
       new CustomBlock(),
+      new CustomInline(),
       new Table(),
       new TableCell(),
       new ThematicBreak(),

--- a/apps/editor/src/markdown/plugins/helper/markInfo.ts
+++ b/apps/editor/src/markdown/plugins/helper/markInfo.ts
@@ -8,6 +8,7 @@ import {
   CodeBlockMdNode,
   CustomBlockMdNode,
   ListItemMdNode,
+  CustomInlineMdNode,
 } from '@toast-ui/toastmark';
 import isFunction from 'tui-code-snippet/type/isFunction';
 import {
@@ -34,6 +35,9 @@ const TASK_DELIM = 'taskDelimiter';
 const TEXT = 'markedText';
 const HTML = 'html';
 const CUSTOM_BLOCK = 'customBlock';
+const CUSTOM_INLINE = 'customInline';
+
+const reWidgetInfo = /widget\d+/;
 
 const delimSize = {
   strong: 2,
@@ -205,6 +209,23 @@ function customBlock(node: MdNode, start: MdPos, end: MdPos) {
   return lineBackgroundMarkInfo ? marks.concat(lineBackgroundMarkInfo) : marks;
 }
 
+function customInline(node: MdNode, start: MdPos, end: MdPos) {
+  const { info } = node as CustomInlineMdNode;
+
+  const openDelimEnd = addOffsetPos(start, 2);
+  const infoEnd = addOffsetPos(openDelimEnd, info.length);
+  const closeDelimStart = addOffsetPos(end, -2);
+
+  return reWidgetInfo.test(info)
+    ? null
+    : [
+        markInfo(start, openDelimEnd, DELIM),
+        markInfo(openDelimEnd, infoEnd, META),
+        markInfo(closeDelimStart, end, DELIM),
+        markInfo(start, end, CUSTOM_INLINE),
+      ];
+}
+
 function markListItemChildren(node: MdNode, markType: MarkType) {
   const marks: MarkInfo[] = [];
 
@@ -302,6 +323,7 @@ const markNodeFuncMap = {
   blockQuote,
   item,
   customBlock,
+  customInline,
 };
 
 const simpleMarkClassNameMap = {

--- a/apps/editor/src/wysiwyg/adaptor/mdLikeNode.ts
+++ b/apps/editor/src/wysiwyg/adaptor/mdLikeNode.ts
@@ -52,6 +52,7 @@ export function createMdLikeNode(node: ProsemirrorNode | Mark): MdLikeNode {
     tableHeadCell: { type: 'tableCell', cellType: 'head', align: attrs.align },
     tableBodyCell: { type: 'tableCell', cellType: 'body', align: attrs.align },
     customBlock: { info: attrs.info },
+    customInline: { info: attrs.info },
   } as const;
   const nodeInfo = nodeTypeMap[nodeType as keyof typeof nodeTypeMap];
   const attributes = { ...mdLikeNode, ...nodeInfo };

--- a/apps/editor/src/wysiwyg/nodes/customInline.ts
+++ b/apps/editor/src/wysiwyg/nodes/customInline.ts
@@ -1,0 +1,35 @@
+import { Node as ProsemirrorNode, DOMOutputSpecArray } from 'prosemirror-model';
+
+import NodeSchema from '@/spec/node';
+
+export class CustomInline extends NodeSchema {
+  get name() {
+    return 'customInline';
+  }
+
+  get schema() {
+    return {
+      content: 'text*',
+      inline: true,
+      attrs: {
+        info: { default: null },
+      },
+      group: 'inline',
+      selectable: false,
+      defining: true,
+      parseDOM: [
+        {
+          tag: 'span[data-custom-info]',
+          getAttrs(dom: Node | string) {
+            const info = (dom as HTMLElement).getAttribute('data-custom-info');
+
+            return { info };
+          },
+        },
+      ],
+      toDOM({ attrs }: ProsemirrorNode): DOMOutputSpecArray {
+        return ['span', { 'data-custom-info': attrs.info || null }, 0];
+      },
+    };
+  }
+}

--- a/apps/editor/src/wysiwyg/nodeview/customInlineView.ts
+++ b/apps/editor/src/wysiwyg/nodeview/customInlineView.ts
@@ -21,7 +21,7 @@ export class CustomInlineView implements NodeView {
   }
 
   private renderCustomInline() {
-    const toDOMNode = this.toDOMAdaptor.getToDOMNode(this.node.attrs.info);
+    const toDOMNode = this.toDOMAdaptor.getToDOMNode('customInline');
 
     if (toDOMNode) {
       const node = toDOMNode(this.node);

--- a/apps/editor/src/wysiwyg/nodeview/customInlineView.ts
+++ b/apps/editor/src/wysiwyg/nodeview/customInlineView.ts
@@ -1,0 +1,49 @@
+import { EditorView, NodeView } from 'prosemirror-view';
+import { Node as ProsemirrorNode } from 'prosemirror-model';
+import { ToDOMAdaptor } from '@t/convertor';
+import { cls } from '@/utils/dom';
+
+export class CustomInlineView implements NodeView {
+  dom: HTMLElement;
+
+  private node: ProsemirrorNode;
+
+  private toDOMAdaptor: ToDOMAdaptor;
+
+  constructor(node: ProsemirrorNode, view: EditorView, toDOMAdaptor: ToDOMAdaptor) {
+    this.node = node;
+    this.toDOMAdaptor = toDOMAdaptor;
+
+    this.dom = document.createElement('span');
+    this.dom.className = cls('custom-inline');
+
+    this.renderCustomInline();
+  }
+
+  private renderCustomInline() {
+    const toDOMNode = this.toDOMAdaptor.getToDOMNode(this.node.attrs.info);
+
+    if (toDOMNode) {
+      const node = toDOMNode(this.node);
+
+      while (this.dom.hasChildNodes()) {
+        this.dom.removeChild(this.dom.lastChild!);
+      }
+
+      if (node) {
+        this.dom.appendChild(node);
+      }
+    }
+  }
+
+  update(node: ProsemirrorNode) {
+    if (!node.sameMarkup(this.node)) {
+      return false;
+    }
+
+    this.node = node;
+    this.renderCustomInline();
+
+    return true;
+  }
+}

--- a/apps/editor/src/wysiwyg/specCreator.ts
+++ b/apps/editor/src/wysiwyg/specCreator.ts
@@ -28,6 +28,7 @@ import { FrontMatter } from './nodes/frontMatter';
 import { LinkAttributes } from '@t/editor';
 import { Widget } from '@/widget/widgetNode';
 import { HTMLComment } from './nodes/htmlComment';
+import { CustomInline } from './nodes/customInline';
 
 export function createSpecs(linkAttributes: LinkAttributes) {
   return new SpecManager([
@@ -57,5 +58,6 @@ export function createSpecs(linkAttributes: LinkAttributes) {
     new FrontMatter(),
     new Widget(),
     new HTMLComment(),
+    new CustomInline(),
   ]);
 }

--- a/apps/editor/src/wysiwyg/wwEditor.ts
+++ b/apps/editor/src/wysiwyg/wwEditor.ts
@@ -17,6 +17,7 @@ import { toolbarStateHighlight } from './plugins/toolbarState';
 import { CustomBlockView } from './nodeview/customBlockView';
 import { ImageView } from './nodeview/imageView';
 import { CodeBlockView } from './nodeview/codeBlockView';
+import { CustomInlineView } from './nodeview/customInlineView';
 
 import { changePastedHTML, changePastedSlice } from './clipboard/paste';
 import { pasteToTable } from './clipboard/pasteToTable';
@@ -147,6 +148,9 @@ export default class WysiwygEditor extends EditorBase {
         },
         codeBlock(node, view, getPos) {
           return new CodeBlockView(node, view, getPos, eventEmitter);
+        },
+        customInline(node, view) {
+          return new CustomInlineView(node, view, toDOMAdaptor);
         },
         widget: widgetNodeView,
         ...this.createPluginNodeViews(),

--- a/apps/editor/types/wysiwyg.d.ts
+++ b/apps/editor/types/wysiwyg.d.ts
@@ -24,7 +24,8 @@ export type WwNodeType =
   | 'frontMatter'
   | 'widget'
   | 'html'
-  | 'htmlComment';
+  | 'htmlComment'
+  | 'customInline';
 
 export type WwMarkType = 'strong' | 'emph' | 'strike' | 'link' | 'code' | 'html';
 


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description

* Added custom inline HTML renderer.
* Can use the custom inline function by giving the editor's `customHTMLRenderer` option as shown below.
```js
const editor = new Editor({
  // ...
  customHTMLRenderer: {
    customInline(node, { entering, skipChildren, origin }) {
      const { info } = node;

      if (info === "katex" && entering) {
        skipChildren();

        const exp = node.literal || node.firstChild?.literal || "";
        const renderedKatex = katex.renderToString(exp, {
          throwOnError: false
        });

        return [
          { type: "openTag", tagName: "span", classNames: ["tui-katex"] },
          { type: "html", content: renderedKatex },
          { type: "closeTag", tagName: "span" }
        ];
      }
      return origin();
    },
    // ...
  }
});
```

**As-Is**
![](https://user-images.githubusercontent.com/41339744/182085717-fdb0bea3-d15f-4305-aa5f-b28be8fec5ac.gif)

**To-Be**
![](https://user-images.githubusercontent.com/41339744/182085727-78d998fd-4537-4c61-97df-04c83460560a.gif)

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
