### PR TITLE
fix: link mark no longer building with misnamed getCustomAttrs (fix #2687, #2671, #2730)

### DIFF
--- a/apps/editor/src/wysiwyg/marks/link.ts
+++ b/apps/editor/src/wysiwyg/marks/link.ts
@@ -53,8 +53,7 @@ export class Link extends Mark {
         attrs.rawHTML || 'a',
         {
           href: escapeXml(attrs.linkUrl),
-          // @ts-ignore
-          ...(this.linkAttributes as DOMOutputSpec),
+          ...this.linkAttributes,
           ...getCustomAttrs(attrs),
         },
       ],


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

I'm not fully sure why but the cast or comment on the changed lines caused the bundler to compile the code wrong. I found this fix by accident by removing the unnecessary cast.

