### PR TITLE
fix: non-spec emphasis (fix #1806 #2708)

### DIFF
--- a/apps/editor/src/convertors/toMarkdown/toMdConvertors.ts
+++ b/apps/editor/src/convertors/toMarkdown/toMdConvertors.ts
@@ -208,11 +208,11 @@ export const toMdConvertors: ToMdConvertorMap = {
     };
   },
 
-  strong({ node }, { entering }, betweenSpace) {
+  strong({ node }, { entering }, nonSpecEmphasis) {
     const { rawHTML } = node.attrs;
     let delim = '**';
 
-    if (!betweenSpace) {
+    if (nonSpecEmphasis) {
       delim = entering ? '<strong>' : '</strong>';
     }
 
@@ -222,11 +222,11 @@ export const toMdConvertors: ToMdConvertorMap = {
     };
   },
 
-  emph({ node }, { entering }, betweenSpace) {
+  emph({ node }, { entering }, nonSpecEmphasis) {
     const { rawHTML } = node.attrs;
     let delim = '*';
 
-    if (!betweenSpace) {
+    if (nonSpecEmphasis) {
       delim = entering ? '<em>' : '</em>';
     }
 
@@ -236,11 +236,11 @@ export const toMdConvertors: ToMdConvertorMap = {
     };
   },
 
-  strike({ node }, { entering }, betweenSpace) {
+  strike({ node }, { entering }, nonSpecEmphasis) {
     const { rawHTML } = node.attrs;
     let delim = '~~';
 
-    if (!betweenSpace) {
+    if (nonSpecEmphasis) {
       delim = entering ? '<del>' : '</del>';
     }
 
@@ -368,7 +368,7 @@ function createMarkTypeConvertors(convertors: ToMdConvertorMap) {
   const markTypes = Object.keys(markTypeOptions) as WwMarkType[];
 
   markTypes.forEach((type) => {
-    markTypeConvertors[type] = (nodeInfo, entering, betweenSpace) => {
+    markTypeConvertors[type] = (nodeInfo, entering, nonSpecEmphasis) => {
       const markOption = markTypeOptions[type];
       const convertor = convertors[type];
 
@@ -378,7 +378,7 @@ function createMarkTypeConvertors(convertors: ToMdConvertorMap) {
       // the converter is called without parameters.
       const runConvertor = convertor && nodeInfo && !isUndefined(entering);
       const params = runConvertor
-        ? convertor!(nodeInfo as MarkInfo, { entering }, betweenSpace)
+        ? convertor!(nodeInfo as MarkInfo, { entering }, nonSpecEmphasis)
         : {};
 
       return { ...params, ...markOption };

--- a/apps/editor/src/utils/common.ts
+++ b/apps/editor/src/utils/common.ts
@@ -264,14 +264,34 @@ export function getSortedNumPair(valueA: number, valueB: number) {
   return valueA > valueB ? [valueB, valueA] : [valueA, valueB];
 }
 
-export function isStartWithSpace(text: string) {
-  const reStartWithSpace = /^\s(\S*)/g;
+const reStartWithSpaceOrPunct = /^[\s\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-./:;<=>?@[\]^_`{|}~]/;
 
-  return reStartWithSpace.test(text);
+export function isStartWithSpaceOrPunct(text?: string) {
+  if (!text) return true;
+
+  return reStartWithSpaceOrPunct.test(text);
 }
 
-export function isEndWithSpace(text: string) {
-  const reEndWithSpace = /(\S*)\s$/g;
+const reEndWithSpaceOrPunct = /[\s\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-./:;<=>?@[\]^_`{|}~]$/;
 
-  return reEndWithSpace.test(text);
+export function isEndWithSpaceOrPunct(text?: string) {
+  if (!text) return true;
+
+  return reEndWithSpaceOrPunct.test(text);
+}
+
+const reStartWithPunct = /^[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-./:;<=>?@[\]^_`{|}~]/;
+
+export function isStartWithPunct(text?: string) {
+  if (!text) return false;
+
+  return reStartWithPunct.test(text);
+}
+
+const reEndWithPunct = /[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-./:;<=>?@[\]^_`{|}~]$/;
+
+export function isEndWithPunct(text?: string) {
+  if (!text) return false;
+
+  return reEndWithPunct.test(text);
 }

--- a/apps/editor/src/utils/constants.ts
+++ b/apps/editor/src/utils/constants.ts
@@ -20,5 +20,3 @@ export const reBR = /<br\s*\/*>/i;
 export const reHTMLComment = /<! ---->|<!--(?:-?[^>-])(?:-?[^-])*-->/;
 
 export const ALTERNATIVE_TAG_FOR_BR = '</p><p>';
-
-export const DEFAULT_TEXT_NOT_START_OR_END_WITH_SPACE = 'a';

--- a/apps/editor/types/convertor.d.ts
+++ b/apps/editor/types/convertor.d.ts
@@ -114,7 +114,7 @@ export type ToMdNodeTypeConvertorMap = Partial<Record<WwNodeType, ToMdNodeTypeCo
 type ToMdMarkTypeConvertor = (
   nodeInfo?: MarkInfo,
   entering?: boolean,
-  betweenSpace?: boolean
+  nonSpecEmphasis?: boolean
 ) => ToMdConvertorReturnValues & ToMdMarkTypeOption;
 
 export type ToMdMarkTypeConvertorMap = Partial<Record<WwMarkType, ToMdMarkTypeConvertor>>;
@@ -128,7 +128,7 @@ interface ToMdConvertorContext {
 type ToMdConvertor = (
   nodeInfo: NodeInfo | MarkInfo,
   context: ToMdConvertorContext,
-  betweenSpace?: boolean
+  nonSpecEmphasis?: boolean
 ) => ToMdConvertorReturnValues;
 
 export type ToMdConvertorMap = Partial<Record<WwNodeType | MdNodeType, ToMdConvertor>>;


### PR DESCRIPTION
https://github.com/nhn/tui.editor/pull/2572 introduced a dirty fix for a very rare non-spec emphasis and lead to many regular emphasis being replaced with html tags, which is no good (#1806 #2708).
This PR fixes that by making sure only [non-compliant emphasis](https://spec.commonmark.org/0.30/#left-flanking-delimiter-run) will be replaced with html tags.

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change
