### PR TITLE
perf: fix the output css @charset warning

### DIFF
--- a/apps/editor/src/css/editor.css
+++ b/apps/editor/src/css/editor.css
@@ -1,4 +1,3 @@
-@charset "utf-8";
 /* height */
 .auto-height,
 .auto-height .toastui-editor-defaultUI {


### PR DESCRIPTION
Fix an issue with exported css files throwing warnings in some build tools

**vite**

```css
@import '@toast-ui/editor/dist/toastui-editor.css';
```
**log**
<img width="1005" alt="image" src="https://user-images.githubusercontent.com/26295698/205234379-ebab70c5-729b-4eb5-8bcf-9e0755bb8bf9.png">

https://github.com/vitejs/vite/issues/6333