### PR TITLE
fix: specify type definition files in 'exports' field of package.json (fix #2985)

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -18,8 +18,14 @@
   "module": "dist/esm/",
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/toastui-editor.js"
+      "import": {
+        "types": "./types/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./types/index.d.ts",
+        "default": "./dist/toastui-editor.js"
+      }
     },
     "./viewer": {
       "import": "./dist/esm/indexViewer.js",


### PR DESCRIPTION
fixes: https://github.com/nhn/tui.editor/issues/2985