### PR TITLE
Fix typo in css

### DIFF
--- a/apps/editor/src/css/contents.css
+++ b/apps/editor/src/css/contents.css
@@ -11,7 +11,7 @@
   color: #222;
   font-size: 13px;
   overflow-y: auto;
-  overflow-X: hidden;
+  overflow-x: hidden;
   height: calc(100% - 36px);
 }
 


### PR DESCRIPTION
https://github.com/nhn/tui.editor/issues/2932

when build:

```
warnings when minifying css:
▲ [WARNING] "overflow-X" is not a known CSS property [unsupported-css-property]

    <stdin>:784:2:
      784 │   overflow-X: hidden;
          │   ~~~~~~~~~~
          ╵   overflow-y

  Did you mean "overflow-y" instead?
```

### Please check if the PR fulfills these requirements
- [ ] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description



---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
