### PR TITLE
fix: escape XML-entities in codeSyntaxHighlight plugin when language is unspecified (fix #3220)

### DIFF
--- a/plugins/code-syntax-highlight/src/renderers/toHTMLRenderers.ts
+++ b/plugins/code-syntax-highlight/src/renderers/toHTMLRenderers.ts
@@ -1,6 +1,7 @@
 import type { MdNode, CodeBlockMdNode } from '@toast-ui/editor';
 import type { HTMLToken } from '@toast-ui/toastmark';
 import { PrismJs } from '@t/index';
+import { escapeXml } from '@/utils/common';
 
 const BACKTICK_COUNT = 3;
 
@@ -17,6 +18,7 @@ export function getHTMLRenderers(prism: PrismJs) {
       }
 
       let content = node.literal!;
+      let contentEscaped = false;
 
       if (infoWords.length && infoWords[0].length) {
         const [lang] = infoWords;
@@ -28,8 +30,11 @@ export function getHTMLRenderers(prism: PrismJs) {
 
         if (registeredLang) {
           content = prism.highlight(node.literal!, registeredLang, lang);
+          contentEscaped = true;
         }
       }
+
+      content = contentEscaped ? content : escapeXml(content);
 
       return [
         { type: 'openTag', tagName: 'pre', classNames: preClasses },

--- a/plugins/code-syntax-highlight/src/utils/common.ts
+++ b/plugins/code-syntax-highlight/src/utils/common.ts
@@ -1,3 +1,28 @@
 export function flatten<T>(arr: T[]): T[] {
   return arr.reduce<T[]>((a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), []);
 }
+
+const XMLSPECIAL = '[&<>"]';
+const reXmlSpecial = new RegExp(XMLSPECIAL, 'g');
+
+function replaceUnsafeChar(char: string) {
+  switch (char) {
+    case '&':
+      return '&amp;';
+    case '<':
+      return '&lt;';
+    case '>':
+      return '&gt;';
+    case '"':
+      return '&quot;';
+    default:
+      return char;
+  }
+}
+
+export function escapeXml(text: string) {
+  if (reXmlSpecial.test(text)) {
+    return text.replace(reXmlSpecial, replaceUnsafeChar);
+  }
+  return text;
+}


### PR DESCRIPTION

<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description

Escapes code block content when code block language is not specified. Fixes https://github.com/nhn/tui.editor/issues/3220
