### PR TITLE
feat: Allow heading inside blockquote (close: #3246)

### DIFF
--- a/apps/editor/src/__test__/unit/editor.spec.ts
+++ b/apps/editor/src/__test__/unit/editor.spec.ts
@@ -810,6 +810,25 @@ describe('editor', () => {
         expect(getPreviewHTML()).toBe(result);
       });
 
+      it('should allow the nested seTextHeading in list', () => {
+        createEditor({
+          el: container,
+          initialValue: '- item1\n\t-',
+          previewHighlight: false,
+          disallowDeepHeading: false,
+        });
+
+        const result = oneLineTrim`
+          <ul>
+            <li>
+              <h2>item1</h2>
+            </li>
+          </ul>
+        `;
+
+        expect(getPreviewHTML()).toBe(result);
+      });
+
       it('should disallow the nested atxHeading in list', () => {
         createEditor({
           el: container,
@@ -821,6 +840,25 @@ describe('editor', () => {
           <ul>
             <li>
               <p># item1</p>
+            </li>
+          </ul>
+        `;
+
+        expect(getPreviewHTML()).toBe(result);
+      });
+
+      it('should allow the nested atxHeading in list', () => {
+        createEditor({
+          el: container,
+          initialValue: '- # item1',
+          previewHighlight: false,
+          disallowDeepHeading: false,
+        });
+
+        const result = oneLineTrim`
+          <ul>
+            <li>
+              <h1>item1</h1>
             </li>
           </ul>
         `;
@@ -845,6 +883,23 @@ describe('editor', () => {
         expect(getPreviewHTML()).toBe(result);
       });
 
+      it('should allow the nested seTextHeading in blockquote', () => {
+        createEditor({
+          el: container,
+          initialValue: '> item1\n> -',
+          previewHighlight: false,
+          disallowDeepHeading: false,
+        });
+
+        const result = oneLineTrim`
+          <blockquote>
+            <h2>item1</h2>
+          </blockquote>
+        `;
+
+        expect(getPreviewHTML()).toBe(result);
+      });
+
       it('should disallow the nested atxHeading in blockquote', () => {
         createEditor({
           el: container,
@@ -855,6 +910,23 @@ describe('editor', () => {
         const result = oneLineTrim`
           <blockquote>
             <p># item1</p>
+          </blockquote>
+        `;
+
+        expect(getPreviewHTML()).toBe(result);
+      });
+
+      it('should allow the nested atxHeading in blockquote', () => {
+        createEditor({
+          el: container,
+          initialValue: '> # item1',
+          previewHighlight: false,
+          disallowDeepHeading: false,
+        });
+
+        const result = oneLineTrim`
+          <blockquote>
+            <h1>item1</h1>
           </blockquote>
         `;
 

--- a/apps/editor/src/editorCore.ts
+++ b/apps/editor/src/editorCore.ts
@@ -82,6 +82,7 @@ import { Pos } from '@t/toastmark';
  *     @param {boolean} [options.referenceDefinition=false] - whether use the specification of link reference definition
  *     @param {function} [options.customHTMLSanitizer=null] - custom HTML sanitizer
  *     @param {boolean} [options.previewHighlight=false] - whether highlight preview area
+ *     @param {boolean} [options.disallowDeepHeading=true] - whether disallow deep heading
  *     @param {boolean} [options.frontMatter=false] - whether use the front matter
  *     @param {Array.<object>} [options.widgetRules=[]] - The rules for replacing the text with widget node
  *     @param {string} [options.theme] - The theme to style the editor with. The default is included in toastui-editor.css.
@@ -151,6 +152,7 @@ class ToastUIEditorCore {
         customMarkdownRenderer: null,
         referenceDefinition: false,
         customHTMLSanitizer: null,
+        disallowDeepHeading: true,
         frontMatter: false,
         widgetRules: [],
         theme: 'light',
@@ -163,6 +165,7 @@ class ToastUIEditorCore {
       customHTMLRenderer,
       extendedAutolinks,
       referenceDefinition,
+      disallowDeepHeading,
       frontMatter,
       customMarkdownRenderer,
       useCommandShortcut,
@@ -204,6 +207,7 @@ class ToastUIEditorCore {
       customHTMLRenderer: deepMergedCopy(toHTMLRenderers, customHTMLRenderer),
       extendedAutolinks,
       referenceDefinition,
+      disallowDeepHeading,
       frontMatter,
       sanitizer: customHTMLSanitizer || sanitizeHTML,
     };
@@ -218,7 +222,7 @@ class ToastUIEditorCore {
       disallowedHtmlBlockTags: ['br', 'img'],
       extendedAutolinks,
       referenceDefinition,
-      disallowDeepHeading: true,
+      disallowDeepHeading,
       frontMatter,
       customParser: markdownParsers,
     });

--- a/apps/editor/types/editor.d.ts
+++ b/apps/editor/types/editor.d.ts
@@ -182,6 +182,7 @@ export interface EditorOptions {
   referenceDefinition?: boolean;
   customHTMLSanitizer?: Sanitizer;
   previewHighlight?: boolean;
+  disallowDeepHeading?: boolean;
   frontMatter?: boolean;
   widgetRules?: WidgetRule[];
   theme?: string;


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description

This PR adds `disallowDeepHeading` to the list of possible options to allow more flexibility.
When `disallowDeepHeading` is `false`, headings can be added inside quotes and lists.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
