### PR TITLE
fix: error when rendering widgets inside table (fix #3198)

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,4 +1,5 @@
 module.exports = {
   printWidth: 100,
-  singleQuote: true
+  singleQuote: true,
+  endOfLine: 'auto',
 };

--- a/apps/editor/demo/esm/index.html
+++ b/apps/editor/demo/esm/index.html
@@ -30,7 +30,7 @@
         '',
         '| name | type | description |',
         '| --- | --- | --- |',
-        '| el | `HTMLElement` | container element |',
+        '| el | `HTMLElement` | [@Widget](Widget) |',
         '',
         '## Features',
         '',
@@ -59,6 +59,19 @@
         extendedAutolinks: true,
         frontMatter: true,
         initialValue: content,
+        widgetRules: [
+          {
+            rule: /\[(@\S+)\]\((\S+)\)/,
+            toDOM(text) {
+              const rule = /\[(@\S+)\]\((\S+)\)/;
+              const matched = text.match(rule);
+              const span = document.createElement('span');
+        
+              span.innerHTML = `<a class="widget-anchor" href="${matched[2]}">${matched[1]}</a>`;
+              return span;
+            },
+          },
+        ],
       });
 
       window.editor = editor;

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toast-ui/editor",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "GFM  Markdown Wysiwyg Editor - Productive and Extensible",
   "keywords": [
     "nhn",

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toast-ui/editor",
-  "version": "3.2.3",
+  "version": "3.2.2",
   "description": "GFM  Markdown Wysiwyg Editor - Productive and Extensible",
   "keywords": [
     "nhn",

--- a/apps/editor/src/convertors/toWysiwyg/htmlToWwConvertors.ts
+++ b/apps/editor/src/convertors/toWysiwyg/htmlToWwConvertors.ts
@@ -30,6 +30,10 @@ export function isInlineNode({ type }: MdNode) {
   return includes(['text', 'strong', 'emph', 'strike', 'image', 'link', 'code'], type);
 }
 
+export function isCustomInline(node: MdNode) {
+  return node.type === 'customInline';
+}
+
 function isSoftbreak(mdNode: MdNode | null) {
   return mdNode?.type === 'softbreak';
 }

--- a/apps/editor/src/convertors/toWysiwyg/toWwConvertors.ts
+++ b/apps/editor/src/convertors/toWysiwyg/toWwConvertors.ts
@@ -21,6 +21,7 @@ import {
   getTextWithoutTrailingNewline,
   isInlineNode,
   isCustomHTMLInlineNode,
+  isCustomInline,
 } from './htmlToWwConvertors';
 
 import { ToWwConvertorMap } from '@t/convertor';
@@ -235,7 +236,10 @@ const toWwConvertors: ToWwConvertorMap = {
   tableCell(state, node, { entering }) {
     if (!(node as TableCellMdNode).ignored) {
       const hasParaNode = (childNode: MdNode | null) =>
-        childNode && (isInlineNode(childNode) || isCustomHTMLInlineNode(state, childNode));
+        childNode &&
+        (isInlineNode(childNode) ||
+          isCustomInline(childNode) ||
+          isCustomHTMLInlineNode(state, childNode));
 
       if (entering) {
         const { tableHeadCell, tableBodyCell, paragraph } = state.schema.nodes;

--- a/apps/editor/types/index.d.ts
+++ b/apps/editor/types/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for TOAST UI Editor v3.2.3
+// Type definitions for TOAST UI Editor v3.2.2
 // TypeScript Version: 4.2.3
 import {
   EditorCore,

--- a/apps/editor/types/index.d.ts
+++ b/apps/editor/types/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for TOAST UI Editor v3.2.2
+// Type definitions for TOAST UI Editor v3.2.3
 // TypeScript Version: 4.2.3
 import {
   EditorCore,


### PR DESCRIPTION
fix: Widgets inside of table cells causing data loss

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description
This PR addresses an issue where rendering widgets inside a table causes an error, resulting in the table cell being removed from both the visual and markdown views when switching modes. This leads to data loss. The fix is based on a previous bug report and potential solution found here.

### Business Case
Fixing this issue is crucial for users who rely on the accurate rendering of widgets within tables. The current bug leads to data loss, which can significantly impact user productivity and trust in the application. By resolving this issue, we ensure a more reliable and seamless user experience, which is essential for maintaining user satisfaction and retention.

### Steps to Reproduce

1. **Open the TOAST UI Editor Demo:**
   - Navigate to the TOAST UI Editor demo page.

2. **Switch to Markdown Mode:**
   - Ensure the editor is in Markdown mode.

3. **Add a Table with a Widget:**
   - Insert the following markdown into the editor:
     ```markdown
     | Header 1 | Header 2 |
     |----------|----------|
     | Cell 1   | [@Widget](widget) |
     | Cell 3   | Cell 4   |
     ```

4. **Switch to Visual Mode:**
   - Change the editor mode to Visual (WYSIWYG) mode.

5. **Observe the Table:**
   - Check if the cell containing the widget (`@Widget`) is still present.

6. **Switch Back to Markdown Mode:**
   - Change the editor mode back to Markdown mode.

7. **Check the Markdown Content:**
   - Call `editor.getMarkdown()` and observe the output.

### Expected Result
- The cell containing the widget (`@Widget`) should be present in both Visual and Markdown modes.
- The `editor.getMarkdown()` output should include the cell with the widget.

### Actual Result
- The cell containing the widget is removed when switching to Visual mode.
- The `editor.getMarkdown()` output does not include the cell with the widget, resulting in data loss.


fix: resolve a bug completely (#3198)

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
