### PR TITLE
fixed import to angular app by import Editor, { EditorOptions } from …

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -18,6 +18,7 @@
   "module": "dist/esm/",
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/toastui-editor.js"
     },


### PR DESCRIPTION
…'@toast-ui/editor';

<!-- FIXED IMPORT FROM LIB TO TS PROJECT -->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  fix: A bug fix
  
  when import like that import Editor  from '@toast-ui/editor';
  
  Could not find a declaration file for module '@toast-ui/editor'. '/Users/v.petrov/Desktop/projects/ats/admin-frontend/node_modules/@toast-ui/editor/dist/esm/index.js' implicitly has an 'any' type.
  There are types at '/Users/v.petrov/Desktop/projects/ats/admin-frontend/node_modules/@toast-ui/editor/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@toast-ui/editor' library may need to update its package.json or typings
-->

<!--  
this fixed this issue because TS dont find ndex.d.ts  
```
{
  "exports": {
    ".": {
      "types": "./types/index.d.ts",  // added this line
      "import": "./dist/esm/index.js",
      "require": "./dist/toastui-editor.js"
    },
    ...
  },
  ...
}
```

-->

## Fixed  import to TS project

**Could not find a declaration file for module '@toast-ui/editor'. '/Users/v.petrov/Desktop/projects/ats/admin-frontend/node_modules/@toast-ui/editor/dist/esm/index.js' implicitly has an 'any' type.
  There are types at '/Users/v.petrov/Desktop/projects/ats/admin-frontend/node_modules/@toast-ui/editor/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@toast-ui/editor' library may need to update its package.json or typings**

### Description
fixed import like that ts cannot find index.d.ts in types because try find in dist/esm/index.js 
So I add "types": "./types/index.d.ts", to exports 
`import Editor  from '@toast-ui/editor';`

`{
  "exports": {
    ".": {
      "types": "./types/index.d.ts",
      "import": "./dist/esm/index.js",
      "require": "./dist/toastui-editor.js"
    },
    ...
  },
  ...
}`


another way use import with out fix: 
`import Editor  from 'node_modules/@toast-ui/editor';` 
then TS automaticly try search in some standart folders like types but when testing component/module, testing-lib cant find lib so failed

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
