### PR TITLE
fix:  create TextNode when adding a link (fix #3260)

### DIFF
--- a/apps/editor/src/wysiwyg/marks/link.ts
+++ b/apps/editor/src/wysiwyg/marks/link.ts
@@ -64,19 +64,15 @@ export class Link extends Mark {
     return (payload) => (state, dispatch) => {
       const { linkUrl, linkText = '' } = payload!;
       const { schema, tr, selection } = state;
-      const { empty, from, to } = selection;
+      const { from, to } = selection;
 
-      if (from && to && linkUrl) {
+      if (from && to && linkUrl && linkText) {
         const attrs = { linkUrl };
         const mark = schema.mark('link', attrs);
 
-        if (empty && linkText) {
-          const node = createTextNode(schema, linkText, mark);
+        const node = createTextNode(schema, linkText, mark);
 
-          tr.replaceRangeWith(from, to, node);
-        } else {
-          tr.addMark(from, to, mark);
-        }
+        tr.replaceRangeWith(from, to, node);
 
         dispatch!(tr.scrollIntoView());
 


### PR DESCRIPTION
Also create a new TextNode when the selection is not empty.

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description



---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
